### PR TITLE
Block UI interaction when menu is disabled

### DIFF
--- a/src/demo/src/app/components/menu.component.ts
+++ b/src/demo/src/app/components/menu.component.ts
@@ -1,8 +1,18 @@
 import { Component } from '@angular/core';
 
+import { TsMenuItem } from '@terminus/ui';
+
+
 @Component({
   selector: 'demo-menu',
   template: `
+    <label>
+      Disabled:
+      <input type="checkbox" [(ngModel)]="disabled"/>
+    </label>
+
+    <hr>
+
     <ts-menu
       [theme]="myTheme"
       [menuItems]="demoItems"
@@ -29,10 +39,16 @@ export class MenuComponent {
       action: 'bing',
     },
   ];
-  disabled = false;
+  disabled = true;
   myTheme = 'primary';
 
-  itemSelected(item: any): void {
+
+
+
+
+
+  itemSelected(item: TsMenuItem): void {
     console.log('Item selected: ', item.name);
   }
+
 }

--- a/src/lib/src/button/button.component.scss
+++ b/src/lib/src/button/button.component.scss
@@ -4,14 +4,6 @@
 @import './../scss/helpers/animation';
 
 
-:host {
-  display: inline-block;
-
-  &.disabled {
-    pointer-events: none;
-  }
-}
-
 // This makes the bottom padding space look better than the default 36px
 $button-line-height: 35px;
 $rotation: 360deg;
@@ -48,6 +40,18 @@ $ladda-background-transition: background $color-transition-duration $g-easing;
   // collapse the text content
   .c-button__content {
     max-width: 0;
+  }
+}
+
+:host {
+  display: inline-block;
+
+  // NOTE: This is a hack of sorts to disable a ts-menu from opening. The menu trigger still seems
+  // to be bound even when disabled.
+  &[data-disabled="true"] {
+    .c-button {
+      pointer-events: none;
+    }
   }
 }
 

--- a/src/lib/src/button/button.component.scss
+++ b/src/lib/src/button/button.component.scss
@@ -48,7 +48,7 @@ $ladda-background-transition: background $color-transition-duration $g-easing;
 
   // NOTE: This is a hack of sorts to disable a ts-menu from opening. The menu trigger still seems
   // to be bound even when disabled.
-  &[data-disabled="true"] {
+  &[data-disabled='true'] {
     .c-button {
       pointer-events: none;
     }

--- a/src/lib/src/menu/menu.component.html
+++ b/src/lib/src/menu/menu.component.html
@@ -22,9 +22,9 @@
 
 <ts-button
   class="qa-menu-trigger"
-  [theme]="theme"
   [mdMenuTriggerFor]="menu"
   [isDisabled]="isDisabled"
+  [attr.data-disabled]="isDisabled"
 >
   <ng-content></ng-content>
   <md-icon>arrow_drop_down</md-icon>

--- a/src/lib/src/menu/menu.component.scss
+++ b/src/lib/src/menu/menu.component.scss
@@ -6,6 +6,12 @@
   &.disabled {
     pointer-events: none;
   }
+
+  // <ts-button> trigger to show the menu
+  ::ng-deep ts-button[data-disabled="true"] {
+    cursor: not-allowed;
+    pointer-events: none;
+  }
 }
 
 //

--- a/src/lib/src/menu/menu.component.scss
+++ b/src/lib/src/menu/menu.component.scss
@@ -8,9 +8,11 @@
   }
 
   // <ts-button> trigger to show the menu
-  ::ng-deep ts-button[data-disabled="true"] {
-    cursor: not-allowed;
-    pointer-events: none;
+  ::ng-deep ts-button {
+    &[data-disabled='true'] {
+      cursor: not-allowed;
+      pointer-events: none;
+    }
   }
 }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/151170044

The material menu component has no native support for disabled. And because they are attaching the click handler to the custom `ts-button` component, it breaks the native HTML disabled ability for buttons.

Hacking a solution using `pointer-events: none`.