### PR TITLE
Fix ripple spilling out of collapsible buttons

### DIFF
--- a/src/lib/src/button/button.component.scss
+++ b/src/lib/src/button/button.component.scss
@@ -155,6 +155,7 @@ $ladda-background-transition: background $color-transition-duration $g-easing;
 
   // Define theme styles
   $themes: primary accent warn;
+  $collapsable-radius: 2em;
 
   // Loop through using each theme name to create styles
   @each $theme in $themes {
@@ -170,7 +171,7 @@ $ladda-background-transition: background $color-transition-duration $g-easing;
 
       // Collapsable button
       &.c-button--collapsable {
-        border-radius: 2em;
+        border-radius: $collapsable-radius;
 
         .c-button__content {
           display: inline-block;
@@ -179,6 +180,10 @@ $ladda-background-transition: background $color-transition-duration $g-easing;
           transition: max-width $content-transition-duration $g-easing;
           white-space: nowrap;
           will-change: max-width;
+        }
+
+        .mat-ripple {
+          border-radius: $collapsable-radius;
         }
       }
 

--- a/src/lib/src/input/input.component.ts
+++ b/src/lib/src/input/input.component.ts
@@ -12,7 +12,7 @@ import { TsInputTypes, TsInputAutocompleteTypes } from './../utilities/types/inp
 
 
 /**
- * @private Custom control value accessor for our component.
+ * Custom control value accessor for our component.
  * This allows our custom components to access the underlying form validation via our base class
  */
 export const CUSTOM_INPUT_CONTROL_VALUE_ACCESSOR: any = {

--- a/src/lib/src/utilities/reactive-form-base.component.ts
+++ b/src/lib/src/utilities/reactive-form-base.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   Input,
 } from '@angular/core';
+import { FormControl } from '@angular/forms';
 
 import { noop } from './noop';
 
@@ -43,7 +44,7 @@ export class TsReactiveFormBaseComponent {
    * (for form control support)
    */
   @Input()
-  public formControl: any;
+  public formControl: FormControl;
 
   /**
    * Return the value


### PR DESCRIPTION
Changes:

4d2ae59 (Benjamin Charity, 11 seconds ago)
   fix(button): ripple no longer spills outside of collapsible buttons

2ecf715 (Benjamin Charity, 42 seconds ago)
   chore(input): explicitly define the form control type