### PR TITLE
fix(Button): Correctly handling timeouts when the component is destroyed

### DIFF
--- a/src/lib/src/button/button.component.spec.ts
+++ b/src/lib/src/button/button.component.spec.ts
@@ -150,6 +150,24 @@ describe(`ButtonComponent`, () => {
     });
 
 
+    describe(`ngOnDestroy()`, () => {
+
+      beforeEach(() => {
+        window.clearTimeout = jasmine.createSpy('clearTimeout');
+        this.component.definedFormat = 'collapsable';
+      });
+
+
+      it(`should clear any existing timeouts`, () => {
+        this.component.collapseWithDelay(this.component.collapseDelay);
+        this.component.ngOnDestroy();
+
+        expect(window.clearTimeout).toHaveBeenCalledWith(this.component.timeout);
+      });
+
+    });
+
+
     describe(`collapseWithDelay()`, () => {
 
       it(`should set isCollapsed and trigger change detection after the delay`, (done) => {

--- a/src/lib/src/button/button.component.ts
+++ b/src/lib/src/button/button.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   OnInit,
+  OnDestroy,
   Input,
   Output,
   EventEmitter,
@@ -48,11 +49,16 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class TsButtonComponent implements OnInit {
+export class TsButtonComponent implements OnInit, OnDestroy {
   /**
    * Define the default delay for collapsable buttons
    */
   private COLLAPSE_DEFAULT_DELAY: number = 4000;
+
+  /**
+   * Store a reference to the timeout needed for collapsable buttons
+   */
+  private timeout: any;
 
   /**
    * Define the delay before the rounded button automatically collapses
@@ -164,7 +170,7 @@ export class TsButtonComponent implements OnInit {
   /**
    * Collapse after delay (if set)
    */
-  ngOnInit(): void {
+  public ngOnInit(): void {
     if (this.collapseDelay) {
       this.collapseWithDelay(this.collapseDelay);
     }
@@ -172,6 +178,17 @@ export class TsButtonComponent implements OnInit {
     // If the format is `collapsable`, verify an `iconName` is set
     if (this.definedFormat === 'collapsable' && !this.iconName) {
       throw new Error('`iconName` must be defined for collapsable buttons.');
+    }
+  }
+
+
+  /**
+   * Clear any existing timeout
+   */
+  public ngOnDestroy(): void {
+    // istanbul ignore else
+    if (this.timeout) {
+      clearTimeout(this.timeout);
     }
   }
 
@@ -185,7 +202,7 @@ export class TsButtonComponent implements OnInit {
    * @param {Number} delay The time to delay before collapsing the button
    */
   private collapseWithDelay(delay: number): void {
-    setTimeout(() => {
+    this.timeout = setTimeout(() => {
       this.isCollapsed = true;
       this.changeDetectorRef.detectChanges();
     }, delay);

--- a/src/lib/src/button/button.component.ts
+++ b/src/lib/src/button/button.component.ts
@@ -17,6 +17,7 @@ import {
   TsButtonFormatTypes,
   TsStyleThemeTypes,
 } from './../utilities/types';
+import { TsWindowService } from './../services/window/window.service';
 
 
 /**
@@ -58,7 +59,7 @@ export class TsButtonComponent implements OnInit, OnDestroy {
   /**
    * Store a reference to the timeout needed for collapsable buttons
    */
-  private timeout: any;
+  private collapseTimeoutId: number;
 
   /**
    * Define the delay before the rounded button automatically collapses
@@ -164,6 +165,7 @@ export class TsButtonComponent implements OnInit, OnDestroy {
    */
   constructor(
     private changeDetectorRef: ChangeDetectorRef,
+    private windowService: TsWindowService,
   ) {}
 
 
@@ -172,7 +174,7 @@ export class TsButtonComponent implements OnInit, OnDestroy {
    */
   public ngOnInit(): void {
     if (this.collapseDelay) {
-      this.collapseWithDelay(this.collapseDelay);
+      this.collapseTimeoutId = this.collapseWithDelay(this.collapseDelay);
     }
 
     // If the format is `collapsable`, verify an `iconName` is set
@@ -187,8 +189,8 @@ export class TsButtonComponent implements OnInit, OnDestroy {
    */
   public ngOnDestroy(): void {
     // istanbul ignore else
-    if (this.timeout) {
-      clearTimeout(this.timeout);
+    if (this.collapseTimeoutId) {
+      this.windowService.nativeWindow.clearTimeout(this.collapseTimeoutId);
     }
   }
 
@@ -200,9 +202,10 @@ export class TsButtonComponent implements OnInit, OnDestroy {
    * patching setTimeout automatically.
    *
    * @param {Number} delay The time to delay before collapsing the button
+   * @return The ID of the timeout
    */
-  private collapseWithDelay(delay: number): void {
-    this.timeout = setTimeout(() => {
+  private collapseWithDelay(delay: number): number {
+    return this.windowService.nativeWindow.setTimeout(() => {
       this.isCollapsed = true;
       this.changeDetectorRef.detectChanges();
     }, delay);

--- a/src/lib/src/copy/copy.component.spec.ts
+++ b/src/lib/src/copy/copy.component.spec.ts
@@ -54,14 +54,19 @@ describe(`TsCopyComponent`, () => {
     });
 
 
-    // TODO: The integration test for this will actually test the functionality.
+    // TODO: The integration test for this will actually test the selection functionality.
+    // NOTE: For some reason, the component does not seem to get the mocked value unless we redefine
+    // it here
     it(`should select the text within the passed in element`, () => {
-      this.component.selectText(this.component.content, false, false);
+      this.component.window.getSelection = jasmine.createSpy('getSelection').and.returnValue({
+        removeAllRanges: jasmine.createSpy('removeAllRanges'),
+        addRange: jasmine.createSpy('addRange'),
+      });
 
       const result = this.component.selectText(this.component.content.nativeElement, false, false);
 
       expect(this.component.window.getSelection).toHaveBeenCalled();
-      expect(this.component.documentService.document.createRange).toHaveBeenCalled();
+      expect(this.component.document.createRange).toHaveBeenCalled();
       expect(this.component.hasSelected).toEqual(true);
     });
 
@@ -96,7 +101,7 @@ describe(`TsCopyComponent`, () => {
         remove: jasmine.createSpy('remove'),
         setSelectionRange: jasmine.createSpy('setSelectionRange'),
       };
-      this.component.documentService.document.createElement =
+      this.component.document.createElement =
         jasmine.createSpy('createElement').and.callFake(() => {
           return MOCK_TEXTAREA;
         });
@@ -104,20 +109,21 @@ describe(`TsCopyComponent`, () => {
 
 
     it(`should set the text to the clipboard`, () => {
-      this.component.documentService.document.execCommand = jasmine.createSpy('execCommand');
+      this.component.document.execCommand = jasmine.createSpy('execCommand');
       this.component.copyToClipboard('foo');
 
-      expect(this.component.documentService.document.createElement).toHaveBeenCalledWith('textarea');
-      expect(this.component.documentService.document.body.appendChild).toHaveBeenCalled();
-      expect(this.component.documentService.document.execCommand).toHaveBeenCalledWith('copy');
-      expect(this.component.documentService.document.execCommand).toHaveBeenCalledWith('copy');
+      expect(this.component.document.createElement).toHaveBeenCalledWith('textarea');
+      expect(this.component.document.body.appendChild).toHaveBeenCalled();
+      expect(this.component.document.execCommand).toHaveBeenCalledWith('copy');
+      expect(this.component.document.execCommand).toHaveBeenCalledWith('copy');
     });
 
 
     it(`should fall back to a prompt if execCommand fails`, () => {
-      this.component.documentService.document.execCommand = () => {
+      this.component.document.execCommand = () => {
         throw new Error('fake error');
       }
+      this.component.window.prompt = jasmine.createSpy('prompt');
 
       this.component.copyToClipboard('foo');
 

--- a/src/lib/src/copy/copy.component.ts
+++ b/src/lib/src/copy/copy.component.ts
@@ -38,6 +38,11 @@ import { TsDocumentService } from '../services/document/document.service';
 })
 export class TsCopyComponent {
   /**
+   * Store a reference to the document object
+   */
+  private document: Document = this.documentService.document;
+
+  /**
    * Internal flag to track if the contents have been selected
    */
   public hasSelected: boolean = false;
@@ -56,7 +61,7 @@ export class TsCopyComponent {
   /**
    * Store a reference to the window object
    */
-  private window: any = this.windowService.nativeWindow;
+  private window: Window = this.windowService.nativeWindow;
 
   /**
    * Define access to the wrapper around the content to be copied
@@ -118,9 +123,11 @@ export class TsCopyComponent {
     }
 
     const selection = this.window.getSelection();
-    const range = this.documentService.document.createRange();
+    // NOTE: Adding the type of 'Range' to this causes an error with `range.selectNodeContents`
+    // `Argument of type ElementRef is not assignable to type 'Node'`
+    const range = this.document.createRange();
 
-    range.selectNodeContents(element);
+    range.selectNodeContents(element as any);
     selection.removeAllRanges();
     selection.addRange(range);
 
@@ -145,7 +152,7 @@ export class TsCopyComponent {
    */
   public copyToClipboard(text: string): void {
     // Create a hidden textarea to seed with text content
-    const target = this.documentService.document.createElement('textarea');
+    const target = this.document.createElement('textarea');
     target.className = 'targetElement';
     target.style.position = 'absolute';
     target.style.left = '101%';
@@ -155,13 +162,13 @@ export class TsCopyComponent {
     target.textContent = text;
 
     // Add the textarea, focus and select the text
-    this.documentService.document.body.appendChild(target);
+    this.document.body.appendChild(target);
     target.focus();
     target.setSelectionRange(0, target.value.length);
 
     // Copy the selection or fall back to prompt
     try {
-      this.documentService.document.execCommand('copy');
+      this.document.execCommand('copy');
       target.remove();
     } catch (error) {
       // Fall back to the native alert

--- a/src/lib/src/date-range/date-range.component.ts
+++ b/src/lib/src/date-range/date-range.component.ts
@@ -56,12 +56,12 @@ export class TsDateRangeComponent {
   /**
    * Store the selected end date
    */
-  private endDate: Date;
+  public endDate: Date;
 
   /**
    * Store the selected start date
    */
-  private startDate: Date;
+  public startDate: Date;
 
   /**
    * Allow access to child directive

--- a/src/lib/src/loading-overlay/loading-overlay.directive.spec.ts
+++ b/src/lib/src/loading-overlay/loading-overlay.directive.spec.ts
@@ -62,7 +62,7 @@ describe(`TsLoadingOverlayDirective`, () => {
 
   describe(`ngOnInit()`, () => {
 
-    it(`should set get the current position and pass to determinePosition()`, () => {
+    it(`should get the current position and pass to determinePosition()`, () => {
       this.directive.determinePosition = jasmine.createSpy('determinePosition');
       this.directive.ngOnInit();
 

--- a/src/lib/src/login-form/login-form.component.ts
+++ b/src/lib/src/login-form/login-form.component.ts
@@ -198,7 +198,7 @@ export class TsLoginFormComponent implements OnChanges {
     // Re-initialize the form
     this.loginForm = this.formBuilder.group(this.FORM_GROUP);
 
-    // This timeout let's one change detection cycle pass so that the form is actually removed from
+    // This timeout lets one change detection cycle pass so that the form is actually removed from
     // the DOM
     setTimeout(() => {
       // Add the form back to the DOM

--- a/src/lib/src/services/document/document.service.mock.ts
+++ b/src/lib/src/services/document/document.service.mock.ts
@@ -1,7 +1,4 @@
-import {
-  Injectable,
-  ElementRef,
-} from '@angular/core';
+import { Injectable } from '@angular/core';
 
 
 @Injectable()

--- a/src/lib/src/services/document/document.service.mock.ts
+++ b/src/lib/src/services/document/document.service.mock.ts
@@ -1,4 +1,7 @@
-import { Injectable } from '@angular/core';
+import {
+  Injectable,
+  ElementRef,
+} from '@angular/core';
 
 
 @Injectable()

--- a/src/lib/src/services/window/window.service.mock.ts
+++ b/src/lib/src/services/window/window.service.mock.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-const windowMock: Window = <any>{
+const windowMock: Window = {
   getComputedStyle: jasmine.createSpy('getComputedStyle').and.returnValue({
     getPropertyValue: jasmine.createSpy('getPropertyValue').and.returnValue('static'),
   }),
@@ -14,12 +14,14 @@ const windowMock: Window = <any>{
     addRange: jasmine.createSpy('addRange'),
   }),
   prompt: jasmine.createSpy('prompt'),
-};
+  // Note: mocking setTimeout/clearTimeout here makes it very hard to test items that use
+  // setTimeout. It seems to be easier to add these two spies as needed.
+} as any;
 
 @Injectable()
 export class TsWindowServiceMock {
 
-  get nativeWindow(): any {
+  get nativeWindow(): Window {
     return windowMock;
   }
 

--- a/tslint.json
+++ b/tslint.json
@@ -44,7 +44,6 @@
       "spaces"
     ],
     "interface-over-type-literal": true,
-    "invoke-injectable": true,
     "jsdoc-format": [
       true,
       "check-multiline-start"
@@ -139,9 +138,7 @@
       true,
       0
     ],
-    "template-to-ng-template": true,
     "templates-no-negated-async": true,
-    "templates-use-public": true,
     "trailing-comma": [
       true,
       {


### PR DESCRIPTION
- remove outdated tslint rules
- collapsable buttons no longer cause error during quick navigation