### PR TITLE
589 date pipe tweaks

### DIFF
--- a/src/lib/src/pipes/date/date.pipe.spec.ts
+++ b/src/lib/src/pipes/date/date.pipe.spec.ts
@@ -47,7 +47,7 @@ describe(`TsDatePipe`, () => {
 
     it(`should format a date`, () => {
       const actual = this.pipe(this.date, 'medium');
-      const expected = 'February 8th, 2018';
+      const expected = 'Feb 8 2018';
 
       expect(actual).toEqual(expected);
     });
@@ -59,7 +59,7 @@ describe(`TsDatePipe`, () => {
 
     it(`should format a date`, () => {
       const actual = this.pipe(this.date, 'extended');
-      const expected = 'Thursday, February 8th, 2018, 12:00:00am';
+      const expected = 'Feb 8 2018 12:00:00am';
 
       expect(actual).toEqual(expected);
     });

--- a/src/lib/src/pipes/date/date.pipe.spec.ts
+++ b/src/lib/src/pipes/date/date.pipe.spec.ts
@@ -23,6 +23,12 @@ describe(`TsDatePipe`, () => {
   });
 
 
+  it(`should return null if no value is passed in`, () => {
+    expect(this.pipe(null)).toEqual(null);
+    expect(this.pipe('')).toEqual(null);
+  });
+
+
   describe(`short format`, () => {
 
     it(`should format a date`, () => {

--- a/src/lib/src/pipes/date/date.pipe.ts
+++ b/src/lib/src/pipes/date/date.pipe.ts
@@ -23,6 +23,10 @@ export class TsDatePipe implements PipeTransform {
       'timestamp', // 2018-02-08T05:00:00.000Z
     ];
 
+    // Check for null values to avoid issues during data-binding
+    if (value == null || value === '') {
+      return null;
+    }
 
     // Check for date validity
     if (!isValid(value) && isDevMode()) {

--- a/src/lib/src/pipes/date/date.pipe.ts
+++ b/src/lib/src/pipes/date/date.pipe.ts
@@ -42,9 +42,9 @@ export class TsDatePipe implements PipeTransform {
       (format === 'short')
       ? formatDate(date, 'MM/DD/YYYY')
       : (format === 'medium')
-      ? formatDate(date, 'MMMM Do, YYYY')
+      ? formatDate(date, 'MMM D YYYY')
       : (format === 'extended')
-      ? formatDate(date, 'dddd, MMMM Do, YYYY, h:mm:ssa')
+      ? formatDate(date, 'MMM D YYYY h:mm:ssa')
       : (format === 'timestamp')
       ? new Date(date).toISOString()
       : '';

--- a/src/lib/src/pipes/time-ago/time-ago.pipe.spec.ts
+++ b/src/lib/src/pipes/time-ago/time-ago.pipe.spec.ts
@@ -10,6 +10,12 @@ describe(`TsTimeAgoPipe`, () => {
   });
 
 
+  it(`should return null if no value is passed in`, () => {
+    expect(this.pipe(null, this.oldDate)).toEqual(null);
+    expect(this.pipe('', this.oldDate)).toEqual(null);
+  });
+
+
   it(`should format a date`, () => {
     const actual = this.pipe(this.date, this.oldDate);
     const expected = '5 days';

--- a/src/lib/src/pipes/time-ago/time-ago.pipe.ts
+++ b/src/lib/src/pipes/time-ago/time-ago.pipe.ts
@@ -14,7 +14,12 @@ import {
 })
 export class TsTimeAgoPipe implements PipeTransform {
   transform(value: string|Date, comparedDate: string|Date): string {
+    // Check for null values to avoid issues during data-binding
+    if (value == null || value === '') {
+      return null;
+    }
 
+    console.log('VALUE: ', value, value == null)
     // Check for date validity
     if (!isValid(value) && isDevMode()) {
       throw Error(`'${value}' is not a valid date.`);


### PR DESCRIPTION
- Update date formats. Fixes: #598 
- Handle `null|''` values correctly. Fixes: #586
