### PR TITLE
708 709 card tweaks

### DIFF
--- a/src/demo/src/app/components/card/card.component.html
+++ b/src/demo/src/app/components/card/card.component.html
@@ -3,13 +3,11 @@
   <input type="checkbox" [(ngModel)]="supportsInteraction">
 </label>
 
-
 <label>
   Centered content:
   <input type="checkbox" [(ngModel)]="centered">
 </label>
 
-<hr>
 <br>
 
 <ts-card
@@ -33,35 +31,16 @@
   supportsInteraction="true"
   centeredContent="true"
   [utilityMenuTemplate]="myTemplate"
-  aspectRatio="4:3"
+  aspectRatio="16:9"
   tsVerticalSpacing
 >
   Standard card with utility menu and aspect ratio
 </ts-card>
 
-<ng-template #myTemplate>
-  <ts-menu
-    triggerType="utility"
-    menuPositionX="before"
-    [menuItemsTemplate]="utilityButtons"
-  ></ts-menu>
-
-
-  <ng-template #utilityButtons>
-    <ts-button>
-      My menu item
-    </ts-button>
-  </ng-template>
-</ng-template>
 
 
 <ts-card centeredContent="true" tsVerticalSpacing>
   Centered content
-</ts-card>
-
-
-<ts-card aspectRatio="16:9" tsVerticalSpacing>
-  16:9 aspect ratio
 </ts-card>
 
 
@@ -97,9 +76,14 @@
 </ts-card>
 
 
+<ts-card disabled="true" supportsInteraction="true" tsVerticalSpacing>
+  Disabled with interactions
+</ts-card>
+
+
 <ts-card disabled="true" tsVerticalSpacing>
   <h3 tsCardTitle tsVerticalSpacing>
-    Disabled Card
+    Disabled Card with a very long title foo bar baz
   </h3>
 
   Foo
@@ -110,3 +94,40 @@
   <br>
   Bing
 </ts-card>
+
+
+<ts-card
+  disabled="false"
+  tsVerticalSpacing
+  [utilityMenuTemplate]="myTemplate"
+>
+  <p>
+    DISABLED WITH UTILITY Repellat alias explicabo voluptatibus nesciunt. Optio maxime delectus ex aspernatur quidem. Dolorem nihil eos cum.
+  </p>
+
+  <p>
+    Voluptate perferendis facere pariatur. Hic ipsum est tempora dignissimos dolores. Magnam blanditiis quisquam fugit.
+  </p>
+
+  <p>
+    Officia voluptatum consequuntur rem quo. Fugiat mollitia maiores tempora et. Culpa distinctio ipsum blanditiis.
+  </p>
+</ts-card>
+
+
+
+
+<ng-template #myTemplate>
+  <ts-menu
+    triggerType="utility"
+    menuPositionX="before"
+    [menuItemsTemplate]="utilityButtons"
+  ></ts-menu>
+
+
+  <ng-template #utilityButtons>
+    <ts-button>
+      My menu item
+    </ts-button>
+  </ng-template>
+</ng-template>

--- a/src/lib/src/card/card.component.html
+++ b/src/lib/src/card/card.component.html
@@ -4,14 +4,15 @@
     'c-card--interaction': supportsInteraction,
     'c-card--centered': centeredContent,
     'c-card--aspect': aspectRatioPadding,
-    'c-card--disabled': disabled
+    'c-card--disabled': disabled,
+    'c-card--right-spacing': utilityMenuTemplate || disabled
   }"
   [style.paddingTop]="aspectRatioPadding"
 >
   <div
     class="c-card__inner"
     mat-ripple
-    [matRippleDisabled]="!supportsInteraction"
+    [matRippleDisabled]="!supportsInteraction || disabled"
   >
     <ng-content></ng-content>
   </div>
@@ -22,7 +23,7 @@
   ></ng-container>
 
   <ts-icon
-    *ngIf="disabled"
+    *ngIf="disabled && !utilityMenuTemplate"
     class="c-card__lock"
   >
     lock_outline

--- a/src/lib/src/card/card.component.scss
+++ b/src/lib/src/card/card.component.scss
@@ -21,6 +21,8 @@
   .c-card {
     @include typography;
     background-color: color(pure);
+    // Set up for possible utility nav
+    position: relative;
     width: 100%;
 
     &:not(.c-card--interaction),
@@ -59,8 +61,6 @@
 
 .c-card--aspect {
   $padding: spacing(large) * 2;
-  // set up for take-space
-  position: relative;
 
   .c-card__inner {
     @include take-space;
@@ -69,15 +69,14 @@
 }
 
 .c-card--disabled {
-  // Set up for absolutely positioned icon
-  position: relative;
-
   .c-card__inner {
     opacity: .5;
   }
 
-  .c-card__title {
-    padding-right: spacing(large);
+  // Class added to menu container when the card is disabled
+  .c-menu {
+    opacity: .3;
+    pointer-events: none;
   }
 
   // Lock icon
@@ -88,5 +87,16 @@
     // Magic number adjustment to align with title
     top: calc(#{spacing(large)} - 2px);
     transform: scale(.7);
+  }
+}
+
+// Class added when padding needed on the right for icon or utility menu
+// NOTE: Dual class needed for specificity
+.c-card.c-card--right-spacing {
+  .c-card__inner {
+    $padding: spacing(large) + spacing(large, 4);
+
+    padding-right: spacing(large, 4);
+    width: calc(100% - #{$padding});
   }
 }

--- a/src/lib/src/card/card.component.ts
+++ b/src/lib/src/card/card.component.ts
@@ -37,6 +37,7 @@ import {
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
+  exportAs: 'tsCard',
 })
 export class TsCardComponent {
   /**


### PR DESCRIPTION
- card text no longer overlaps the disabled icon or utility menu if no title directive if used
- when disabled, a card's utility menu is now disabled also