### PR TITLE
chore(Link): add deprecation notice for [color] param

### DIFF
--- a/src/lib/src/link/link.component.spec.ts
+++ b/src/lib/src/link/link.component.spec.ts
@@ -12,4 +12,12 @@ describe(`TsLinkComponent`, () => {
     expect(this.component).toBeTruthy();
   });
 
+
+  it(`should log a warning if the color parameter is set`, () => {
+    window.console.warn = jest.fn();
+    this.component.color = 'primary';
+
+    expect(window.console.warn).toHaveBeenCalled();
+  });
+
 });

--- a/src/lib/src/link/link.component.ts
+++ b/src/lib/src/link/link.component.ts
@@ -3,6 +3,7 @@ import {
   Input,
   ChangeDetectionStrategy,
   ViewEncapsulation,
+  isDevMode,
 } from '@angular/core';
 
 
@@ -46,6 +47,24 @@ export class TsLinkComponent {
   public externalIcon: string = `open_in_new`;
 
   /**
+   * Create input to show deprecation notice
+   *
+   * @deprecated
+   * @deletion-target 7.0.0
+   */
+  @Input()
+  public set color(value: string) {
+    // istanbul ignore else
+    if (isDevMode()) {
+      console.warn(
+        'The TsLinkComponent `[color]` parameter has been deprecated and will be removed in ' +
+        '`@terminus/ui@7.0.0`.\n' +
+        'You can use the `[theme]` parameter to set the link\'s color.',
+      );
+    }
+  }
+
+  /**
    * Define the link's destination
    */
   @Input()
@@ -62,4 +81,5 @@ export class TsLinkComponent {
    */
   @Input()
   public tabIndex: number = 0;
+
 }

--- a/src/lib/src/services/document/document.service.spec.ts
+++ b/src/lib/src/services/document/document.service.spec.ts
@@ -1,4 +1,3 @@
-import { DOCUMENT } from '@angular/platform-browser';
 
 import { TsDocumentService } from './document.service';
 
@@ -6,9 +5,11 @@ import { TsDocumentService } from './document.service';
 describe(`TsDocumentService`, () => {
 
   it(`should return the window object`, () => {
+    window.console.warn = jest.fn();
     const service = new TsDocumentService();
 
     expect(service.document).toBeTruthy();
+    expect(window.console.warn).toHaveBeenCalled();
   });
 
 });

--- a/src/lib/src/services/window/window.service.spec.ts
+++ b/src/lib/src/services/window/window.service.spec.ts
@@ -4,9 +4,11 @@ import { TsWindowService } from './window.service';
 describe(`TsWindowService`, () => {
 
   it(`should return the window object`, () => {
+    window.console.warn = jest.fn();
     const service = new TsWindowService();
 
     expect(service.nativeWindow.innerWidth).toBeTruthy();
+    expect(window.console.warn).toHaveBeenCalled();
   });
 
 });


### PR DESCRIPTION
Also added spies for window/document services so that console.log isn’t actually called during tests