### PR TITLE
feat(Tooltip): Create tooltip extension that adds a dotted underline

### DIFF
--- a/src/demo/src/app/components/tooltip/tooltip.component.ts
+++ b/src/demo/src/app/components/tooltip/tooltip.component.ts
@@ -28,6 +28,16 @@ import { Component } from '@angular/core';
         <option value="right">Right</option>
       </select>
     </label>
+    <br>
+
+    <label>
+      Dotted Underline?
+
+      <select class="example-select-text" [(ngModel)]="myUnderlineOption">
+        <option [ngValue]="true">Yes</option>
+        <option [ngValue]="false">No</option>
+      </select>
+    </label>
 
     <hr>
     <br>
@@ -37,6 +47,7 @@ import { Component } from '@angular/core';
         <ts-tooltip
           [tooltipValue]="myTooltip"
           [tooltipPosition]="myPosition"
+          [hasUnderline]="myUnderlineOption"
         >Hover me.</ts-tooltip>
       </div>
     </section>
@@ -45,4 +56,5 @@ import { Component } from '@angular/core';
 export class TooltipComponent {
   myTooltip = 'Here is my content';
   myPosition = 'below';
+  myUnderlineOption = false;
 }

--- a/src/lib/src/tooltip/tooltip.component.html
+++ b/src/lib/src/tooltip/tooltip.component.html
@@ -2,6 +2,7 @@
   class="c-tooltip qa-tooltip"
   [matTooltip]="tooltipValue"
   [matTooltipPosition]="tooltipPosition"
+  [ngClass]="{'c-tooltip--underline': hasUnderline}"
 >
   <ng-content></ng-content>
 </span>

--- a/src/lib/src/tooltip/tooltip.component.scss
+++ b/src/lib/src/tooltip/tooltip.component.scss
@@ -1,3 +1,5 @@
+@import './../scss/helpers/cursors';
+
 //
 // @component
 //  Tooltip
@@ -7,4 +9,10 @@
 .ts-tooltip {
   display: inline-block;
   // Top level styles should be nested here
+}
+
+.c-tooltip--underline {
+  border-bottom: .1em dotted;
+  border-color: inherit;
+  cursor: cursor(help);
 }

--- a/src/lib/src/tooltip/tooltip.component.ts
+++ b/src/lib/src/tooltip/tooltip.component.ts
@@ -19,6 +19,7 @@ import { TsTooltipPositionTypes } from './../utilities/types';
  * <ts-tooltip
  *              [tooltipValue]="myTooltip"
  *              [tooltipPosition]="myPosition"
+ *              [hasUnderline]="myUnderlineOption"
  * >My Tooltip!</ts-tooltip>
  *
  * <example-url>https://goo.gl/ieUPaG</example-url>
@@ -45,4 +46,10 @@ export class TsTooltipComponent {
    */
   @Input()
   public tooltipValue: string;
+
+  /**
+   * Define whether there is a dotted underline shown on the text
+   */
+  @Input()
+  public hasUnderline: boolean = false;
 }


### PR DESCRIPTION
Provide an input to tooltip component named `hasUnderline`.
If it's true, dotted underline showing underneath the text.
It's default to false.