### PR TITLE
fix(Validator): Hotfix incorrect validation message

### DIFF
--- a/src/lib/src/services/validation-message/validation-message.service.spec.ts
+++ b/src/lib/src/services/validation-message/validation-message.service.spec.ts
@@ -26,6 +26,16 @@ describe(`TsValidationMessageService`, () => {
       expect(actual).toEqual(expected);
     });
 
+    test(`should return an error message when supplied lowercase letters less than required`, () => {
+      const validatorValueMock = {
+        lowercase: 4,
+      };
+      const actual = this.service.getValidatorErrorMessage('lowercase', validatorValueMock);
+      const expected = `Must contain at least 4 lowercase letters`;
+
+      expect(actual).toEqual(expected);
+    });
+
     test(`should return a maxLength message`, () => {
       const validatorValueMock = {
         requiredLength: 12,

--- a/src/lib/src/services/validation-message/validation-message.service.ts
+++ b/src/lib/src/services/validation-message/validation-message.service.ts
@@ -46,7 +46,7 @@ export class TsValidationMessageService {
       noResults: `No results found.`,
       url: `'${validatorValue.actual}' is not a valid URL.`,
       equalToControl: `'${validatorValue.actual}' is not equal to '${validatorValue.compareValue}'`,
-      lowercase: `Must contain at least ${validatorValue.lowercaseMin} lowercase letters`,
+      lowercase: `Must contain at least ${validatorValue.lowercase} lowercase letters`,
     };
 
     if (validatorName === 'maxDate') {


### PR DESCRIPTION
Correct that validation message references a wrong key.