### PR TITLE
fix(LoadingOverlay): add another zindex level for internal overlays

### DIFF
--- a/terminus-ui/src/loading-overlay/loading-overlay.component.scss
+++ b/terminus-ui/src/loading-overlay/loading-overlay.component.scss
@@ -55,7 +55,7 @@ $duration: 1.4s;
     right: 0;
     top: 0;
     will-change: opacity;
-    z-index: z(overlay);
+    z-index: z(panel-overlay);
   }
 }
 

--- a/terminus-ui/src/scss/helpers/_z-index.scss
+++ b/terminus-ui/src/scss/helpers/_z-index.scss
@@ -10,6 +10,7 @@ $z-layers: (
   'overlay',
   'tooltip',
   'header',
+  'panel-overlay',
   'menu',
   'menu-trigger',
 );


### PR DESCRIPTION
This allows in-page overlays to be below items like the header while still allowing a full page overlay to cover all content.

ISSUES CLOSED: #850