### PR TITLE
fix(Autocomplete): clicking the x on a chip now correctly removes the option

### DIFF
--- a/terminus-ui/src/autocomplete/autocomplete.component.html
+++ b/terminus-ui/src/autocomplete/autocomplete.component.html
@@ -15,7 +15,7 @@
         class="qa-autocomplete-chip"
         [selectable]="selectableChips"
         removable="true"
-        (remove)="deselectOption(option)"
+        (removed)="deselectOption(option)"
       >
         {{ displayOption(option) }}
         <ts-icon matChipRemove>


### PR DESCRIPTION
ISSUES CLOSED: #926