### PR TITLE
fix(FileUpload): fileContents now available for files that are not images

### DIFF
--- a/terminus-ui/src/file-upload/selected-file.spec.ts
+++ b/terminus-ui/src/file-upload/selected-file.spec.ts
@@ -73,6 +73,7 @@ describe(`TsSelectedFile`, () => {
   beforeEach(() => {
     // Mock FileReader
     class DummyFileReader {
+      onload = jest.fn();
       addEventListener = jest.fn();
       readAsDataURL = jest.fn().mockImplementation(function(this: FileReader) { this.onload({} as Event); });
       // tslint:disable: max-line-length
@@ -225,6 +226,18 @@ describe(`TsSelectedFile`, () => {
         }
       });
       expect.assertions(4);
+    });
+
+
+    test(`should still seed the FileReader for non-image files`, (done) => {
+      const file = createFile(FILE_CSV_MOCK);
+      file.fileLoaded$.subscribe((f) => {
+        if (f) {
+          expect(f.fileContents).toBeTruthy();
+          done();
+        }
+      });
+      expect.assertions(1);
     });
 
 

--- a/terminus-ui/src/file-upload/selected-file.ts
+++ b/terminus-ui/src/file-upload/selected-file.ts
@@ -142,26 +142,23 @@ export class TsSelectedFile {
    * @param callback - A function to call after the dimensions have been calculated (asynchronously)
    */
   private determineImageDimensions(callback?: Function): void {
-    // If we are not dealing with an image, exit
-    if (!this.isImage) {
-      // istanbul ignore else
-      if (callback) {
-        callback();
-      }
+    let img: HTMLImageElement | undefined;
 
-      // Since this is not an image, set dimension validation to `true` to 'bypass'
-      this.validations.imageDimensions = true;
-      return;
-    }
+    if (this.isImage) {
+      // Create an image so that dimensions can be determined
+      img = new Image();
 
-    // Create an image so that dimensions can be determined
-    const img: HTMLImageElement = new Image();
-
-    this.fileReader.onload = (v: Event) => {
-      img.src = this.fileReader.result;
-    };
-    img.onload = (v: Event) => {
-        this.dimensions = new TsImageDimensions(img.naturalWidth, img.naturalHeight);
+      this.fileReader.onload = (v: Event) => {
+        // istanbul ignore else
+        if (img) {
+          img.src = this.fileReader.result;
+        }
+      };
+      img.onload = (v: Event) => {
+        // istanbul ignore else
+        if (img) {
+          this.dimensions = new TsImageDimensions(img.naturalWidth, img.naturalHeight);
+        }
 
         // Validate dimensions
         this.validations.imageDimensions = this.validateImageDimensions(this.imageDimensionConstraints);
@@ -171,7 +168,17 @@ export class TsSelectedFile {
         if (callback) {
           callback();
         }
-    };
+      };
+    } else {
+      // We are not dealing with an image:
+      // istanbul ignore else
+      if (callback) {
+        callback();
+      }
+
+      // Since this is not an image, set dimension validation to `true` to 'bypass'
+      this.validations.imageDimensions = true;
+    }
 
     // Read the file (this triggers the FileReader load event)
     this.fileReader.readAsDataURL(this.file);


### PR DESCRIPTION
Previously, only images would trigger the FileReader to seed it's contents

ISSUES CLOSED: #991