### PR TITLE
fix(Scrollbars): use forward ref to fix demo issue

### DIFF
--- a/terminus-ui/src/scrollbars/scrollbars.component.ts
+++ b/terminus-ui/src/scrollbars/scrollbars.component.ts
@@ -6,6 +6,7 @@ import {
   Output,
   ViewChild,
   ViewEncapsulation,
+  forwardRef,
 } from '@angular/core';
 import {
   Geometry,
@@ -120,7 +121,7 @@ export class TsScrollbarsComponent {
   /**
    * Access underlying scrollbar directive
    */
-  @ViewChild('scrollbar')
+  @ViewChild(forwardRef(() => PerfectScrollbarDirective))
   public scrollbar!: PerfectScrollbarDirective;
 
   /**


### PR DESCRIPTION
Can't construct a query for the property "scrollbars" of "ScrollbarsComponent" since the query
selector wasn't defined.