### PR TITLE
fix(Autocomplete): correctly allows removal when in single select mode

### DIFF
--- a/demo/app/components/autocomplete/autocomplete.component.html
+++ b/demo/app/components/autocomplete/autocomplete.component.html
@@ -29,7 +29,6 @@
       [selectionsControl]="myForm.get('selections')"
       [displayWith]="displayFn"
       [initialSelections]="null"
-      [multiple]="comparator"
       [minimumCharacters]="minCharacters"
       [showProgress]="inProgress"
       label="Select user names"

--- a/terminus-ui/src/autocomplete/autocomplete.component.ts
+++ b/terminus-ui/src/autocomplete/autocomplete.component.ts
@@ -380,8 +380,8 @@ export class TsAutocompleteComponent<OptionType = {[name: string]: any}> impleme
     // The selected option
     const selection: OptionType = event.option.value;
 
-    // Stop the flow if the selection already exists in the array
-    if (arrayContainsObject(selection, this.selectedOptions, this.comparatorFn)) {
+    // Stop the flow if the selection already exists in the array and we're in multiple mode
+    if (!!this.multiple && arrayContainsObject(selection, this.selectedOptions, this.comparatorFn)) {
       // Set an error on the control to let the user know they chose a duplicate option
       // istanbul ignore else
       if (this.selectionsControl) {


### PR DESCRIPTION
1) removing `[multiple]="comparator"` 
2) typeahead and select one
3) remove that one and try to typeahead and select another one
4) that’s when this error message shows up.