### PR TITLE
DateRange: Validation now correct

### DIFF
--- a/demo/app/components/date-range/date-range.component.html
+++ b/demo/app/components/date-range/date-range.component.html
@@ -8,7 +8,7 @@
     </button>
   </div>
 
-  <button (click)="printRange(myForm.value)">Print Range</button>
+  <button (click)="printRange(myForm.value)">Print Range to Console</button>
 </ts-card>
 
 
@@ -22,3 +22,9 @@
 
   </form>
 </ts-card>
+
+
+<pre>
+FORM VALUE:
+{{ myForm.value | json }}
+</pre>

--- a/demo/app/components/date-range/date-range.component.html
+++ b/demo/app/components/date-range/date-range.component.html
@@ -8,7 +8,9 @@
     </button>
   </div>
 
-  <button (click)="printRange(myForm.value)">Print Range to Console</button>
+  <button (click)="updateStartDate()">Update start date</button>
+  <br>
+  <button (click)="printRange(myForm.value)">Print Range</button>
 </ts-card>
 
 

--- a/demo/app/components/date-range/date-range.component.ts
+++ b/demo/app/components/date-range/date-range.component.ts
@@ -59,6 +59,14 @@ export class DateRangeComponent implements OnInit {
     console.log('DEMO: formValue: ', formValue);
   }
 
+  updateStartDate() {
+    const ctrl = this.myForm.get('dateRange.startDate');
+
+    if (ctrl) {
+      ctrl.setValue(new Date(2019, 0, 2).toISOString());
+    }
+  }
+
 
   toggleStart() {
     const ctrl = this.myForm.get('dateRange.startDate');

--- a/terminus-ui/src/date-range/date-range.component.html
+++ b/terminus-ui/src/date-range/date-range.component.html
@@ -1,7 +1,7 @@
 <div class="c-date-range qa-date-range" fxLayout="row">
   <ts-input
     class="qa-date-range-start-datepicker"
-    [formControl]="startDateControl"
+    [formControl]="internalStartControl"
     [label]="startLabel"
     [maxDate]="startMaxDate$ | async"
     [minDate]="startMinDate"
@@ -22,7 +22,7 @@
 
   <ts-input
     class="qa-date-range-end-datepicker"
-    [formControl]="endDateControl"
+    [formControl]="internalEndControl"
     [label]="endLabel"
     [maxDate]="endMaxDate"
     [minDate]="endMinDate$ | async"

--- a/terminus-ui/src/date-range/testing/test-components.ts
+++ b/terminus-ui/src/date-range/testing/test-components.ts
@@ -1,0 +1,131 @@
+// tslint:disable: component-class-suffix
+import {
+  Component,
+  ViewChild,
+} from '@angular/core';
+import {
+  FormBuilder,
+} from '@angular/forms';
+
+import { createDateRangeGroup } from './test-helpers';
+import { TsDateRangeComponent } from '../date-range.component';
+
+
+@Component({
+  template: `
+  <form [formGroup]="dateGroup" novalidate>
+    <ts-date-range
+      [dateFormGroup]="dateGroup"
+    ></ts-date-range>
+  </form>
+  `,
+})
+export class Basic {
+  dateGroup = createDateRangeGroup();
+
+  @ViewChild(TsDateRangeComponent)
+  dateRangeComponent!: TsDateRangeComponent;
+}
+
+@Component({
+  template: `
+  <form [formGroup]="dateGroup" novalidate>
+    <ts-date-range
+      [dateFormGroup]="dateGroup"
+    ></ts-date-range>
+  </form>
+  `,
+})
+export class SeededDates {
+  date1 = new Date(2018, 1, 1);
+  date2 = new Date(2018, 1, 12);
+  dateGroup = createDateRangeGroup(this.date1, this.date2);
+
+  @ViewChild(TsDateRangeComponent)
+  dateRangeComponent!: TsDateRangeComponent;
+}
+
+@Component({
+  template: `
+  <form [formGroup]="dateGroup" novalidate>
+    <ts-date-range
+      [dateFormGroup]="dateGroup"
+      (change)="change($event)"
+      (endSelected)="endSelected($event)"
+      (startSelected)="startSelected($event)"
+    ></ts-date-range>
+  </form>
+  `,
+})
+export class Emitters {
+  dateGroup = createDateRangeGroup();
+  change = jest.fn();
+  endSelected = jest.fn();
+  startSelected = jest.fn();
+
+  @ViewChild(TsDateRangeComponent)
+  dateRangeComponent!: TsDateRangeComponent;
+}
+
+@Component({
+  template: `
+  <form [formGroup]="dateGroup" novalidate>
+    <ts-date-range
+      [dateFormGroup]="dateGroup"
+      [endMaxDate]="endMax"
+      [endMinDate]="endMin"
+      [isDisabled]="disabled"
+      [startingView]="startingView"
+      [startMaxDate]="startMax"
+      [startMinDate]="startMin"
+      [theme]="theme"
+    ></ts-date-range>
+  </form>
+  `,
+})
+export class Params {
+  dateGroup = createDateRangeGroup();
+  endMax = new Date(2017, 4, 25);
+  endMin = new Date(2017, 4, 1);
+  disabled = true;
+  startingView = 'year';
+  startMax = new Date(2017, 5, 25);
+  startMin = new Date(2017, 5, 1);
+  theme = 'accent';
+
+  @ViewChild(TsDateRangeComponent)
+  dateRangeComponent!: TsDateRangeComponent;
+}
+
+@Component({
+  template: `
+  <ts-date-range
+    (startSelected)="startSelected($event)"
+  ></ts-date-range>`,
+})
+export class NoFormGroup {
+  startSelected = jest.fn();
+
+  @ViewChild(TsDateRangeComponent)
+  dateRangeComponent!: TsDateRangeComponent;
+}
+
+@Component({
+  template: `
+  <form [formGroup]="dateGroup" novalidate>
+    <ts-date-range
+      [dateFormGroup]="dateGroup"
+      (startSelected)="startSelected($event)"
+    ></ts-date-range>
+  </form>
+  `,
+})
+export class NoControls {
+  dateGroup = this.formBuilder.group({});
+  startSelected = jest.fn();
+
+  @ViewChild(TsDateRangeComponent)
+  dateRangeComponent!: TsDateRangeComponent;
+
+  constructor(private formBuilder: FormBuilder) {}
+}

--- a/terminus-ui/src/date-range/testing/test-helpers.ts
+++ b/terminus-ui/src/date-range/testing/test-helpers.ts
@@ -1,0 +1,23 @@
+import {
+  FormBuilder,
+  FormGroup,
+  Validators,
+} from '@angular/forms';
+
+
+
+
+export function createDateRangeGroup(startDate: null | Date = null, endDate: null | Date = null): FormGroup {
+  const formBuilder = new FormBuilder();
+
+  return formBuilder.group({
+    startDate: [
+      startDate,
+      [Validators.required],
+    ],
+    endDate: [
+      endDate,
+      [Validators.required],
+    ],
+  });
+}

--- a/terminus-ui/src/form-field/form-field-control.ts
+++ b/terminus-ui/src/form-field/form-field-control.ts
@@ -1,4 +1,4 @@
-import { NgControl } from '@angular/forms';
+import { NgControl, FormControl } from '@angular/forms';
 import { Observable } from 'rxjs';
 
 
@@ -62,6 +62,11 @@ export abstract class TsFormFieldControl<T> {
    * Whether the input is currently in an autofilled state. If property is not present on the control it is assumed to be false.
    */
   readonly autofilled?: boolean;
+
+  /**
+   * An optional form control (used by DateRange)
+   */
+  readonly formControl?: FormControl;
 
   /**
    * Handles a click on the control's container

--- a/terminus-ui/src/form-field/form-field.component.html
+++ b/terminus-ui/src/form-field/form-field.component.html
@@ -62,10 +62,10 @@
     fxLayoutAlign="space-between center"
     [fxLayoutGap]="flexGap"
   >
-    <div *ngIf="control && control?.ngControl">
+    <div *ngIf="control && (control.ngControl || control.formControl)">
       <ts-validation-messages
         class="qa-form-field-validation-messages"
-        [control]="control.ngControl"
+        [control]="control.ngControl || control.formControl"
         [validateOnChange]="validateOnChange"
       ></ts-validation-messages>
     </div>

--- a/terminus-ui/src/input/date-adapter.ts
+++ b/terminus-ui/src/input/date-adapter.ts
@@ -61,7 +61,9 @@ export class TsDateAdapter extends NativeDateAdapter {
    * @return Whether it is valid
    */
   public isValid(date: Date): boolean {
-    return isValidDate(date) && !isNaN(date.getTime());
+    // HACK: I cannot reproduce a case where the date is valid but date.getTime is not a function.
+    // However, when dynamically updating a date in real use throws an error.
+    return isValidDate(date) && date.getTime && !isNaN(date.getTime());
   }
 
 

--- a/terminus-ui/src/select/select.component.ts
+++ b/terminus-ui/src/select/select.component.ts
@@ -215,6 +215,7 @@ let nextUniqueId = 0;
  *              hint="My hint!"
  *              id="my-id"
  *              isDisabled="true"
+ *              isFilterable="true"
  *              isRequired="true"
  *              label="My label!"
  *              minimumCharacters="3"

--- a/terminus-ui/src/validation-messages/validation-messages.component.spec.ts
+++ b/terminus-ui/src/validation-messages/validation-messages.component.spec.ts
@@ -1,3 +1,5 @@
+import { ChangeDetectorRefMock } from '@terminus/ngx-tools/testing';
+
 import { TsValidationMessagesComponent } from './validation-messages.component';
 import { TsValidationMessageServiceMock } from './validation-message.service.mock';
 
@@ -6,7 +8,10 @@ describe('InputMessagesComponent', () => {
   let component: TsValidationMessagesComponent;
 
   beforeEach(() => {
-    component = new TsValidationMessagesComponent(new TsValidationMessageServiceMock());
+    component = new TsValidationMessagesComponent(
+      new TsValidationMessageServiceMock(),
+      new ChangeDetectorRefMock(),
+    );
     component['validationMessageService'].getValidatorErrorMessage = jest.fn();
   });
 

--- a/terminus-ui/src/validation-messages/validation-messages.component.ts
+++ b/terminus-ui/src/validation-messages/validation-messages.component.ts
@@ -78,8 +78,9 @@ export class TsValidationMessagesComponent implements OnDestroy {
     this._control = value;
 
     // Trigger change detection if the underlying control's status changes
-    if (this.control) {
-      this.control.statusChanges.pipe(untilComponentDestroyed(this)).subscribe((v) => {
+    // istanbul ignore else
+    if (this.control && this.control.statusChanges) {
+      this.control.statusChanges.pipe(untilComponentDestroyed(this)).subscribe(() => {
         this.changeDetectorRef.detectChanges();
       });
     }


### PR DESCRIPTION
- Now using an internal FormControl to sync changes and values between the date range component and the passed in FormGroup.
- Rewritten tests to use `TestBed` rather than `new Class`
- FormField now works with injected ngControl or formControl property
- Validation messages component now triggers change detection when the passed in control's status changes.
- Added `isFilterable` to select docs since it was missed during the docs addition.