### PR TITLE
refactor(Packages): moved Material to a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Install the library and required dependencies:
 $ yarn add @terminus/ui @terminus/ngx-tools
 
 # Peer dependencies that will need to be installed (needed by UI and tools libraries):
-$ yarn add @angular/flex-layout@6.0.0-beta.18 date-fns@2.0.0-alpha.16 @ngrx/effects @ngrx/store hammerjs
+$ yarn add @angular/material @angular/flex-layout@7.0.0-beta.22 date-fns@2.0.0-alpha.26 @ngrx/effects @ngrx/store hammerjs
 
 # Optional dependencies (needed if using the TsChartComponent):
 $ yarn add @amcharts/amcharts4 @amcharts/amcharts4-geodata

--- a/terminus-ui/package.json
+++ b/terminus-ui/package.json
@@ -46,7 +46,6 @@
   },
   "dependencies": {
     "@angular/cdk": "^7.2.0",
-    "@angular/material": "^7.2.0",
     "ngx-perfect-scrollbar": "^7.2.0",
     "text-mask-addons": "^3.8.0",
     "text-mask-core": "^5.1.2"
@@ -56,6 +55,7 @@
     "@angular/core": "^7.2.0",
     "@angular/flex-layout": "7.0.0-beta.22",
     "@angular/forms": "^7.2.0",
+    "@angular/material": "^7.2.0",
     "@angular/platform-browser": "^7.2.0",
     "@angular/router": "^7.2.0",
     "@terminus/ngx-tools": "^5.0.0",
@@ -72,7 +72,6 @@
     "lib": {
       "entryFile": "src/public-api.ts",
       "umdModuleIds": {
-        "@angular/material": "ng.material",
         "@angular/cdk": "ng.cdk",
         "@terminus/ngx-tools": "terminus.ngxTools",
         "@terminus/ngx-tools/coercion": "terminus.ngxTools.coercion",


### PR DESCRIPTION
BREAKING CHANGE:
Material is now a peer dependency so it must be installed by the consumer. This is so a consumer can use parts of Material outside of the library if needed.

ISSUES CLOSED: #1091