### PR TITLE
fix(Select): subscribe to form control value changes and select option

### DIFF
--- a/terminus-ui/src/select/select.component.ts
+++ b/terminus-ui/src/select/select.component.ts
@@ -954,6 +954,9 @@ export class TsSelectComponent implements
         this.autocompleteFormControl.setValue(this.ngControl.value);
         this.autocompleteSelections = this.ngControl.value;
       }
+      if (this.ngControl.valueChanges) {
+        this.ngControl.valueChanges.subscribe((newValue) => this.setSelectionByValue(newValue));
+      }
     } else {
       // HACK: Wait until the next detection cycle to set the value from an ngModel.
       // NOTE: Using CDR.detectChanges causes errors in children that expect TsSelectOptionComponents to exist.

--- a/terminus-ui/src/select/select.component.ts
+++ b/terminus-ui/src/select/select.component.ts
@@ -955,7 +955,9 @@ export class TsSelectComponent implements
         this.autocompleteSelections = this.ngControl.value;
       }
       if (this.ngControl.valueChanges) {
-        this.ngControl.valueChanges.subscribe((newValue) => this.setSelectionByValue(newValue));
+        this.ngControl.valueChanges
+          .pipe(untilComponentDestroyed(this))
+          .subscribe((newValue) => this.setSelectionByValue(newValue));
       }
     } else {
       // HACK: Wait until the next detection cycle to set the value from an ngModel.


### PR DESCRIPTION
Fix issue where selection isn't updated if options are rendered before the form control is populated.