### PR TITLE
chore(CI): rename primary typings file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,10 @@ jobs:
           command: yarn run build
 
       - run:
+          name: Rename Primary Typings File
+          command: tooling/ci/rename-typings-index.sh
+
+      - run:
           name: Test AoT Demo App Build
           command: tooling/ci/copy-dist-to-node-modules.sh && yarn run build:app:ci
 

--- a/tooling/ci/rename-typings-index.sh
+++ b/tooling/ci/rename-typings-index.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#
+# Rename built typings index file
+#
+#
+
+. ~/.bashrc
+
+mv dist/terminus-ui/terminus-ui.d.ts dist/terminus-ui/index.d.ts


### PR DESCRIPTION
This should fix an issue when importing from the top level and building aot