### PR TITLE
docs(Input): update docs to clarify how to acheive validation using ngModel

### DIFF
--- a/terminus-ui/input/src/input.component.md
+++ b/terminus-ui/input/src/input.component.md
@@ -97,19 +97,28 @@ myControl: FormControl = new FormControl({value: null, disabled: true});
 
 ### Required
 
-For input's not using a `FormControl`, set the `isRequired` input to `true`:
+When using a `FormControl`, set the required validator on the control:
+
+```typescript
+myControl = new FormControl(null, Validators.required);
+```
+
+When using `ngModel`, validations are placed on the input as data-attributes (just like native HTML inputs):
+
+```html
+<ts-input
+  [formControl]="myForm.get('myControl')"
+  required
+></ts-input>
+```
+
+If only the required asterisk is needed rather than valiation errors, the `isRequired` flag can be used:
 
 ```html
 <ts-input
   [formControl]="myForm.get('myControl')"
   [isRequired]="true"
 ></ts-input>
-```
-
-When using a `FormControl`, set the required validator on the control:
-
-```typescript
-myControl = new FormControl(null, Validators.required);
 ```
 
 


### PR DESCRIPTION
ISSUES CLOSED: #1214

@shani-terminus I traced down the same path you did and got the same results. I looked deeper into how `ngModel` works and it seems that it doesn't actually care about the `required` attribute that is added to the underlying input element. Rather, it is looking for the `required` attribute that lives on whichever element is the ControlValueAccessor. So in our case, if the user adds a standard `required` attribute to a `ts-input`, then `ngModel` validation works (ie shows error messages).

```
// works:
<ts-input required></ts-input>
```

After some testing it seems that we cannot mirror the `isDisabled` flag to set the input as required. I tried setting it via the `host` definition, via the template and via the `Renderer2` with no luck. Each method correctly sets the attribute in the DOM, but `ngModel` doesn't reflect that via errors. 

So for now, I am just submitting a docs change to make this more clear for consumers.
