### PR TITLE
fix(DateRange): now emits change when an input is manually cleared

### DIFF
--- a/demo/app/components/date-range/date-range.component.ts
+++ b/demo/app/components/date-range/date-range.component.ts
@@ -7,7 +7,7 @@ import {
 import { TsValidatorsService } from '@terminus/ui/validators';
 
 
-const date1 = new Date(2018, 10, 12);
+const date1 = new Date();
 if (date1.getDate() > 25) {
   date1.setDate(date1.getDate() + 6);
 }
@@ -63,7 +63,7 @@ export class DateRangeComponent implements OnInit {
     const ctrl = this.myForm.get('dateRange.startDate');
 
     if (ctrl) {
-      ctrl.setValue(new Date(2019, 0, 2).toISOString());
+      ctrl.setValue(new Date(2019, 0, 2));
     }
   }
 

--- a/terminus-ui/date-range/src/date-range.component.html
+++ b/terminus-ui/date-range/src/date-range.component.html
@@ -1,6 +1,6 @@
 <div class="c-date-range qa-date-range" fxLayout="row">
   <ts-input
-    class="qa-date-range-start-datepicker"
+    class="c-date-range--start qa-date-range-start-datepicker"
     [formControl]="internalStartControl"
     [label]="startLabel"
     [maxDate]="startMaxDate$ | async"
@@ -21,7 +21,7 @@
   </span>
 
   <ts-input
-    class="qa-date-range-end-datepicker"
+    class="c-date-range--end qa-date-range-end-datepicker"
     [formControl]="internalEndControl"
     [label]="endLabel"
     [maxDate]="endMaxDate"

--- a/terminus-ui/date-range/src/date-range.component.md
+++ b/terminus-ui/date-range/src/date-range.component.md
@@ -10,6 +10,7 @@
 - [Disabling](#disabling)
   - [Disable a control](#disable-a-control)
   - [Disable the component](#disable-the-component)
+- [Test Helpers](#test-helpers)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -166,3 +167,15 @@ The entire component can be disabled:
 ```html
 <ts-date-range [isDisabled]="true"></ts-date-range>
 ```
+
+
+## Test Helpers
+
+Some helpers are exposed to assist with testing. These are imported from `@terminus/ui/date-range/testing`;
+
+| Function                 |
+|--------------------------|
+| `createDateRangeGroup`   |
+| `getDebugRangeInputs`    |
+| `getRangeInputInstances` |
+| `getRangeInputElements`  |

--- a/terminus-ui/date-range/src/date-range.component.spec.ts
+++ b/terminus-ui/date-range/src/date-range.component.spec.ts
@@ -8,6 +8,11 @@ import { Type, Provider } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { typeInElement } from '@terminus/ngx-tools/testing';
 import * as testComponents from '@terminus/ui/date-range/testing';
+import {
+  getDebugRangeInputs,
+  getRangeInputElements,
+  getRangeInputInstances,
+} from '@terminus/ui/date-range/testing';
 
 import { TsDateRangeModule } from './date-range.module';
 
@@ -25,7 +30,7 @@ describe(`TsDateRangeComponent`, function() {
     test(`should set the END min date according to the start date`, function() {
       const fixture = createComponent(testComponents.SeededDates);
       fixture.detectChanges();
-      const endInputInstance = fixture.debugElement.queryAll(By.css('ts-input'))[1].componentInstance;
+      const endInputInstance = getRangeInputInstances(fixture)[1];
 
       expect(endInputInstance.minDate).toEqual(new Date(2018, 1, 1));
     });
@@ -34,7 +39,7 @@ describe(`TsDateRangeComponent`, function() {
     test(`should set the START max date according to the end date`, function() {
       const fixture = createComponent(testComponents.SeededDates);
       fixture.detectChanges();
-      const startInputInstance = fixture.debugElement.queryAll(By.css('ts-input'))[0].componentInstance;
+      const startInputInstance = getRangeInputInstances(fixture)[0];
 
       expect(startInputInstance.maxDate).toEqual(new Date(2018, 1, 12));
     });
@@ -43,10 +48,10 @@ describe(`TsDateRangeComponent`, function() {
     test(`should set the START max date according to the end date on BLUR`, function() {
       const fixture = createComponent(testComponents.Basic);
       fixture.detectChanges();
-      const startInputInstance = fixture.debugElement.queryAll(By.css('ts-input'))[0].componentInstance;
-      const endInputInstance = fixture.debugElement.queryAll(By.css('ts-input'))[1].componentInstance;
-      typeInElement('3-4-2019', endInputInstance.inputElement.nativeElement);
-      endInputInstance.inputElement.nativeElement.blur();
+      const [startInputInstance, endInputInstance] = getRangeInputInstances(fixture);
+      const endInputElement = endInputInstance.inputElement.nativeElement;
+      typeInElement('3-4-2019', endInputElement);
+      endInputElement.blur();
       fixture.detectChanges();
 
       expect(startInputInstance.maxDate).toEqual(new Date('3-4-2019'));
@@ -62,8 +67,7 @@ describe(`TsDateRangeComponent`, function() {
       test(`should update their VALUE when the external control value changes`, function() {
         const fixture = createComponent(testComponents.Basic);
         fixture.detectChanges();
-        const startInputInstance = fixture.debugElement.queryAll(By.css('ts-input'))[0].componentInstance;
-        const endInputInstance = fixture.debugElement.queryAll(By.css('ts-input'))[1].componentInstance;
+        const [startInputInstance, endInputInstance] = getRangeInputInstances(fixture);
 
         expect(startInputInstance.formControl.value).toEqual(null);
         expect(endInputInstance.formControl.value).toEqual(null);
@@ -84,8 +88,7 @@ describe(`TsDateRangeComponent`, function() {
         jest.useFakeTimers();
         const fixture = createComponent(testComponents.Basic);
         fixture.detectChanges();
-        const startInputInstance = fixture.debugElement.queryAll(By.css('ts-input'))[0].componentInstance;
-        const endInputInstance = fixture.debugElement.queryAll(By.css('ts-input'))[1].componentInstance;
+        const [startInputInstance, endInputInstance] = getRangeInputInstances(fixture);
 
         expect(startInputInstance.formControl.valid).toEqual(true);
         expect(endInputInstance.formControl.valid).toEqual(true);
@@ -109,8 +112,7 @@ describe(`TsDateRangeComponent`, function() {
         jest.useFakeTimers();
         const fixture = createComponent(testComponents.NoControls);
         fixture.detectChanges();
-        const startInputInstance = fixture.debugElement.queryAll(By.css('ts-input'))[0].componentInstance;
-        const endInputInstance = fixture.debugElement.queryAll(By.css('ts-input'))[1].componentInstance;
+        const [startInputInstance, endInputInstance] = getRangeInputInstances(fixture);
 
         expect(startInputInstance.formControl.valid).toEqual(true);
         expect(endInputInstance.formControl.valid).toEqual(true);
@@ -137,8 +139,7 @@ describe(`TsDateRangeComponent`, function() {
       test(`should update their VALUE when the internal control changes`, function() {
         const fixture = createComponent(testComponents.Basic);
         fixture.detectChanges();
-        const startInputInstance = fixture.debugElement.queryAll(By.css('ts-input'))[0].componentInstance;
-        const endInputInstance = fixture.debugElement.queryAll(By.css('ts-input'))[1].componentInstance;
+        const [startInputInstance, endInputInstance] = getRangeInputInstances(fixture);
 
         expect(startInputInstance.formControl.value).toBeNull();
         expect(endInputInstance.formControl.value).toBeNull();
@@ -162,8 +163,7 @@ describe(`TsDateRangeComponent`, function() {
     test(`should pass correct values when fired`, function() {
       const fixture = createComponent(testComponents.Emitters);
       fixture.detectChanges();
-      const startInputInstance = fixture.debugElement.queryAll(By.css('ts-input'))[0].componentInstance;
-      const endInputInstance = fixture.debugElement.queryAll(By.css('ts-input'))[1].componentInstance;
+      const [startInputInstance, endInputInstance] = getRangeInputInstances(fixture);
 
       typeInElement('3-4-2019', startInputInstance.inputElement.nativeElement);
       fixture.detectChanges();
@@ -175,7 +175,16 @@ describe(`TsDateRangeComponent`, function() {
       expect(fixture.componentInstance.endSelected).toHaveBeenCalledWith(new Date('3-8-2019'));
       expect(fixture.componentInstance.change).toHaveBeenCalledWith({start: new Date('3-4-2019'), end: new Date('3-8-2019')});
 
-      expect.assertions(4);
+      typeInElement('', startInputInstance.inputElement.nativeElement);
+      fixture.detectChanges();
+      startInputInstance.inputElement.nativeElement.blur();
+      fixture.detectChanges();
+      const changeMock = fixture.componentInstance.change.mock;
+      // FIXME: Once https://github.com/GetTerminus/terminus-ui/issues/1361 is complete we should adjust this
+      // test to verify that the changeMock was called exactly 3 times.
+      expect(changeMock.calls[changeMock.calls.length - 1][0]).toEqual({start: null, end: new Date('3-8-2019')});
+
+      expect.assertions(5);
     });
 
   });
@@ -187,8 +196,7 @@ describe(`TsDateRangeComponent`, function() {
       const fixture = createComponent(testComponents.Params);
       const hostInstance = fixture.componentInstance;
       fixture.detectChanges();
-      const startInputInstance = fixture.debugElement.queryAll(By.css('ts-input'))[0].componentInstance;
-      const endInputInstance = fixture.debugElement.queryAll(By.css('ts-input'))[1].componentInstance;
+      const [startInputInstance, endInputInstance] = getRangeInputInstances(fixture);
 
       expect(endInputInstance.maxDate).toEqual(hostInstance.endMax);
       expect(endInputInstance.minDate).toEqual(hostInstance.endMin);
@@ -214,7 +222,7 @@ describe(`TsDateRangeComponent`, function() {
   test(`should work without a form group`, function() {
     const fixture = createComponent(testComponents.NoFormGroup);
     fixture.detectChanges();
-    const startInputInstance = fixture.debugElement.queryAll(By.css('ts-input'))[0].componentInstance;
+    const startInputInstance = getRangeInputInstances(fixture)[0];
     typeInElement('3-4-2019', startInputInstance.inputElement.nativeElement);
     fixture.detectChanges();
 

--- a/terminus-ui/date-range/src/date-range.component.ts
+++ b/terminus-ui/date-range/src/date-range.component.ts
@@ -393,6 +393,7 @@ export class TsDateRangeComponent implements OnInit, OnDestroy {
       ctrl.setValue(value);
       ctrl.markAsTouched();
       ctrl.updateValueAndValidity();
+      this.change.emit(this.dateRange);
     }
   }
 
@@ -415,6 +416,7 @@ export class TsDateRangeComponent implements OnInit, OnDestroy {
       ctrl.setValue(value);
       ctrl.markAsTouched();
       ctrl.updateValueAndValidity();
+      this.change.emit(this.dateRange);
     }
   }
 

--- a/terminus-ui/date-range/testing/src/test-helpers.ts
+++ b/terminus-ui/date-range/testing/src/test-helpers.ts
@@ -1,8 +1,12 @@
+import { ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import {
   FormBuilder,
   FormGroup,
   Validators,
 } from '@angular/forms';
+import { DebugElement } from '@angular/core';
+import { TsInputComponent } from '@terminus/ui/input';
 
 
 
@@ -19,5 +23,22 @@ export function createDateRangeGroup(startDate: null | Date = null, endDate: nul
       endDate,
       [Validators.required],
     ],
+  });
+}
+
+
+export function getDebugRangeInputs(fixture: ComponentFixture<any>): DebugElement[] {
+  return fixture.debugElement.queryAll(By.css('ts-input'));
+}
+
+export function getRangeInputInstances(fixture: ComponentFixture<any>): TsInputComponent[] {
+  return fixture.debugElement.queryAll(By.css('ts-input')).map((v) => {
+    return v.componentInstance;
+  });
+}
+
+export function getRangeInputElements(fixture: ComponentFixture<any>): HTMLInputElement[] {
+  return fixture.debugElement.queryAll(By.css('ts-input')).map((v) => {
+    return v.nativeElement;
   });
 }


### PR DESCRIPTION
ISSUES CLOSED: #1359

- fix bug where range wasn't emitted when an input was cleared manually
- created some more test helpers
- cleaned up tests using new helpers
- added test helpers to usage doc
- updated demo to use current date
- added helper classes to make it easier to query a specific input