### PR TITLE
fix(Input): datepicker icon focus state now centered correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     }
   },
   "config": {
-    "loglevel": "verbose",
+    "loglevel": "warn",
     "commitizen": {
       "path": "./node_modules/cz-customizable"
     },

--- a/terminus-ui/form-field/src/form-field.component.scss
+++ b/terminus-ui/form-field/src/form-field.component.scss
@@ -356,3 +356,15 @@ $outline-appearance-label-offset: -.25em;
     text-align: left;
   }
 }
+
+
+// Target an input datepicker within a form field
+.ts-input--datepicker {
+  .ts-form-field {
+    // Center the datepicker icon vertically
+    .ts-form-field__suffix {
+      padding: .5em 0;
+      top: .2em;
+    }
+  }
+}

--- a/terminus-ui/input/src/input.component.scss
+++ b/terminus-ui/input/src/input.component.scss
@@ -144,5 +144,12 @@
     .mat-datepicker-toggle-default-icon {
       vertical-align: baseline;
     }
+
+    // This is the button used to trigger the datepicker
+    .mat-button-wrapper {
+      align-items: center;
+      display: flex;
+      justify-content: center;
+    }
   }
 }

--- a/terminus-ui/input/src/input.component.ts
+++ b/terminus-ui/input/src/input.component.ts
@@ -230,6 +230,7 @@ const DEFAULT_TEXTAREA_ROWS = 4;
   styleUrls: ['./input.component.scss'],
   host: {
     class: 'ts-input',
+    '[class.ts-input--datepicker]': 'datepicker',
   },
   providers: [
     {


### PR DESCRIPTION
ISSUES CLOSED: #1336 

- added scoping class for datepicker instances of input
- datepicker icon focus state is now correctly centered

<img width="106" alt="screen shot 2019-02-14 at 9 24 43 am" src="https://user-images.githubusercontent.com/270193/52793238-4926e400-303b-11e9-826b-fee456ca1b67.png">
