### PR TITLE
refactor: move validation messages test helper into correct module

### DIFF
--- a/terminus-ui/select/src/select.component.spec.ts
+++ b/terminus-ui/select/src/select.component.spec.ts
@@ -52,8 +52,8 @@ import {
   getSelectInstance,
   getSelectTriggerElement,
   getToggleAllElement,
-  getValidationMessageElement,
 } from '@terminus/ui/select/testing';
+import { getValidationMessageElement } from '@terminus/ui/validation-messages/testing';
 
 import { TsSelectOptionComponent } from './option/option.component';
 import { TsSelectModule, TsSelectFormatFn, TsSelectOption } from './select.module';

--- a/terminus-ui/select/testing/src/test-helpers.ts
+++ b/terminus-ui/select/testing/src/test-helpers.ts
@@ -95,8 +95,3 @@ export function getChipElementDisplayValue(fixture: ComponentFixture<any>, index
 export function getFilterInputElement(fixture: ComponentFixture<any>): HTMLInputElement {
   return fixture.debugElement.query(By.css('.ts-select-panel__filter-input .c-input__text')).nativeElement as HTMLInputElement;
 }
-
-export function getValidationMessageElement(fixture: ComponentFixture<any>): HTMLInputElement {
-  return fixture.debugElement.query(By.css('.ts-validation-messages')).nativeElement;
-}
-

--- a/terminus-ui/validation-messages/testing/package.json
+++ b/terminus-ui/validation-messages/testing/package.json
@@ -1,0 +1,7 @@
+{
+  "ngPackage": {
+    "lib": {
+      "entryFile": "src/public-api.ts"
+    }
+  }
+}

--- a/terminus-ui/validation-messages/testing/src/public-api.ts
+++ b/terminus-ui/validation-messages/testing/src/public-api.ts
@@ -1,0 +1,1 @@
+export * from './test-helpers';

--- a/terminus-ui/validation-messages/testing/src/test-helpers.ts
+++ b/terminus-ui/validation-messages/testing/src/test-helpers.ts
@@ -1,0 +1,8 @@
+import { ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+
+export function getValidationMessageElement(fixture: ComponentFixture<any>): HTMLElement {
+  return fixture.debugElement.query(By.css('.ts-validation-messages')).nativeElement;
+}
+


### PR DESCRIPTION
Note: Once I was digging into this issue I realized that the validation messages helper(s) should live with their own module rather than at a top level.

ISSUES CLOSED: #1355