### PR TITLE
fix(TestHelpers): moved all core test helpers into the library

### DIFF
--- a/terminus-ui/checkbox/src/checkbox.component.md
+++ b/terminus-ui/checkbox/src/checkbox.component.md
@@ -6,6 +6,7 @@
 - [Reactive Forms](#reactive-forms)
 - [`ngModel`](#ngmodel)
 - [`isChecked`](#ischecked)
+- [Test Helpers](#test-helpers)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -53,3 +54,20 @@ To seed the initial checked state use the `isChecked` property:
 ```
 
 > NOTE: This should rarely be used (if ever). We should be relying on a Reactive Form or ngModel.
+
+
+## Test Helpers
+
+Some helpers are exposed to assist with testing. These are imported from `@terminus/ui/checkbox/testing`;
+
+[[source]][test-helpers-src]
+
+| Function                  |
+|---------------------------|
+| `getAllCheckboxInstances` |
+| `getCheckboxInstance`     |
+| `getCheckboxElement`      |
+| `toggleCheckbox`          |
+
+
+[test-helpers-src]: https://github.com/GetTerminus/terminus-ui/blob/master/terminus-ui/checkbox/testing/src/test-helpers.ts

--- a/terminus-ui/checkbox/testing/package.json
+++ b/terminus-ui/checkbox/testing/package.json
@@ -1,0 +1,7 @@
+{
+  "ngPackage": {
+    "lib": {
+      "entryFile": "src/public-api.ts"
+    }
+  }
+}

--- a/terminus-ui/checkbox/testing/src/public-api.ts
+++ b/terminus-ui/checkbox/testing/src/public-api.ts
@@ -1,0 +1,1 @@
+export * from './test-helpers';

--- a/terminus-ui/checkbox/testing/src/test-helpers.ts
+++ b/terminus-ui/checkbox/testing/src/test-helpers.ts
@@ -1,0 +1,70 @@
+import { Predicate, DebugElement } from '@angular/core';
+import { ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TsCheckboxComponent } from '@terminus/ui/checkbox';
+
+
+/**
+ * Get all TsCheckboxComponent instances
+ *
+ * @param fixture - The component fixture
+ * @return The array of TsCheckboxComponent instances
+ */
+export function getAllCheckboxInstances(fixture: ComponentFixture<any>): TsCheckboxComponent[] {
+  const debugElements = fixture.debugElement.queryAll(By.css('ts-checkbox'));
+  if (!debugElements) {
+    throw new Error(`'getAllCheckboxInstances' found no checkboxes`);
+  }
+  return debugElements.map((i) => i.componentInstance);
+}
+
+/**
+ * Get a single TsCheckboxComponent instance
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the checkbox to return
+ * @return The TsCheckboxComponent instance
+ */
+export function getCheckboxInstance(fixture: ComponentFixture<any>, index = 0): TsCheckboxComponent {
+  const all = getAllCheckboxInstances(fixture);
+  if (!all[index]) {
+    throw new Error(`'getCheckboxInstance' found no checkboxes at index '${index}'. ${all.length} were found.`);
+  }
+  return all[index];
+}
+
+/**
+ * Get a single TsCheckboxComponent element
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the checkbox to return
+ * @return The TsCheckboxComponent element
+ */
+export function getCheckboxElement(fixture: ComponentFixture<any>, index = 0): HTMLElement {
+  const debugElements = fixture.debugElement.queryAll(By.css('ts-checkbox'));
+  if (!debugElements) {
+    throw new Error(`'getCheckboxElement' found no checkboxes`);
+  }
+  if (!debugElements[index]) {
+    throw new Error(`'getCheckboxElement' found no checkboxes at index '${index}'. ${debugElements.length} were found.`);
+  }
+  return debugElements[index].nativeElement as HTMLElement;
+}
+
+/**
+ * Toggle a single checkbox
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the checkbox to return
+ * @return The Promise from fixture.whenStable
+ */
+export function toggleCheckbox(fixture: ComponentFixture<any>, index = 0): Promise<any> {
+  const element = getCheckboxElement(fixture);
+  const innerCheckbox: HTMLElement | null = element.querySelector('input');
+  if (!innerCheckbox) {
+    throw new Error(`'toggleCheckbox' found no inner checkbox`);
+  }
+  innerCheckbox.click();
+  fixture.detectChanges();
+  return fixture.whenStable();
+}

--- a/terminus-ui/date-range/src/date-range.component.spec.ts
+++ b/terminus-ui/date-range/src/date-range.component.spec.ts
@@ -9,7 +9,6 @@ import { By } from '@angular/platform-browser';
 import { typeInElement } from '@terminus/ngx-tools/testing';
 import * as testComponents from '@terminus/ui/date-range/testing';
 import {
-  getDebugRangeInputs,
   getRangeInputElements,
   getRangeInputInstances,
 } from '@terminus/ui/date-range/testing';

--- a/terminus-ui/date-range/testing/src/test-helpers.ts
+++ b/terminus-ui/date-range/testing/src/test-helpers.ts
@@ -7,10 +7,77 @@ import {
 } from '@angular/forms';
 import { DebugElement } from '@angular/core';
 import { TsInputComponent } from '@terminus/ui/input';
+import { TsDateRangeComponent } from '@terminus/ui/date-range';
 
 
+/**
+ * Get an array of all TsDateRangeComponent debug elements
+ *
+ * @param fixture - The component fixture
+ * @return The array of DebugElements
+ */
+export function getAllDateRangeDebugElements(fixture: ComponentFixture<any>): DebugElement[] {
+  const debugElements = fixture.debugElement.queryAll(By.css('ts-date-range'));
+  if (!debugElements || debugElements.length < 1) {
+    throw new Error(`'getAllDateRangeInstances' found no date range instances`);
+  }
+  return debugElements;
+}
 
+/**
+ * Get all TsDateRangeComponent instances
+ *
+ * @param fixture - The component fixture
+ * @return The array of TsDateRangeComponent instances
+ */
+export function getAllDateRangeInstances(fixture: ComponentFixture<any>): TsDateRangeComponent[] {
+  return getAllDateRangeDebugElements(fixture).map((i) => i.componentInstance);
+}
 
+/**
+ * Get an array of debug elements for TsInputComponents within a single TsDateRangeComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the TsDateRangeComponent
+ * @return The array of DebugElements
+ */
+export function getDateRangeInputDebugElements(fixture: ComponentFixture<any>, index = 0): DebugElement[] {
+  const debugElement = getAllDateRangeDebugElements(fixture)[index];
+  if (!debugElement) {
+    throw new Error(`'getDebugRangeInputs' found no debug element at '${index}'`);
+  }
+  return debugElement.queryAll(By.css('ts-input'));
+}
+
+/**
+ * Get an array of TsInputComponent instances for a single TsDateRangeComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the TsDateRangeComponent
+ * @return The array of TsInputComponent instances
+ */
+export function getRangeInputInstances(fixture: ComponentFixture<any>, index = 0): TsInputComponent[] {
+  return getDateRangeInputDebugElements(fixture, index).map((v) => v.componentInstance);
+}
+
+/**
+ * Get an array of HTMLInputElements for a single TsDateRangeComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the TsDateRangeComponent
+ * @return The array of TsInputComponent instances
+ */
+export function getRangeInputElements(fixture: ComponentFixture<any>, index = 0): HTMLInputElement[] {
+  return getDateRangeInputDebugElements(fixture, index).map((v) => v.componentInstance.inputElement.nativeElement);
+}
+
+/**
+ * Create a date range form group with required controls
+ *
+ * @param startDate - The initial start date
+ * @param endDate - The initial end date
+ * @return The FormGroup
+ */
 export function createDateRangeGroup(startDate: null | Date = null, endDate: null | Date = null): FormGroup {
   const formBuilder = new FormBuilder();
 
@@ -27,18 +94,32 @@ export function createDateRangeGroup(startDate: null | Date = null, endDate: nul
 }
 
 
-export function getDebugRangeInputs(fixture: ComponentFixture<any>): DebugElement[] {
-  return fixture.debugElement.queryAll(By.css('ts-input'));
-}
+/**
+ * Set values for both date range inputs
+ *
+ * @param fixture - The component fixture
+ * @param startDate - The date to set the start input
+ * @param endDate - The date to set the end input
+ * @param index - The select instance
+ * @return The whenStable promise
+ */
+export function setDateRangeValues(fixture: ComponentFixture<any>, startDate: Date, endDate: Date, index = 0): Promise<any> {
+  const [startElement, endElement] = getRangeInputElements(fixture, index);
 
-export function getRangeInputInstances(fixture: ComponentFixture<any>): TsInputComponent[] {
-  return fixture.debugElement.queryAll(By.css('ts-input')).map((v) => {
-    return v.componentInstance;
-  });
-}
+  // Set input values
+  startElement.value = startDate.toISOString();
+  endElement.value = endDate.toISOString();
 
-export function getRangeInputElements(fixture: ComponentFixture<any>): HTMLInputElement[] {
-  return fixture.debugElement.queryAll(By.css('ts-input')).map((v) => {
-    return v.nativeElement;
-  });
+  // Create events
+  const startEvent = document.createEvent('KeyboardEvent');
+  startEvent.initEvent('input', true, false);
+  const endEvent = document.createEvent('KeyboardEvent');
+  endEvent.initEvent('input', true, false);
+
+  // Dispatch Events
+  startElement.dispatchEvent(startEvent);
+  endElement.dispatchEvent(endEvent);
+
+  fixture.detectChanges();
+  return fixture.whenStable();
 }

--- a/terminus-ui/input/src/input.component.html
+++ b/terminus-ui/input/src/input.component.html
@@ -110,7 +110,7 @@
 
   <ng-container *ngIf="!isTextarea && datepicker">
     <input
-      class="c-input__text qa-input-text ts-form-field-autofill-control"
+      class="c-input__text c-input__text--datepicker qa-input-text ts-form-field-autofill-control"
       type="{{ type }}"
       [attr.aria-required]="isRequired"
       [attr.aria-describedby]="ariaDescribedby || null"
@@ -139,7 +139,7 @@
 
   <ng-container *ngIf="isTextarea">
     <textarea
-      class="c-input__text qa-input-text ts-form-field-autofill-control"
+      class="c-input__text c-input__text--textarea qa-input-text ts-form-field-autofill-control"
       [attr.aria-required]="isRequired"
       [attr.aria-describedby]="ariaDescribedby || null"
       [attr.autocapitalize]="autocapitalize ? 'on' : 'off'"

--- a/terminus-ui/input/src/input.component.md
+++ b/terminus-ui/input/src/input.component.md
@@ -544,15 +544,18 @@ The row count can be dynamically adjusted:
 
 Some helpers are exposed to assist with testing. These are imported from `@terminus/ui/input/testing`;
 
+[[source]][test-helpers-src]
 
-| Function            |
-|---------------------|
-| `getInputComponent` |
-| `getInputElement`   |
-| `sendInput`         |
+| Function               |
+|------------------------|
+| `getAllInputInstances` |
+| `getInputInstance`     |
+| `getInputElement`      |
+| `sendInput`            |
 
 
 
 <!-- LINKS -->
 [autocomplete]: https://github.com/getterminus/terminus-ui/blob/master/terminus-ui/src/input/input.component.ts#l64-73
 [input-types]: https://github.com/getterminus/terminus-ui/blob/master/terminus-ui/src/input/input.component.ts#l48-57
+[test-helpers-src]: https://github.com/GetTerminus/terminus-ui/blob/master/terminus-ui/input/testing/src/test-helpers.ts

--- a/terminus-ui/input/src/input.component.spec.ts
+++ b/terminus-ui/input/src/input.component.spec.ts
@@ -31,7 +31,7 @@ import * as TestComponents from '@terminus/ui/input/testing';
 import {
   getInputElement,
   sendInput,
-  getInputComponent,
+  getInputInstance,
 } from '@terminus/ui/input/testing';
 
 
@@ -49,7 +49,7 @@ describe(`TsInputComponent`, function() {
 
     test(`should emit valueChange if the value was updated for a datepicker`, () => {
       const fixture = createComponent(TestComponents.Autocomplete);
-      const component = getInputComponent(fixture);
+      const component = getInputInstance(fixture);
       fixture.detectChanges();
       component._valueChange.emit = jest.fn();
       fixture.componentInstance.updateDate();
@@ -68,7 +68,7 @@ describe(`TsInputComponent`, function() {
       test(`should not be required by default`, () => {
         const fixture = createComponent(TestComponents.AttrNotRequired);
         fixture.detectChanges();
-        const component = getInputComponent(fixture);
+        const component = getInputInstance(fixture);
         const el = component.inputElement.nativeElement;
 
         expect(el.getAttribute('required')).toEqual(null);
@@ -78,7 +78,7 @@ describe(`TsInputComponent`, function() {
       test(`should set required if the form control is required`, () => {
         const fixture = createComponent(TestComponents.FormControlAttrRequired);
         fixture.detectChanges();
-        const component = getInputComponent(fixture);
+        const component = getInputInstance(fixture);
         const el = component.inputElement.nativeElement;
 
         expect(el.getAttribute('required')).toEqual('');
@@ -89,7 +89,7 @@ describe(`TsInputComponent`, function() {
         const fixture = createComponent(TestComponents.AttrInputRequired);
         fixture.componentInstance.required = true;
         fixture.detectChanges();
-        const component = getInputComponent(fixture);
+        const component = getInputInstance(fixture);
         const el = component.inputElement.nativeElement;
 
         expect(el.getAttribute('required')).toEqual('');
@@ -103,7 +103,7 @@ describe(`TsInputComponent`, function() {
       test(`should add the correct attribute`, () => {
         const fixture = createComponent(TestComponents.AttrReadonly);
         fixture.detectChanges();
-        const component = getInputComponent(fixture);
+        const component = getInputInstance(fixture);
         const el = component.inputElement.nativeElement;
 
         expect(component.readOnly).toEqual(false);
@@ -126,7 +126,7 @@ describe(`TsInputComponent`, function() {
       test(`should add the correct attribute`, () => {
         const fixture = createComponent(TestComponents.AttrSpellcheck);
         fixture.detectChanges();
-        const component = getInputComponent(fixture);
+        const component = getInputInstance(fixture);
         const el = getInputElement(fixture);
 
         expect(component.spellcheck).toEqual(false);
@@ -572,7 +572,7 @@ describe(`TsInputComponent`, function() {
       expect(container).toBeTruthy();
 
       const inputElement = getInputElement(fixture);
-      sendInput('foo', inputElement, fixture);
+      sendInput(fixture, 'foo');
       fixture.detectChanges();
       const clearButton = fixture.debugElement.query(By.css('.c-input__clear')).nativeElement;
       expect(clearButton).toBeTruthy();
@@ -788,7 +788,7 @@ describe(`TsInputComponent`, function() {
       const resetButton = fixture.debugElement.query(By.css('.c-input__clear')).nativeElement as HTMLButtonElement;
       const component = fixture.componentInstance.inputComponent;
       const inputElement = getInputElement(fixture);
-      sendInput('11111111', inputElement, fixture);
+      sendInput(fixture, '11111111');
 
       resetButton.click();
 

--- a/terminus-ui/input/testing/src/test-helpers.ts
+++ b/terminus-ui/input/testing/src/test-helpers.ts
@@ -4,38 +4,64 @@ import { TsInputComponent } from '@terminus/ui/input';
 
 
 /**
- * Get the TsInputComponent instance
+ * Get all TsInputComponent instances
  *
  * @param fixture - The component fixture
- * @return The TsInputComponent instance
+ * @return The array of TsInputComponent instances
  */
-export function getInputComponent(fixture: ComponentFixture<any>): TsInputComponent {
-  return fixture.debugElement.query(By.css('.ts-input')).componentInstance;
+export function getAllInputInstances(fixture: ComponentFixture<any>): TsInputComponent[] {
+  const debugElements = fixture.debugElement.queryAll(By.css('ts-input'));
+  if (!debugElements) {
+    throw new Error(`'getAllInputInstances' found no inputs`);
+  }
+  return debugElements.map((i) => i.componentInstance);
 }
-
 
 /**
- * Get the input element instance
+ * Get a TsInputComponent instance
  *
  * @param fixture - The component fixture
- * @return The HTMLInputfElement
+ * @param index - The index of the input to return
+ * @return The TsInputComponent instance
  */
-export function getInputElement(fixture: ComponentFixture<any>): HTMLInputElement {
-  return fixture.debugElement.query(By.css('.c-input__text')).nativeElement as HTMLInputElement;
+export function getInputInstance(fixture: ComponentFixture<any>, index = 0): TsInputComponent {
+  const all = getAllInputInstances(fixture);
+  if (!all[index]) {
+    throw new Error(`'getInputInstance' found no inputs at index '${index}'. ${all.length} were found.`);
+  }
+  return all[index];
 }
 
+/**
+ * Get the input element
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the input to query
+ * @return The HTMLInputElement
+ */
+export function getInputElement(fixture: ComponentFixture<any>, index = 0): HTMLInputElement {
+  const instance = getInputInstance(fixture, index);
+  if (!instance.inputElement) {
+    throw new Error(`'getInputElement' found no input elements at index '${index}'`);
+  }
+  return instance.inputElement.nativeElement as HTMLInputElement;
+}
 
 /**
  * Send an input event to the input element
  *
  * @param fixture - The component fixture
+ * @param text - The value to set
+ * @param index - The index of the input to set
  * @return The Promise from fixture.whenStable
  */
-export function sendInput(text: string, el: HTMLInputElement, fixture: ComponentFixture<any>): Promise<any> {
-  el.value = text;
+export function sendInput(fixture: ComponentFixture<any>, text: string, index = 0): Promise<any> {
+  const inputElement = getInputElement(fixture, index);
+  inputElement.focus();
+  inputElement.value = text;
   const event = document.createEvent('KeyboardEvent');
   event.initEvent('input', true, false);
-  el.dispatchEvent(event);
+  inputElement.dispatchEvent(event);
   fixture.detectChanges();
   return fixture.whenStable();
 }

--- a/terminus-ui/radio-group/src/radio-group.component.html
+++ b/terminus-ui/radio-group/src/radio-group.component.html
@@ -83,7 +83,9 @@
             </ts-icon>
 
             <ng-container *ngIf="!option.template">
-              {{ retrieveValue(option, formatUILabelFn) }}
+              <span class="c-radio__content-label">
+                {{ retrieveValue(option, formatUILabelFn) }}
+              </span>
 
               <small
                 class="c-radio__control-sublabel"

--- a/terminus-ui/radio-group/src/radio-group.component.md
+++ b/terminus-ui/radio-group/src/radio-group.component.md
@@ -13,6 +13,7 @@
   - [Disabled option](#disabled-option)
 - [Visual mode](#visual-mode)
   - [Custom content](#custom-content)
+- [Test Helpers](#test-helpers)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -212,3 +213,21 @@ items$: Observable<TsRadioOption[]> = of([
   [formatModelValueFn]="modelFormatter"
 ></ts-radio-group>
 ```
+
+
+## Test Helpers
+
+Some helpers are exposed to assist with testing. These are imported from `@terminus/ui/radio-group/testing`;
+
+[[source]][test-helpers-src]
+
+| Function                     |
+|------------------------------|
+| `getAllRadioGroupInstances`  |
+| `getRadioGroupInstance`      |
+| `getRadioGroupParentElement` |
+| `selectStandardRadio`        |
+| `selectVisualRadio`          |
+
+
+[test-helpers-src]: https://github.com/GetTerminus/terminus-ui/blob/master/terminus-ui/radio-group/testing/src/test-helpers.ts

--- a/terminus-ui/radio-group/src/radio-group.component.ts
+++ b/terminus-ui/radio-group/src/radio-group.component.ts
@@ -320,9 +320,6 @@ export class TsRadioGroupComponent extends TsReactiveFormBaseComponent implement
     public domSanitizer: DomSanitizer,
   ) {
     super();
-
-    // Force setter to be called in case the ID was not specified.
-    this.id = this.id;
   }
 
 

--- a/terminus-ui/radio-group/testing/package.json
+++ b/terminus-ui/radio-group/testing/package.json
@@ -1,0 +1,7 @@
+{
+  "ngPackage": {
+    "lib": {
+      "entryFile": "src/public-api.ts"
+    }
+  }
+}

--- a/terminus-ui/radio-group/testing/src/public-api.ts
+++ b/terminus-ui/radio-group/testing/src/public-api.ts
@@ -1,0 +1,1 @@
+export * from './test-helpers';

--- a/terminus-ui/radio-group/testing/src/test-helpers.ts
+++ b/terminus-ui/radio-group/testing/src/test-helpers.ts
@@ -1,0 +1,106 @@
+import { ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TsRadioGroupComponent } from '@terminus/ui/radio-group';
+import { DebugElement } from '@angular/core';
+
+
+/**
+ * Get all TsRadioGroupComponent instances
+ *
+ * @param fixture - The component fixture
+ * @return The array of TsRadioGroupComponent instances
+ */
+export function getAllRadioGroupInstances(fixture: ComponentFixture<any>): TsRadioGroupComponent[] {
+  const debugElements = fixture.debugElement.queryAll(By.css('ts-radio-group'));
+  if (!debugElements) {
+    throw new Error(`'getAllRadioGroupInstances' found no radio groups`);
+  }
+  return debugElements.map((i) => i.componentInstance);
+}
+
+/**
+ * Get a TsRadioGroupComponent instance
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the radio group to return
+ * @return The TsRadioGroupComponent instance
+ */
+export function getRadioGroupInstance(fixture: ComponentFixture<any>, index = 0): TsRadioGroupComponent {
+  const all = getAllRadioGroupInstances(fixture);
+  if (!all[index]) {
+    throw new Error(`'getRadioGroupInstance' found no radio groups at index '${index}'. ${all.length} were found.`);
+  }
+  return all[index];
+}
+
+/**
+ * Get the radio group element
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the radio group to query
+ * @return The HTMLElement
+ */
+export function getRadioGroupParentElement(fixture: ComponentFixture<any>, index = 0): HTMLElement {
+  const debugElements = fixture.debugElement.queryAll(By.css('ts-radio-group'));
+  if (!debugElements) {
+    throw new Error(`'getRadioGroupParentElement' found no radio groups`);
+  }
+  if (!debugElements[index]) {
+    throw new Error(`'getRadioGroupParentElement' found no radio groups at index '${index}'. ${debugElements.length} were found.`);
+  }
+  return debugElements[index].nativeElement as HTMLElement;
+}
+
+/**
+ * Make a selection on a standard radio group
+ *
+ * @param fixture - The component fixture
+ * @param radioValue - The value to match
+ * @param index - The index of the radio group to set
+ * @return The Promise from fixture.whenStable
+ */
+export function selectStandardRadio(fixture: ComponentFixture<any>, radioValue: string, index = 0): Promise<any> {
+  const debugElement: DebugElement = fixture.debugElement.queryAll(By.css('ts-radio-group'))[index];
+  if (!debugElement) {
+    throw new Error(`'selectStandardRadio' found no radio group`);
+  }
+  const labels: DebugElement[] = debugElement.queryAll(By.css('.mat-radio-label'));
+
+  labels.forEach((labelDebugEl) => {
+    const labelTextElement = labelDebugEl.query(By.css('.mat-radio-label-content')).nativeElement;
+
+    if (labelTextElement.textContent.trim() === radioValue) {
+      labelDebugEl.nativeElement.click();
+    }
+  });
+
+  fixture.detectChanges();
+  return fixture.whenStable();
+}
+
+/**
+ * Make a selection on a visual radio group
+ *
+ * @param fixture - The component fixture
+ * @param radioValue - The value to match
+ * @param index - The index of the radio group to set
+ * @return The Promise from fixture.whenStable
+ */
+export function selectVisualRadio(fixture: ComponentFixture<any>, radioValue: string, index = 0): Promise<any> {
+  const debugElement: DebugElement = fixture.debugElement.queryAll(By.css('ts-radio-group .c-radio--visual'))[index];
+  if (!debugElement) {
+    throw new Error(`'selectVisualRadio' found no radio group`);
+  }
+  const labels: DebugElement[] = debugElement.queryAll(By.css('.c-radio__control'));
+
+  labels.forEach((labelDebugEl) => {
+    const labelTextElement = labelDebugEl.query(By.css('.c-radio__content-label')).nativeElement;
+
+    if (labelTextElement.textContent.trim() === radioValue) {
+      labelDebugEl.nativeElement.click();
+    }
+  });
+
+  fixture.detectChanges();
+  return fixture.whenStable();
+}

--- a/terminus-ui/select/src/select.component.md
+++ b/terminus-ui/select/src/select.component.md
@@ -527,6 +527,8 @@ class TsSelectChange {
 
 Some helpers are exposed to assist with testing. These are imported from `@terminus/ui/select/testing`;
 
+[[source]][test-helpers-src]
+
 | Function                  |
 |---------------------------|
 | `getSelectInstance`       |
@@ -545,3 +547,6 @@ Some helpers are exposed to assist with testing. These are imported from `@termi
 | `getChipInstance`         |
 | `getChipElement`          |
 | `getFilterInputElement`   |
+
+
+[test-helpers-src]: https://github.com/GetTerminus/terminus-ui/blob/master/terminus-ui/select/testing/src/test-helpers.ts

--- a/terminus-ui/select/src/select.component.spec.ts
+++ b/terminus-ui/select/src/select.component.spec.ts
@@ -1,4 +1,3 @@
-// tslint:disable: no-non-null-assertion
 import {
   Provider,
   Type,
@@ -52,13 +51,25 @@ import {
   getSelectInstance,
   getSelectTriggerElement,
   getToggleAllElement,
+  openSelect,
 } from '@terminus/ui/select/testing';
 import { getValidationMessageElement } from '@terminus/ui/validation-messages/testing';
+import { createComponent as createComponentInner } from '@terminus/ngx-tools/testing';
 
 import { TsSelectOptionComponent } from './option/option.component';
 import { TsSelectModule, TsSelectFormatFn, TsSelectOption } from './select.module';
 
 
+function createComponent<T>(component: Type<T>): ComponentFixture<T> {
+  const moduleImports = [
+    FormsModule,
+    ReactiveFormsModule,
+    TsSelectModule,
+    NoopAnimationsModule,
+  ];
+
+  return createComponentInner(component, undefined, moduleImports);
+}
 
 
 describe(`TsSelectComponent`, function() {
@@ -139,7 +150,7 @@ describe(`TsSelectComponent`, function() {
 
 
     test(`should emit events for selections and changes`, () => {
-      const fixture = createComponent(testComponents.SelectionChangeEventEmitters);
+      const fixture = createComponent<testComponents.SelectionChangeEventEmitters>(testComponents.SelectionChangeEventEmitters);
       fixture.detectChanges();
       fixture.componentInstance.selected = jest.fn();
       fixture.componentInstance.change = jest.fn();
@@ -160,7 +171,7 @@ describe(`TsSelectComponent`, function() {
       dispatchMouseEvent(trigger, 'click');
       fixture.detectChanges();
 
-      const option = getOptionElement(fixture, 1)!;
+      const option = getOptionElement(fixture, 0, 1);
 
       expect(option.innerHTML).toEqual(expect.stringContaining('bar'));
     });
@@ -201,8 +212,8 @@ describe(`TsSelectComponent`, function() {
       fixture.detectChanges();
 
       fixture.whenStable().then(() => {
-        const disabledOption = getOptionElement(fixture, 1)!;
-        const activeOption = getOptionElement(fixture, 4)!;
+        const disabledOption = getOptionElement(fixture, 0, 1);
+        const activeOption = getOptionElement(fixture, 0, 4);
         expect(disabledOption.classList.contains('ts-select-option--disabled')).toEqual(true);
         expect(activeOption.classList.contains('ts-selected')).toEqual(true);
       });
@@ -215,9 +226,9 @@ describe(`TsSelectComponent`, function() {
       const trigger = getSelectTriggerElement(fixture);
       dispatchMouseEvent(trigger, 'click');
       fixture.detectChanges();
-      const group = getOptgroupElement(fixture)!;
-      const groupDisabled = getOptgroupElement(fixture, 1)!;
-      const label = group.querySelector('label')!;
+      const group = getOptgroupElement(fixture);
+      const groupDisabled = getOptgroupElement(fixture, 0, 1);
+      const label = group.querySelector('label');
 
       // Existence
       expect(group).toBeTruthy();
@@ -238,7 +249,7 @@ describe(`TsSelectComponent`, function() {
 
         fixture.whenStable().then(() => {
           const trigger = getSelectTriggerElement(fixture);
-          const valueSpan = trigger.querySelector('.ts-select-value-text')!;
+          const valueSpan = trigger.querySelector('.ts-select-value-text');
 
           expect(valueSpan.textContent).toEqual('Florida- Texas');
         });
@@ -246,13 +257,13 @@ describe(`TsSelectComponent`, function() {
 
 
       test(`should fall back to the default delimiter if a non-string value is passed in`, () => {
-        const fixture = createComponent(testComponents.CustomDelimiter);
+        const fixture = createComponent<testComponents.CustomDelimiter>(testComponents.CustomDelimiter);
         fixture.componentInstance.delimiter = 1 as any;
         fixture.detectChanges();
 
         fixture.whenStable().then(() => {
           const trigger = getSelectTriggerElement(fixture);
-          const valueSpan = trigger.querySelector('.ts-select-value-text')!;
+          const valueSpan = trigger.querySelector('.ts-select-value-text');
 
           expect(valueSpan.textContent).toEqual('Florida, Texas');
         });
@@ -262,7 +273,7 @@ describe(`TsSelectComponent`, function() {
 
 
     test(`should not open when disabled`, () => {
-      const fixture = createComponent(testComponents.Disabled);
+      const fixture = createComponent<testComponents.Disabled>(testComponents.Disabled);
       fixture.detectChanges();
       fixture.componentInstance.wasOpened = jest.fn();
       const trigger = getSelectTriggerElement(fixture);
@@ -276,7 +287,7 @@ describe(`TsSelectComponent`, function() {
 
 
     test(`should update when options change`, async(() => {
-      const fixture = createComponent(testComponents.SelectOptionChange);
+      const fixture = createComponent<testComponents.SelectOptionChange>(testComponents.SelectOptionChange);
       fixture.detectChanges();
 
       fixture.whenStable().then(() => {
@@ -336,7 +347,7 @@ describe(`TsSelectComponent`, function() {
 
 
       test(`should do nothing if no options exist`, () => {
-        const fixture = createComponent(testComponents.Basic);
+        const fixture = createComponent<testComponents.Basic>(testComponents.Basic);
         fixture.componentInstance.options.length = 0;
         const instance = getSelectInstance(fixture);
         fixture.detectChanges();
@@ -521,13 +532,14 @@ describe(`TsSelectComponent`, function() {
 
 
       test('should update when making a new selection', async(() => {
-        const fixture = createComponent(testComponents.CustomCompareFn);
+        const fixture = createComponent<testComponents.CustomCompareFn>(testComponents.CustomCompareFn);
         fixture.detectChanges();
         const options = getAllOptionInstances(fixture);
 
-        getOptionInstance(fixture, options.length - 1)!.selectViaInteraction();
+        getOptionInstance(fixture, 0, options.length - 1).selectViaInteraction();
         fixture.detectChanges();
-        const selectedOption = getSelectInstance(fixture).selected as TsSelectOptionComponent;
+        const getterValue = getSelectInstance(fixture).selected;
+        const selectedOption = getterValue[0] ? getterValue[0] : getterValue;
 
         expect(fixture.componentInstance.selectedFood.value).toEqual('tacos-2');
         expect(selectedOption.value.value).toEqual('tacos-2');
@@ -539,7 +551,7 @@ describe(`TsSelectComponent`, function() {
     describe('comparing by reference', function() {
 
       test('should initialize with no selection despite having a value', async(() => {
-        const fixture = createComponent(testComponents.CustomCompareFn);
+        const fixture = createComponent<testComponents.CustomCompareFn>(testComponents.CustomCompareFn);
         fixture.detectChanges();
         fixture.componentInstance.useCompareByReference();
         fixture.detectChanges();
@@ -550,7 +562,7 @@ describe(`TsSelectComponent`, function() {
 
 
       test('should log a warning when using a non-function comparator', async(() => {
-        const fixture = createComponent(testComponents.CustomCompareFn);
+        const fixture = createComponent<testComponents.CustomCompareFn>(testComponents.CustomCompareFn);
         fixture.detectChanges();
         window.console.warn = jest.fn();
         fixture.componentInstance.useNullComparator();
@@ -563,7 +575,7 @@ describe(`TsSelectComponent`, function() {
 
 
     test(`should defer optionSelection stream if no options exist`, async(() => {
-      const fixture = createComponent(testComponents.DeferOptionSelectionStream);
+      const fixture = createComponent<testComponents.DeferOptionSelectionStream>(testComponents.DeferOptionSelectionStream);
       fixture.detectChanges();
       const instance = getSelectInstance(fixture);
 
@@ -588,7 +600,7 @@ describe(`TsSelectComponent`, function() {
         getSelectInstance(fixture).placeholder = 'foo';
         fixture.detectChanges();
 
-        expect(trigger.textContent!.trim()).toEqual('foo');
+        expect(trigger.textContent.trim()).toEqual('foo');
       });
 
     });
@@ -639,30 +651,27 @@ describe(`TsSelectComponent`, function() {
 
     describe(`handleOpenKeydown`, function() {
 
-/*
- *      test(`should select OR deselect all items with CTRL + A`, () => {
- *        const fixture = createComponent(testComponents.OptgroupsMultiple);
- *        fixture.detectChanges();
- *        const instance = getSelectInstance(fixture);
- *        const element = getSelectElement(fixture);
- *        instance.open();
- *        fixture.detectChanges();
- *
- *        const event = createKeyboardEvent('keydown', A, element);
- *        Object.defineProperty(event, 'ctrlKey', {get: () => true});
- *        dispatchEvent(element, event);
- *        fixture.detectChanges();
- *
- *        // Only two items are not disabled or within a disabled group
- *        expect(instance.selectionModel.selected.length).toEqual(2);
- *        expect(event.defaultPrevented).toEqual(true);
- *
- *        dispatchEvent(element, event);
- *        fixture.detectChanges();
- *
- *        expect(instance.selectionModel.selected.length).toEqual(0);
- *      });
- */
+      test(`should select OR deselect all items with CTRL + A`, () => {
+        const fixture = createComponent(testComponents.OptgroupsMultiple);
+        fixture.detectChanges();
+        const instance = getSelectInstance(fixture);
+        const element = getSelectElement(fixture);
+        openSelect(fixture);
+
+        const event = createKeyboardEvent('keydown', A, element);
+        Object.defineProperty(event, 'ctrlKey', {get: () => true});
+        dispatchEvent(element, event);
+        fixture.detectChanges();
+
+        // Only two items are not disabled or within a disabled group
+        expect(instance.selectionModel.selected.length).toEqual(2);
+        expect(event.defaultPrevented).toEqual(true);
+
+        dispatchEvent(element, event);
+        fixture.detectChanges();
+
+        expect(instance.selectionModel.selected.length).toEqual(0);
+      });
 
 
       // TODO: Shift/Arrow functionality does not seem to be working
@@ -700,24 +709,26 @@ describe(`TsSelectComponent`, function() {
 
     describe(`optgroup`, function() {
 
-/*
- *      test(`should toggle all child options if not disabled`, () => {
- *        const fixture = createComponent(testComponents.OptgroupsMultiple);
- *        fixture.detectChanges();
- *        const trigger = getSelectTriggerElement(fixture);
- *        dispatchMouseEvent(trigger, 'click');
- *        fixture.detectChanges();
- *        const group = getOptgroupElement(fixture)!;
- *        const select = getSelectInstance(fixture);
- *        const label = group.querySelector('label')!;
- *
- *        expect(select.selectionModel.selected.length).toBeFalsy();
- *
- *        dispatchMouseEvent(label, 'click');
- *
- *        expect(select.selectionModel.selected.length).toEqual(2);
- *      });
- */
+      test(`should toggle all child options if not disabled`, () => {
+        const fixture = createComponent(testComponents.OptgroupsMultiple);
+        fixture.detectChanges();
+        const trigger = getSelectTriggerElement(fixture);
+        dispatchMouseEvent(trigger, 'click');
+        fixture.detectChanges();
+        const group = getOptgroupElement(fixture);
+        const select = getSelectInstance(fixture);
+        const label = group.querySelector('label');
+
+        expect(select.selectionModel.selected.length).toEqual(0);
+
+        dispatchMouseEvent(label, 'click');
+        fixture.detectChanges();
+
+        fixture.whenStable().then(() => {
+          expect(select.selectionModel.selected.length).toEqual(2);
+        });
+
+      });
 
     });
 
@@ -731,7 +742,7 @@ describe(`TsSelectComponent`, function() {
 
     test(`should show a progress indicator`, () => {
       jest.useFakeTimers();
-      const fixture = createComponent(testComponents.Autocomplete);
+      const fixture = createComponent<testComponents.Autocomplete>(testComponents.Autocomplete);
       fixture.detectChanges();
 
       let spinner = fixture.debugElement.query(By.css('.c-autocomplete__spinner'));
@@ -748,7 +759,7 @@ describe(`TsSelectComponent`, function() {
 
 
     test(`should not open when disabled`, () => {
-      const fixture = createComponent(testComponents.Autocomplete);
+      const fixture = createComponent<testComponents.Autocomplete>(testComponents.Autocomplete);
       fixture.componentInstance.disabled = true;
       fixture.detectChanges();
       const trigger = getSelectTriggerElement(fixture);
@@ -768,7 +779,7 @@ describe(`TsSelectComponent`, function() {
         const fixture = createComponent(testComponents.SeededAutocomplete);
         fixture.detectChanges();
 
-        const chip = getChipElement(fixture, 0);
+        const chip = getChipElement(fixture);
 
         expect(chip).toBeTruthy();
       });
@@ -779,28 +790,28 @@ describe(`TsSelectComponent`, function() {
         const fixture = createComponent(testComponents.SeededAutocomplete);
         fixture.detectChanges();
 
-        let chips = getAllChipInstances(fixture)!;
+        let chips = getAllChipInstances(fixture);
         expect(chips.length).toEqual(1);
 
-        const chip = getChipElement(fixture)!;
-        const chipRemovalButton = chip.querySelector('.mat-chip-remove')!;
+        const chip = getChipElement(fixture);
+        const chipRemovalButton = chip.querySelector('.mat-chip-remove');
         const instance = getSelectInstance(fixture);
 
         // Open the panel so that overlayRef is created
         instance.autocompleteTrigger.handleFocus();
-        instance.autocompleteTrigger.overlayRef!.updatePosition = jest.fn();
+        instance.autocompleteTrigger.overlayRef.updatePosition = jest.fn();
 
         dispatchMouseEvent(chipRemovalButton, 'click');
         fixture.detectChanges();
 
-        chips = getAllChipInstances(fixture)!;
+        chips = getAllChipInstances(fixture);
         expect(chips.length).toEqual(0);
 
         const input = getAutocompleteInput(fixture);
         expect(document.activeElement).toEqual(input);
         jest.advanceTimersByTime(200);
 
-        expect(instance.autocompleteTrigger.overlayRef!.updatePosition).toHaveBeenCalled();
+        expect(instance.autocompleteTrigger.overlayRef.updatePosition).toHaveBeenCalled();
         jest.runAllTimers();
       });
 
@@ -810,17 +821,17 @@ describe(`TsSelectComponent`, function() {
         const fixture = createComponent(testComponents.SeededAutocomplete);
         fixture.detectChanges();
 
-        let chips = getAllChipInstances(fixture)!;
+        let chips = getAllChipInstances(fixture);
         expect(chips.length).toEqual(1);
 
-        const chip = getChipElement(fixture)!;
+        const chip = getChipElement(fixture);
         // The first backspace selects the previous chip
         dispatchKeyboardEvent(chip, 'keydown', BACKSPACE);
         jest.advanceTimersByTime(250);
         dispatchKeyboardEvent(chip, 'keydown', BACKSPACE);
         fixture.detectChanges();
 
-        chips = getAllChipInstances(fixture)!;
+        chips = getAllChipInstances(fixture);
         expect(chips.length).toEqual(0);
       });
 
@@ -828,9 +839,9 @@ describe(`TsSelectComponent`, function() {
       test(`should show UI element based on format function passed in`, () => {
         const fixture = createComponent(testComponents.SeededAutocompleteWithFormatFn);
         fixture.detectChanges();
-        const chip = getChipElementDisplayValue(fixture);
+        const displayValue = getChipElementDisplayValue(fixture);
 
-        expect(chip).toEqual('Florida');
+        expect(displayValue).toEqual('Florida');
       });
 
 
@@ -874,7 +885,7 @@ describe(`TsSelectComponent`, function() {
 
       test(`should debounce the stream`, () => {
         jest.useFakeTimers();
-        const fixture = createComponent(testComponents.Debounce);
+        const fixture = createComponent<testComponents.Debounce>(testComponents.Debounce);
         fixture.componentInstance.change = jest.fn();
         fixture.detectChanges();
         const instance = getSelectInstance(fixture);
@@ -892,7 +903,7 @@ describe(`TsSelectComponent`, function() {
 
       test(`should allow a custom debounce delay`, () => {
         jest.useFakeTimers();
-        const fixture = createComponent(testComponents.CustomDebounce);
+        const fixture = createComponent<testComponents.CustomDebounce>(testComponents.CustomDebounce);
         fixture.componentInstance.change = jest.fn();
         fixture.detectChanges();
         const instance = getSelectInstance(fixture);
@@ -914,7 +925,7 @@ describe(`TsSelectComponent`, function() {
 
       test(`should only emit query once past the minimum character count`, () => {
         jest.useFakeTimers();
-        const fixture = createComponent(testComponents.CustomCharacterCount);
+        const fixture = createComponent<testComponents.CustomCharacterCount>(testComponents.CustomCharacterCount);
         fixture.componentInstance.change = jest.fn();
         fixture.detectChanges();
         const instance = getSelectInstance(fixture);
@@ -934,7 +945,7 @@ describe(`TsSelectComponent`, function() {
 
       test(`should allow a custom minimum character count`, () => {
         jest.useFakeTimers();
-        const fixture = createComponent(testComponents.CustomCharacterCount);
+        const fixture = createComponent<testComponents.CustomCharacterCount>(testComponents.CustomCharacterCount);
         fixture.componentInstance.customCount = 1;
         fixture.componentInstance.change = jest.fn();
         fixture.detectChanges();
@@ -957,7 +968,7 @@ describe(`TsSelectComponent`, function() {
 
     test(`should only allow unique queries`, function() {
       jest.useFakeTimers();
-      const fixture = createComponent(testComponents.Debounce);
+      const fixture = createComponent<testComponents.Debounce>(testComponents.Debounce);
       fixture.componentInstance.change = jest.fn();
       fixture.detectChanges();
       const instance = getSelectInstance(fixture);
@@ -978,24 +989,24 @@ describe(`TsSelectComponent`, function() {
       // NOTE: Even though we are simulating a typed query, the list of states is not actually changing.
       test(`should not be allowed by default but should emit an event`, function() {
         jest.useFakeTimers();
-        const fixture = createComponent(testComponents.SeededAutocomplete);
+        const fixture = createComponent<testComponents.SeededAutocomplete>(testComponents.SeededAutocomplete);
         fixture.detectChanges();
         fixture.componentInstance.duplicate = jest.fn();
 
-        let chips = getAllChipInstances(fixture)!;
+        let chips = getAllChipInstances(fixture);
         expect(chips.length).toEqual(1);
 
-        const input = getAutocompleteInput(fixture)!;
-        typeInElement('fl', input!);
+        const input = getAutocompleteInput(fixture);
+        typeInElement('fl', input);
         fixture.detectChanges();
 
         // Select Florida (it's selected by default in this test component)
-        const opt = getOptionElement(fixture, 4)!;
+        const opt = getOptionElement(fixture, 0, 4);
         opt.click();
         fixture.detectChanges();
 
         // Verify the selection did NOT work
-        chips = getAllChipInstances(fixture)!;
+        chips = getAllChipInstances(fixture);
         expect(chips.length).toEqual(1);
         expect(fixture.componentInstance.duplicate).toHaveBeenCalledWith('Florida');
         jest.runAllTimers();
@@ -1006,24 +1017,24 @@ describe(`TsSelectComponent`, function() {
       describe(`when allowed`, function() {
 
         test(`should allow a duplicate selection`, () => {
-          const fixture = createComponent(testComponents.SeededAutocomplete);
+          const fixture = createComponent<testComponents.SeededAutocomplete>(testComponents.SeededAutocomplete);
           fixture.componentInstance.allowDuplicates = true;
           fixture.detectChanges();
 
-          let chips = getAllChipInstances(fixture)!;
+          let chips = getAllChipInstances(fixture);
           expect(chips.length).toEqual(1);
 
-          const input = getAutocompleteInput(fixture)!;
-          typeInElement('fl', input!);
+          const input = getAutocompleteInput(fixture);
+          typeInElement('fl', input);
           fixture.detectChanges();
 
           // Select Florida (it's selected by default in this test component)
-          const opt = getOptionElement(fixture, 4)!;
+          const opt = getOptionElement(fixture, 0, 4);
           opt.click();
           fixture.detectChanges();
 
           // Verify the selection DID work
-          chips = getAllChipInstances(fixture)!;
+          chips = getAllChipInstances(fixture);
           expect(chips.length).toEqual(2);
           expect(getSelectInstance(fixture).autocompleteSelections).toEqual(['Florida', 'Florida']);
 
@@ -1040,17 +1051,17 @@ describe(`TsSelectComponent`, function() {
       describe(`in single selection mode`, function() {
 
         test(`should set single value`, () => {
-          const fixture = createComponent(testComponents.SeededAutocomplete);
+          const fixture = createComponent<testComponents.SeededAutocomplete>(testComponents.SeededAutocomplete);
           fixture.componentInstance.allowMultiple = false;
           fixture.componentInstance.keepOpen = false;
           fixture.detectChanges();
           const instance = getSelectInstance(fixture);
-          const input = getAutocompleteInput(fixture)!;
+          const input = getAutocompleteInput(fixture);
 
           typeInElement('fl', input);
           fixture.detectChanges();
 
-          const opt = getOptionElement(fixture, 0)!;
+          const opt = getOptionElement(fixture);
           opt.click();
           fixture.detectChanges();
 
@@ -1059,18 +1070,18 @@ describe(`TsSelectComponent`, function() {
 
 
         test(`should set single value 2`, () => {
-          const fixture = createComponent(testComponents.SeededAutocompleteWithFormatFn);
+          const fixture = createComponent<testComponents.SeededAutocompleteWithFormatFn>(testComponents.SeededAutocompleteWithFormatFn);
           fixture.componentInstance.allowMultiple = false;
           fixture.componentInstance.keepOpen = false;
           fixture.componentInstance.myCtrl.setValue([{ name: 'Florida', population: '20.27M'}]);
           fixture.detectChanges();
           const instance = getSelectInstance(fixture);
-          const input = getAutocompleteInput(fixture)!;
+          const input = getAutocompleteInput(fixture);
 
           typeInElement('fl', input);
           fixture.detectChanges();
 
-          const opt = getOptionElement(fixture, 0)!;
+          const opt = getOptionElement(fixture);
           opt.click();
           fixture.detectChanges();
 
@@ -1086,7 +1097,7 @@ describe(`TsSelectComponent`, function() {
       const fixture = createComponent(testComponents.AutocompleteAllowMultipleNoReopen);
       fixture.detectChanges();
 
-      const input = getAutocompleteInput(fixture)!;
+      const input = getAutocompleteInput(fixture);
       typeInElement('fl', input);
       fixture.detectChanges();
 
@@ -1106,7 +1117,7 @@ describe(`TsSelectComponent`, function() {
 
 
     test(`should support a custom tabindex`, function() {
-      const fixture = createComponent(testComponents.Tabindex);
+      const fixture = createComponent<testComponents.Tabindex>(testComponents.Tabindex);
       fixture.componentInstance.autocomplete = true;
       fixture.detectChanges();
       const input = getAutocompleteInput(fixture);
@@ -1129,7 +1140,7 @@ describe(`TsSelectComponent`, function() {
 
 
     test(`should close the panel if open when getting a blur event that isn't from a selection`, function() {
-      const fixture = createComponent(testComponents.Autocomplete);
+      const fixture = createComponent<testComponents.Autocomplete>(testComponents.Autocomplete);
       fixture.componentInstance.disabled = true;
       fixture.detectChanges();
       const input = getAutocompleteInput(fixture);
@@ -1160,20 +1171,21 @@ describe(`TsSelectComponent`, function() {
       fixture.detectChanges();
       const instance = getSelectInstance(fixture);
       const triggerInstance = instance.autocompleteTrigger;
-      const chip = getChipElement(fixture)!;
-      const chipRemovalButton = chip.querySelector('.mat-chip-remove')!;
+      const chip = getChipElement(fixture);
+      const chipRemovalButton = chip.querySelector('.mat-chip-remove');
 
       triggerInstance.openPanel();
       fixture.detectChanges();
-      instance.autocompleteTrigger.overlayRef!.updatePosition = jest.fn();
+      instance.autocompleteTrigger.overlayRef.updatePosition = jest.fn();
 
       dispatchMouseEvent(chipRemovalButton, 'click');
       jest.advanceTimersByTime(1000);
       fixture.detectChanges();
 
-      expect(instance.autocompleteTrigger.overlayRef!.updatePosition).toHaveBeenCalled();
+      expect(instance.autocompleteTrigger.overlayRef.updatePosition).toHaveBeenCalled();
       jest.runAllTimers();
     });
+
 
     describe(`required`, () => {
 
@@ -1203,10 +1215,11 @@ describe(`TsSelectComponent`, function() {
       });
     });
 
+
     describe(`panel`, function() {
 
       test(`should support a custom ID`, () => {
-        const fixture = createComponent(testComponents.Autocomplete);
+        const fixture = createComponent<testComponents.Autocomplete>(testComponents.Autocomplete);
         fixture.componentInstance.disabled = true;
         fixture.detectChanges();
         const instance = getSelectInstance(fixture);
@@ -1224,7 +1237,7 @@ describe(`TsSelectComponent`, function() {
 
 
   test(`should be able to hide the required marker`, function() {
-    const fixture = createComponent(testComponents.HideRequired);
+    const fixture = createComponent<testComponents.HideRequired>(testComponents.HideRequired);
     fixture.detectChanges();
     let marker = fixture.debugElement.query(By.css('.ts-form-field-required-marker'));
     expect(marker).toBeTruthy();
@@ -1260,7 +1273,7 @@ describe(`TsSelectComponent`, function() {
 
 
     test(`should fall back to the UID if no ID is passed in`, () => {
-      const fixture = createComponent(testComponents.Id);
+      const fixture = createComponent<testComponents.Id>(testComponents.Id);
       fixture.componentInstance.myId = undefined as any;
       fixture.detectChanges();
       const trigger = getSelectTriggerElement(fixture);
@@ -1283,7 +1296,7 @@ describe(`TsSelectComponent`, function() {
 
 
     test(`should trigger change detection and alert consumers when the label is changed`, () => {
-      const fixture = createComponent(testComponents.Label);
+      const fixture = createComponent<testComponents.Label>(testComponents.Label);
       fixture.detectChanges();
       const instance = getSelectInstance(fixture);
       instance['changeDetectorRef'].detectChanges = jest.fn();
@@ -1335,14 +1348,14 @@ describe(`TsSelectComponent`, function() {
   describe(`onSelect`, function() {
 
     test(`should reset selection values when a null value is selected`, () => {
-      const fixture = createComponent(testComponents.NullSelection);
+      const fixture = createComponent<testComponents.NullSelection>(testComponents.NullSelection);
       fixture.detectChanges();
       const instance = getSelectInstance(fixture);
       const trigger = getSelectTriggerElement(fixture);
 
       expect(fixture.componentInstance.myCtrl.value).toEqual('bar');
 
-      const option = getOptionElement(fixture, 1)!;
+      const option = getOptionElement(fixture, 0, 1);
       option.click();
       fixture.detectChanges();
 
@@ -1382,7 +1395,7 @@ describe(`TsSelectComponent`, function() {
   describe(`propogateChanges`, function() {
 
     test(`should use fallback value if the option has no value`, () => {
-      const fixture = createComponent(testComponents.Basic);
+      const fixture = createComponent<testComponents.Basic>(testComponents.Basic);
       fixture.detectChanges();
       const instance = getSelectInstance(fixture);
       fixture.componentInstance.change = jest.fn();
@@ -1427,7 +1440,7 @@ describe(`TsSelectComponent`, function() {
       test(`should support custom IDs`, () => {
         const fixture = createComponent(testComponents.OptionId);
         fixture.detectChanges();
-        const option = getOptionInstance(fixture, 1)!;
+        const option = getOptionInstance(fixture, 0, 1);
 
         expect(option.id).toEqual('Alabama');
       });
@@ -1436,7 +1449,7 @@ describe(`TsSelectComponent`, function() {
       test(`should fall back to UID`, () => {
         const fixture = createComponent(testComponents.OptionId);
         fixture.detectChanges();
-        const option = getOptionInstance(fixture, 1)!;
+        const option = getOptionInstance(fixture, 0, 1);
 
         option.id = undefined as any;
         fixture.detectChanges();
@@ -1452,7 +1465,7 @@ describe(`TsSelectComponent`, function() {
       test(`should return the viewValue`, () => {
         const fixture = createComponent(testComponents.OptionId);
         fixture.detectChanges();
-        const option = getOptionInstance(fixture, 1)!;
+        const option = getOptionInstance(fixture, 0, 1);
 
         expect(option.getLabel()).toEqual('Alabama');
       });
@@ -1465,7 +1478,7 @@ describe(`TsSelectComponent`, function() {
       test(`should select via interaction when SPACE is used`, () => {
         const fixture = createComponent(testComponents.OptionId);
         fixture.detectChanges();
-        const option = getOptionInstance(fixture, 1)!;
+        const option = getOptionInstance(fixture, 0, 1);
         const event = createKeyboardEvent('keydown', SPACE);
         option.selectViaInteraction = jest.fn();
 
@@ -1479,7 +1492,7 @@ describe(`TsSelectComponent`, function() {
       test(`should select via interaction when ENTER is used`, () => {
         const fixture = createComponent(testComponents.OptionId);
         fixture.detectChanges();
-        const option = getOptionInstance(fixture, 1)!;
+        const option = getOptionInstance(fixture, 0, 1);
         const event = createKeyboardEvent('keydown', ENTER);
         option.selectViaInteraction = jest.fn();
 
@@ -1497,7 +1510,7 @@ describe(`TsSelectComponent`, function() {
       test(`should retrieve the option object`, () => {
         const fixture = createComponent(testComponents.OptionId);
         fixture.detectChanges();
-        const option = getOptionInstance(fixture, 1)!;
+        const option = getOptionInstance(fixture, 0, 1);
 
         expect(option.option).toEqual(expect.objectContaining({name: 'Alabama'}));
       });
@@ -1507,21 +1520,21 @@ describe(`TsSelectComponent`, function() {
 
     describe(`deselect`, function() {
 
-/*
- *      test(`should emit event not from user interaction`, () => {
- *        const fixture = createComponent(testComponents.OptionId);
- *        fixture.detectChanges();
- *        fixture.componentInstance.change = jest.fn();
- *        const option = getOptionInstance(fixture, 2)!;
- *        option.select();
- *        fixture.detectChanges();
- *
- *        option.deselect();
- *        fixture.detectChanges();
- *
- *        expect(fixture.componentInstance.change).toHaveBeenCalledTimes(2);
- *      });
- */
+      test(`should emit event not from user interaction`, () => {
+        const fixture = createComponent<testComponents.OptionId>(testComponents.OptionId);
+        fixture.detectChanges();
+        const option = getOptionInstance(fixture, 0, 2);
+        option.select();
+        fixture.detectChanges();
+        option.emitSelectionChangeEvent = jest.fn();
+
+        option.deselect();
+        fixture.detectChanges();
+
+        expect(option.emitSelectionChangeEvent.mock.calls.length).toEqual(1);
+        // Verify it was not called with the boolean
+        expect(option.emitSelectionChangeEvent.mock.calls[0]).toEqual([]);
+      });
 
     });
 
@@ -1536,7 +1549,7 @@ describe(`TsSelectComponent`, function() {
       const trigger = getSelectTriggerElement(fixture);
       dispatchMouseEvent(trigger, 'click');
       fixture.detectChanges();
-      const group = getOptgroupElement(fixture)!;
+      const group = getOptgroupElement(fixture);
 
       expect(group.getAttribute('id')).toEqual('Group A');
     });
@@ -1548,7 +1561,7 @@ describe(`TsSelectComponent`, function() {
       const trigger = getSelectTriggerElement(fixture);
       dispatchMouseEvent(trigger, 'click');
       fixture.detectChanges();
-      const group = getOptgroupElement(fixture)!;
+      const group = getOptgroupElement(fixture);
 
       expect(group.getAttribute('id')).toEqual(expect.stringContaining('ts-select-optgroup-'));
     });
@@ -1563,18 +1576,18 @@ describe(`TsSelectComponent`, function() {
       fixture.detectChanges();
       const instance = getSelectInstance(fixture);
 
-      expect(instance.customTrigger!.id).toEqual('foo');
+      expect(instance.customTrigger.id).toEqual('foo');
     });
 
 
     test(`should fall back to the UID if no valid ID is passed in`, () => {
-      const fixture = createComponent(testComponents.CustomTrigger);
+      const fixture = createComponent<testComponents.CustomTrigger>(testComponents.CustomTrigger);
       fixture.detectChanges();
       fixture.componentInstance.myId = undefined as any;
       fixture.detectChanges();
       const instance = getSelectInstance(fixture);
 
-      expect(instance.customTrigger!.id).toEqual(expect.stringContaining('ts-select-trigger-'));
+      expect(instance.customTrigger.id).toEqual(expect.stringContaining('ts-select-trigger-'));
     });
 
   });
@@ -1640,7 +1653,7 @@ describe(`TsSelectComponent`, function() {
   describe('isFilterable', function() {
 
     test(`should filter options`, () => {
-      const fixture = createComponent(testComponents.Filterable);
+      const fixture = createComponent<testComponents.Filterable>(testComponents.Filterable);
       fixture.detectChanges();
       const trigger = getSelectTriggerElement(fixture);
       dispatchMouseEvent(trigger, 'click');
@@ -1666,8 +1679,9 @@ describe(`TsSelectComponent`, function() {
       expect.assertions(5);
     });
 
+
     test('should allow space as part of filter and not select an option', () => {
-      const fixture = createComponent(testComponents.Filterable);
+      const fixture = createComponent<testComponents.Filterable>(testComponents.Filterable);
       fixture.detectChanges();
       const trigger = getSelectTriggerElement(fixture);
       dispatchMouseEvent(trigger, 'click');
@@ -1690,29 +1704,3 @@ describe(`TsSelectComponent`, function() {
   });
 
 });
-
-
-
-
-/**
- * HELPERS
- */
-
-// TODO: Move to ngx-tools (and all other instances of this utility)
-export function createComponent<T>(component: Type<T>, providers: Provider[] = [], imports: any[] = []): ComponentFixture<T> {
-  TestBed.configureTestingModule({
-    imports: [
-      FormsModule,
-      ReactiveFormsModule,
-      TsSelectModule,
-      NoopAnimationsModule,
-      ...imports,
-    ],
-    declarations: [component],
-    providers: [
-      ...providers,
-    ],
-  }).compileComponents();
-
-  return TestBed.createComponent<T>(component);
-}

--- a/terminus-ui/select/testing/src/test-components.ts
+++ b/terminus-ui/select/testing/src/test-components.ts
@@ -337,11 +337,11 @@ export class Optgroups {
       >
         <ts-select-option
           *ngFor="let option of group.children"
-          [value]="option.slug"
+          [value]="option.name"
           [option]="option"
           [isDisabled]="option?.disabled"
         >
-          {{ option.foo }}
+          {{ option.name }}
         </ts-select-option>
       </ts-select-optgroup>
     </ts-select>
@@ -618,9 +618,6 @@ export class SelectOptionChange {
   `,
 })
 export class CustomCompareFn {
-  /*
-   *myCtrl = new FormControl({ value: 'pizza-1', viewValue: 'Pizza' });
-   */
   foods: ({value: string; viewValue: string})[] = [
     { value: 'steak-0', viewValue: 'Steak' },
     { value: 'pizza-1', viewValue: 'Pizza' },

--- a/terminus-ui/select/testing/src/test-helpers.ts
+++ b/terminus-ui/select/testing/src/test-helpers.ts
@@ -6,8 +6,16 @@ import {
   TsSelectOptgroupComponent,
   TsSelectOptionComponent,
 } from '@terminus/ui/select';
+import { DebugElement } from '@angular/core';
 
 
+/**
+ * Create a mock keydown event
+ *
+ * @param key - The key that should be pressed
+ * @param keyCode - The corresponding keyCode
+ * @return The KeyboardEvent
+ */
 export function createKeydownEvent(key: string, keyCode: number): KeyboardEvent {
   const event = document.createEvent('KeyboardEvent');
   event.initEvent('keydown', true, false);
@@ -18,80 +26,318 @@ export function createKeydownEvent(key: string, keyCode: number): KeyboardEvent 
   return event;
 }
 
-export function getSelectInstance(fixture: ComponentFixture<any>): TsSelectComponent {
-  return fixture.debugElement.query(By.css('ts-select')).componentInstance;
+/**
+ * Get an array of all DebugElements for TsSelectComponents
+ *
+ * @param fixture - The component fixture
+ * @return An array of DebugElements
+ */
+export function getAllSelectDebugElements(fixture: ComponentFixture<any>): DebugElement[] {
+  const debugElements = fixture.debugElement.queryAll(By.css('ts-select'));
+  if (!debugElements) {
+    throw new Error(`'getAllSelectInstances' did not find any debug elements`);
+  }
+  return debugElements;
 }
 
-export function getSelectElement(fixture: ComponentFixture<any>): HTMLElement {
-  const instance = getSelectInstance(fixture);
+/**
+ * Get an array of all component instances for TsSelectComponents
+ *
+ * @param fixture - The component fixture
+ * @return An array of TsSelectComponents
+ */
+export function getAllSelectInstances(fixture: ComponentFixture<any>): TsSelectComponent[] {
+  return getAllSelectDebugElements(fixture).map((v) => v.componentInstance);
+}
+
+/**
+ * Get the DebugElement for a TsSelectComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsSelectComponent
+ * @return The DebugElement
+ */
+export function getSelectDebugElement(fixture: ComponentFixture<any>, index = 0): DebugElement {
+  const debugElements = getAllSelectDebugElements(fixture);
+  if (!debugElements[index]) {
+    throw new Error(`'getSelectDebugElement' did not find a debug element at index '${index}'`);
+  }
+  return debugElements[index];
+}
+
+/**
+ * Get the component instance for a TsSelectComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsSelectComponent
+ * @return The instance
+ */
+export function getSelectInstance(fixture: ComponentFixture<any>, index = 0): TsSelectComponent {
+  const instances = getAllSelectInstances(fixture);
+  if (!instances[index]) {
+    throw new Error(`'getSelectInstance' did not find an instance at index '${index}'`);
+  }
+  return instances[index];
+}
+
+/**
+ * Get the element for a TsSelectComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsSelectComponent
+ * @return The element
+ */
+export function getSelectElement(fixture: ComponentFixture<any>, index = 0): HTMLElement {
+  const instance = getSelectInstance(fixture, index);
   return instance['elementRef'].nativeElement as HTMLElement;
 }
 
-export function getSelectTriggerElement(fixture: ComponentFixture<any>): HTMLElement {
-  return fixture.debugElement.query(By.css('.ts-select-trigger')).nativeElement as HTMLElement;
+/**
+ * Get the trigger element for a TsSelectComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsSelectComponent
+ * @return The element
+ */
+export function getSelectTriggerElement(fixture: ComponentFixture<any>, index = 0): HTMLElement {
+  const debugElement = getSelectDebugElement(fixture, index);
+  return debugElement.query(By.css('.ts-select-trigger')).nativeElement as HTMLElement;
 }
 
-export function getToggleAllElement(fixture: ComponentFixture<any>): HTMLElement {
-  return fixture.debugElement.query(By.css('.ts-select-panel__toggle-all')).nativeElement as HTMLElement;
+/**
+ * Get the trigger element for a TsSelectComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsSelectComponent
+ * @return The trigger element
+ */
+export function getToggleAllElement(fixture: ComponentFixture<any>, index = 0): HTMLElement {
+  const debugElement = getSelectDebugElement(fixture, index);
+  return debugElement.query(By.css('.ts-select-panel__toggle-all')).nativeElement as HTMLElement;
 }
 
-export function getPanelElement(fixture: ComponentFixture<any>): HTMLElement {
-  return fixture.debugElement.query(By.css('.ts-select-panel')).nativeElement as HTMLElement;
+/**
+ * Get the panel element for a TsSelectComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsSelectComponent
+ * @return The panel element
+ */
+export function getPanelElement(fixture: ComponentFixture<any>, index = 0): HTMLElement {
+  const debugElement = getSelectDebugElement(fixture, index);
+  return debugElement.query(By.css('.ts-select-panel')).nativeElement as HTMLElement;
 }
 
-export function getAllOptionInstances(fixture: ComponentFixture<any>): TsSelectOptionComponent[] {
-  const instance = getSelectInstance(fixture);
-  return instance.options.toArray();
+/**
+ * Get all TsSelectOptionComponent instances for a TsSelectComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsSelectComponent
+ * @return An array of TsSelectOptionComponents
+ */
+export function getAllOptionInstances(fixture: ComponentFixture<any>, index = 0): TsSelectOptionComponent[] {
+  const instance = getSelectInstance(fixture, index);
+  const options = instance.options.toArray();
+  if (options.length < 1) {
+    throw new Error(`'getAllOptionInstances' found no options.`);
+  }
+  return options;
 }
 
-export function getOptionInstance(fixture: ComponentFixture<any>, index = 0): TsSelectOptionComponent | null {
-  const options = getAllOptionInstances(fixture);
-  return options[index] ? options[index] : null;
+/**
+ * Get a specific TsSelectOptionComponent instance for a TsSelectComponent
+ *
+ * @param fixture - The component fixture
+ * @param selectIndex - The index of the desired TsSelectComponent
+ * @param optionIndex - The index of the desired TsSelectOptionComponent
+ * @return A TsSelectOptionComponent
+ */
+export function getOptionInstance(fixture: ComponentFixture<any>, selectIndex = 0, optionIndex = 0): TsSelectOptionComponent {
+  const options = getAllOptionInstances(fixture, selectIndex);
+  if (!options[optionIndex]) {
+    throw new Error(`'getOptionInstance' did not find an option at index '${optionIndex}' from the select at index '${selectIndex}'`);
+  }
+  return options[optionIndex];
 }
 
-export function getOptionElement(fixture: ComponentFixture<any>, index = 0): HTMLElement | null {
-  const option = getOptionInstance(fixture, index);
-  return option ? option.elementRef.nativeElement as HTMLElement : null;
+/**
+ * Get the element of a TsSelectOptionComponent instance for a TsSelectComponent
+ *
+ * @param fixture - The component fixture
+ * @param selectIndex - The index of the desired TsSelectComponent
+ * @param optionIndex - The index of the desired TsSelectOptionComponent
+ * @return The TsSelectOptionComponent element
+ */
+export function getOptionElement(fixture: ComponentFixture<any>, selectIndex = 0, optionIndex = 0): HTMLElement {
+  const option = getOptionInstance(fixture, selectIndex, optionIndex);
+  return option.elementRef.nativeElement;
 }
 
-export function getAllOptgroups(fixture: ComponentFixture<any>): TsSelectOptgroupComponent[] {
-  return fixture.debugElement.queryAll(By.css('ts-select-optgroup')).map((i) => i.componentInstance);
+/**
+ * Get an array of all TsSelectOptgroupComponents
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsSelectComponent
+ * @return An array of TsSelectOptionComponents
+ */
+export function getAllOptgroups(fixture: ComponentFixture<any>, index = 0): TsSelectOptgroupComponent[] {
+  const debugElement = getSelectDebugElement(fixture, index);
+  const optgroups = debugElement.queryAll(By.css('ts-select-optgroup'));
+  if (!optgroups) {
+    throw new Error(`'getAllOptgroups' did not find any optgroups`);
+  }
+  return optgroups.map((i) => i.componentInstance);
 }
 
-export function getOptgroup(fixture: ComponentFixture<any>, index = 0): TsSelectOptgroupComponent | null {
-  const groups = getAllOptgroups(fixture);
-  return groups && groups[index] ? groups[index] : null;
+/**
+ * Get a specific TsSelectOptgroupComponent
+ *
+ * @param fixture - The component fixture
+ * @param selectIndex - The index of the desired TsSelectComponent
+ * @param groupIndex - The index of the desired TsSelectOptgroupComponent
+ * @return A TsSelectOptgroupComponent
+ */
+export function getOptgroup(fixture: ComponentFixture<any>, selectIndex = 0, groupIndex = 0): TsSelectOptgroupComponent {
+  const groups = getAllOptgroups(fixture, selectIndex);
+  if (!groups[groupIndex]) {
+    throw new Error(`'getOptgroup' did not find an optgroup at index '${groupIndex}'`);
+  }
+  return groups[groupIndex];
 }
 
-export function getOptgroupElement(fixture: ComponentFixture<any>, index = 0): HTMLElement | null {
-  const group = getOptgroup(fixture, index);
-  return group ? group['elementRef'].nativeElement as HTMLElement : null;
+/**
+ * Get the element for a TsSelectOptgroupComponent
+ *
+ * @param fixture - The component fixture
+ * @param selectIndex - The index of the desired TsSelectComponent
+ * @param groupIndex - The index of the desired TsSelectOptgroupComponent
+ * @return The optgroup element
+ */
+export function getOptgroupElement(fixture: ComponentFixture<any>, selectIndex = 0, groupIndex = 0): HTMLElement {
+  const group = getOptgroup(fixture, selectIndex, groupIndex);
+  return group['elementRef'].nativeElement;
 }
 
-export function getAutocompleteInput(fixture: ComponentFixture<any>): HTMLInputElement {
-  return fixture.debugElement.query(By.css('.ts-select__autocomplete-input')).nativeElement as HTMLInputElement;
+/**
+ * Get the autocomplete input element for a TsSelectComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsSelectComponent
+ * @return The input element
+ */
+export function getAutocompleteInput(fixture: ComponentFixture<any>, index = 0): HTMLInputElement {
+  const debugElement = getSelectDebugElement(fixture, index);
+  const inputDebugElement = debugElement.query(By.css('.ts-select__autocomplete-input'));
+  if (!inputDebugElement) {
+    throw new Error(`'getAutocompleteInput' did not find an input at index '${index}'`);
+  }
+  return inputDebugElement.nativeElement as HTMLInputElement;
 }
 
-export function getAllChipInstances(fixture: ComponentFixture<any>): MatChip[] | null {
-  const instance = getSelectInstance(fixture);
-  const chipList = instance.chipList;
-  return chipList ? chipList.chips.toArray() : null;
+/**
+ * Get an array of all chip instances for a TsSelectComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsSelectComponent
+ * @return An array of chip instances
+ */
+export function getAllChipInstances(fixture: ComponentFixture<any>, index = 0): MatChip[] {
+  const instance = getSelectInstance(fixture, index);
+  if (!instance.chipList) {
+    throw new Error(`'getAllChipInstances' did not find a chips collection from the select at index '${index}'`);
+  }
+  return instance.chipList.chips.toArray();
 }
 
-export function getChipInstance(fixture: ComponentFixture<any>, index = 0): MatChip | null {
-  const chips = getAllChipInstances(fixture);
-  return chips && chips[index] ? chips[index] : null;
+/**
+ * Get a specific chip instance for a TsSelectComponent
+ *
+ * @param fixture - The component fixture
+ * @param selectIndex - The index of the desired TsSelectComponent
+ * @param chipIndex - The index of the desired chip
+ * @return A chip instances
+ */
+export function getChipInstance(fixture: ComponentFixture<any>, selectIndex = 0, chipIndex = 0): MatChip {
+  const chips = getAllChipInstances(fixture, selectIndex);
+  if (!chips[chipIndex]) {
+    throw new Error(`'getChipInstance' did not find a chip at index '${chipIndex}'`);
+  }
+  return chips[chipIndex];
 }
 
-export function getChipElement(fixture: ComponentFixture<any>, index = 0): HTMLElement | null {
-  const chip = getChipInstance(fixture, index);
-  return chip ? chip._elementRef.nativeElement : null;
+/**
+ * Get the element for a specific chip instance for a TsSelectComponent
+ *
+ * @param fixture - The component fixture
+ * @param selectIndex - The index of the desired TsSelectComponent
+ * @param chipIndex - The index of the desired chip
+ * @return The chip element
+ */
+export function getChipElement(fixture: ComponentFixture<any>, selectIndex = 0, chipIndex = 0): HTMLElement {
+  const chip = getChipInstance(fixture, selectIndex, chipIndex);
+  return chip._elementRef.nativeElement;
 }
 
-export function getChipElementDisplayValue(fixture: ComponentFixture<any>, index = 0): string | null {
-  const chip = fixture.debugElement.query(By.css('.ts-autocomplete-chip-value')).nativeElement;
-  return chip.textContent.trim();
+/**
+ * Get the display value for a specific chip instance for a TsSelectComponent
+ *
+ * @param fixture - The component fixture
+ * @param selectIndex - The index of the desired TsSelectComponent
+ * @return The chip element
+ */
+export function getChipElementDisplayValue(fixture: ComponentFixture<any>, selectIndex = 0, chipIndex = 0): string | null {
+  const chipElement = getChipElement(fixture, selectIndex, chipIndex);
+  // We need to remove the text that represents the chip's delete icon
+  return chipElement.textContent.replace(/cancel/g, '').trim();
 }
-export function getFilterInputElement(fixture: ComponentFixture<any>): HTMLInputElement {
-  return fixture.debugElement.query(By.css('.ts-select-panel__filter-input .c-input__text')).nativeElement as HTMLInputElement;
+
+/**
+ * Get the element for the filter input for a TsSelectComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsSelectComponent
+ * @return The filter input element
+ */
+export function getFilterInputElement(fixture: ComponentFixture<any>, index = 0): HTMLInputElement {
+  const debugElement = getSelectDebugElement(fixture, index);
+  const inputDebugElement = debugElement.query(By.css('.ts-select-panel__filter-input .c-input__text'));
+  if (!inputDebugElement) {
+    throw new Error(`'getFilterInputElement' did not find the filter input`);
+  }
+  return inputDebugElement.nativeElement as HTMLInputElement;
+}
+
+/**
+ * Open a select element
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsSelectComponent
+ * @return The whenStable promise
+ */
+export function openSelect(fixture: ComponentFixture<any>, index = 0): Promise<any> {
+  const trigger = getSelectTriggerElement(fixture, index);
+  trigger.click();
+  fixture.detectChanges();
+  return fixture.whenStable();
+}
+
+/**
+ * Select an option
+ *
+ * @param fixture - The component fixture
+ * @param optionText - The text to find the option by
+ * @param selectIndex - The index of the desired TsSelectComponent
+ * @return The whenStable promise
+ */
+export function selectOption(fixture: ComponentFixture<any>, optionText: string, selectIndex = 0): Promise<any> {
+  const allOptions = getAllOptionInstances(fixture, selectIndex);
+  const foundOptions = allOptions.filter((option) => option.viewValue === optionText);
+
+  if (foundOptions.length < 1) {
+    throw new Error(`'selectOption' did not find an option with the view value of '${optionText}'`);
+  }
+
+  foundOptions[0].select();
+  fixture.detectChanges();
+  return fixture.whenStable();
 }


### PR DESCRIPTION
ISSUES CLOSED: #1074 

- Moved test helpers from core into library
- Added JSDoc comments to all helpers
- Added all helpers to the primary component readmes
- Added a couple classes for easier targeting
- Removed unneeded import
- Remove unneeded ID setter

---

#### Replaced core helpers:

`toggleCheckbox` replaces `checkTsCheckbox` and `uncheckTsCheckbox`
`sendInput` replaces `setTsInputValue` and `setTsDatePicker`
`selectStandardRadio`/`selectVisualRadio` replaces `setTsRadioBoxValueByText`
`setDateRangeValues` replaces `setTsDateRangeValue`
`getAllOptionInstances` replaces `getOptions`
`openSelect` replaces `openSelector`
`selectOption` replaces `selectOption`
