### PR TITLE
289 expansion panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,51 +92,51 @@ for each feature.
 
 ### Components
 
-| Feature                                | Notes                                                     | Status             | Demo                            | Docs                         | Usage                       |
-|----------------------------------------|-----------------------------------------------------------|:------------------:|---------------------------------|------------------------------|-----------------------------|
-| alert                                  |                                                           |                    |                                 |                              |                             |
-| [autocomplete][src-autocomplete]       | Deprecated in favor of the new `TsInputComponent`         | :hankey:           | [Demo][demo-autocomplete]       | [Docs][autocomplete-docs]    | [Usage][autocomplete-usage] |
-| [autofocus][src-autofocus]             | Focus a focusable element on load                         | :white_check_mark: | [Demo][demo-autofocus]          | [Docs][autofocus-docs]       | [Usage][autofocus-usage]    |
-| badge                                  |                                                           |                    |                                 |                              |                             |
-| [button][src-button]                   |                                                           | :white_check_mark: | [Demo][demo-button]             | [Docs][button-docs]          |                             |
-| breadcrumbs                            |                                                           |                    |                                 |                              |                             |
-| [card][src-card]                       |                                                           | :white_check_mark: | [Demo][demo-card]               | [Docs][card-docs]            | [Usage][card-usage]         |
-| [chart][src-chart]                     | Charts, graphs etc                                        | :white_check_mark: | [Demo][demo-chart]              | [Docs][chart-docs]           | [Usage][chart-usage]        |
-| chip                                   |                                                           |                    |                                 |                              |                             |
-| [checkbox][src-checkbox]               |                                                           | :white_check_mark: | [Demo][demo-checkbox]           | [Docs][checkbox-docs]        | [Usage][checkbox-usage]     |
-| [confirmation][src-confirmation]       | Add a confirmation step to any `ts-button`                | :white_check_mark: | [Demo][demo-confirmation]       | [Docs][confirmation-docs]    | [Usage][confirmation-usage] |
-| [copy][src-copy]                       |                                                           | :white_check_mark: | [Demo][demo-copy]               | [Docs][copy-docs]            |                             |
-| [csv entry][src-csv-entry]             | Manually enter CSV values                                 | :white_check_mark: | [Demo][demo-csv-entry]          | [Docs][csv-entry-docs]       | [Usage][csv-entry-usage]    |
-| [datepicker][src-input]                | See `TsInputComponent`                                    | :white_check_mark: | [Demo][demo-input]              | [Docs][input-docs]           | [Usage][input-usage]        |
-| [date-range][src-date-range]           | Dual inputs with calendar pop-ups                         | :white_check_mark: | [Demo][demo-date-range]         | [Docs][date-range-docs]      | [Usage][date-range-usage]   |
-| dialog                                 |                                                           |                    |                                 |                              |                             |
-| divider                                |                                                           |                    |                                 |                              |                             |
-| expansion                              |                                                           |                    |                                 |                              |                             |
-| [file-upload][src-file-upload]         | File upload with drag and drop                            | :white_check_mark: | [Demo][demo-file-upload]        | [Docs][file-upload-docs]     | [Usage][file-upload-usage]  |
-| [icon][src-icon]                       | Supported icons: https://material.io/icons                | :white_check_mark: | [Demo][demo-icon]               | [Docs][icon-docs]            | [Usage][icon-usage]         |
-| [icon-button][src-button]              |                                                           | :white_check_mark: | [Demo][demo-icon-button]        | [Docs][icon-button-docs]     | [Usage][icon-button-usage]  |
-| [input][src-input]                     |                                                           | :white_check_mark: | [Demo][demo-input]              | [Docs][input-docs]           | [Usage][input-usage]        |
-| [link][src-link]                       |                                                           | :white_check_mark: | [Demo][demo-link]               | [Docs][link-docs]            | [Usage][link-usage]         |
-| [loading overlay][src-loading-overlay] | Overlay with loading spinner                              | :white_check_mark: | [Demo][demo-loading-overlay]    | [Docs][loading-overlay-docs] |                             |
-| [login form][src-login-form]           | Email/password with 'remember me' checkbox                | :white_check_mark: | [Demo][demo-log-in-form]        | [Docs][login-form-docs]      |                             |
-| [logo][src-logo]                       | Variations of the official logo, certain colors available | :white_check_mark: | [Demo][demo-logo]               | [Docs][logo-docs]            | [Usage][logo-usage]         |
-| [menu][src-menu]                       |                                                           | :white_check_mark: | [Demo][demo-menu]               | [Docs][menu-docs]            | [Usage][menu-usage]         |
-| [navigation][src-navigation]           | Global navigation menu                                    | :white_check_mark: | [Demo][demo-navigation]         | [Docs][navigation-docs]      | [Usage][navigation-usage]   |
-| [paginator][src-paginator]             | Paging controls for collections                           | :white_check_mark: | [Demo][demo-paginator]          | [Docs][paginator-docs]       | [Usage][paginator-usage]    |
-| [pipes][src-pipes]                     | A collection of pipes for Angular                         | :white_check_mark: | [Demo][demo-pipes]              | [Docs][pipes-docs]           |                             |
-| progress                               |                                                           |                    |                                 |                              |                             |
-| progression                            | i.e. Stepper, wizard                                      |                    |                                 |                              |                             |
-| [radio-group][src-radio-group]         |                                                           | :white_check_mark: | [Demo][demo-radio-group]        | [Docs][radio-group-docs]     | [Usage][radio-group-usage]  |
-| [scrollbars][src-scrollbars]           | Custom scrollars for both axis'                           | :white_check_mark: | [Demo][demo-scrollbars]         | [Docs][scrollbars-docs]      | [Usage][scrollbars-usage]   |
-| [search][src-search]                   | input with search capabilities                            | :white_check_mark: | [Demo][demo-search]             | [Docs][search-docs]          |                             |
-| [select][src-select]                   |                                                           | :white_check_mark: | [Demo][demo-select]             | [Docs][select-docs]          |                             |
-| [spacing][src-spacing]                 | Helpers for consistent spacing                            | :white_check_mark: | [Demo][demo-spacing]            | [Docs][spacing-docs]         |                             |
-| [sort][src-sort]                       | Used by `table` for column sorting                        | :white_check_mark: | <small>(see table demo)</small> | [Docs][sort-docs]            | [Usage][sort-usage]         |
-| [table][src-table]                     |                                                           | :white_check_mark: | [Demo][demo-table]              | [Docs][table-docs]           | [Usage][table-usage]        |
-| tabs                                   |                                                           |                    |                                 |                              |                             |
-| textarea                               | See `input`                                               |                    | <small>(see input demo)</small> |                              |                             |
-| [toggle][src-toggle]                   |                                                           | :white_check_mark: | [Demo][demo-toggle]             | [Docs][toggle-docs]          |                             |
-| [tooltip][src-tooltip]                 |                                                           | :white_check_mark: | [Demo][demo-tooltip]            | [Docs][tooltip-docs]         |                             |
+| Feature                                | Notes                                                     | Status             | Demo                            | Docs                         | Usage                          |
+|----------------------------------------|-----------------------------------------------------------|:------------------:|---------------------------------|------------------------------|--------------------------------|
+| alert                                  |                                                           |                    |                                 |                              |                                |
+| [autocomplete][src-autocomplete]       | Deprecated in favor of the new `TsInputComponent`         | :hankey:           | [Demo][demo-autocomplete]       | [Docs][autocomplete-docs]    | [Usage][autocomplete-usage]    |
+| [autofocus][src-autofocus]             | Focus a focusable element on load                         | :white_check_mark: | [Demo][demo-autofocus]          | [Docs][autofocus-docs]       | [Usage][autofocus-usage]       |
+| badge                                  |                                                           |                    |                                 |                              |                                |
+| [button][src-button]                   |                                                           | :white_check_mark: | [Demo][demo-button]             | [Docs][button-docs]          |                                |
+| breadcrumbs                            |                                                           |                    |                                 |                              |                                |
+| [card][src-card]                       |                                                           | :white_check_mark: | [Demo][demo-card]               | [Docs][card-docs]            | [Usage][card-usage]            |
+| [chart][src-chart]                     | Charts, graphs etc                                        | :white_check_mark: | [Demo][demo-chart]              | [Docs][chart-docs]           | [Usage][chart-usage]           |
+| chip                                   |                                                           |                    |                                 |                              |                                |
+| [checkbox][src-checkbox]               |                                                           | :white_check_mark: | [Demo][demo-checkbox]           | [Docs][checkbox-docs]        | [Usage][checkbox-usage]        |
+| [confirmation][src-confirmation]       | Add a confirmation step to any `ts-button`                | :white_check_mark: | [Demo][demo-confirmation]       | [Docs][confirmation-docs]    | [Usage][confirmation-usage]    |
+| [copy][src-copy]                       |                                                           | :white_check_mark: | [Demo][demo-copy]               | [Docs][copy-docs]            |                                |
+| [csv entry][src-csv-entry]             | Manually enter CSV values                                 | :white_check_mark: | [Demo][demo-csv-entry]          | [Docs][csv-entry-docs]       | [Usage][csv-entry-usage]       |
+| [datepicker][src-input]                | See `TsInputComponent`                                    | :white_check_mark: | [Demo][demo-input]              | [Docs][input-docs]           | [Usage][input-usage]           |
+| [date-range][src-date-range]           | Dual inputs with calendar pop-ups                         | :white_check_mark: | [Demo][demo-date-range]         | [Docs][date-range-docs]      | [Usage][date-range-usage]      |
+| dialog                                 |                                                           |                    |                                 |                              |                                |
+| divider                                |                                                           |                    |                                 |                              |                                |
+| [expansion-panel][src-expansion-panel] | An expansion panel and accordion functionality            | :white_check_mark: | [Demo][demo-expansion-panel]    | [Docs][expansion-panel-docs] | [Usage][expansion-panel-usage] |
+| [file-upload][src-file-upload]         | File upload with drag and drop                            | :white_check_mark: | [Demo][demo-file-upload]        | [Docs][file-upload-docs]     | [Usage][file-upload-usage]     |
+| [icon][src-icon]                       | Supported icons: https://material.io/icons                | :white_check_mark: | [Demo][demo-icon]               | [Docs][icon-docs]            | [Usage][icon-usage]            |
+| [icon-button][src-button]              |                                                           | :white_check_mark: | [Demo][demo-icon-button]        | [Docs][icon-button-docs]     | [Usage][icon-button-usage]     |
+| [input][src-input]                     |                                                           | :white_check_mark: | [Demo][demo-input]              | [Docs][input-docs]           | [Usage][input-usage]           |
+| [link][src-link]                       |                                                           | :white_check_mark: | [Demo][demo-link]               | [Docs][link-docs]            | [Usage][link-usage]            |
+| [loading overlay][src-loading-overlay] | Overlay with loading spinner                              | :white_check_mark: | [Demo][demo-loading-overlay]    | [Docs][loading-overlay-docs] |                                |
+| [login form][src-login-form]           | Email/password with 'remember me' checkbox                | :white_check_mark: | [Demo][demo-log-in-form]        | [Docs][login-form-docs]      |                                |
+| [logo][src-logo]                       | Variations of the official logo, certain colors available | :white_check_mark: | [Demo][demo-logo]               | [Docs][logo-docs]            | [Usage][logo-usage]            |
+| [menu][src-menu]                       |                                                           | :white_check_mark: | [Demo][demo-menu]               | [Docs][menu-docs]            | [Usage][menu-usage]            |
+| [navigation][src-navigation]           | Global navigation menu                                    | :white_check_mark: | [Demo][demo-navigation]         | [Docs][navigation-docs]      | [Usage][navigation-usage]      |
+| [paginator][src-paginator]             | Paging controls for collections                           | :white_check_mark: | [Demo][demo-paginator]          | [Docs][paginator-docs]       | [Usage][paginator-usage]       |
+| [pipes][src-pipes]                     | A collection of pipes for Angular                         | :white_check_mark: | [Demo][demo-pipes]              | [Docs][pipes-docs]           |                                |
+| progress                               |                                                           |                    |                                 |                              |                                |
+| progression                            | i.e. Stepper, wizard                                      |                    |                                 |                              |                                |
+| [radio-group][src-radio-group]         |                                                           | :white_check_mark: | [Demo][demo-radio-group]        | [Docs][radio-group-docs]     | [Usage][radio-group-usage]     |
+| [scrollbars][src-scrollbars]           | Custom scrollars for both axis'                           | :white_check_mark: | [Demo][demo-scrollbars]         | [Docs][scrollbars-docs]      | [Usage][scrollbars-usage]      |
+| [search][src-search]                   | input with search capabilities                            | :white_check_mark: | [Demo][demo-search]             | [Docs][search-docs]          |                                |
+| [select][src-select]                   |                                                           | :white_check_mark: | [Demo][demo-select]             | [Docs][select-docs]          |                                |
+| [spacing][src-spacing]                 | Helpers for consistent spacing                            | :white_check_mark: | [Demo][demo-spacing]            | [Docs][spacing-docs]         |                                |
+| [sort][src-sort]                       | Used by `table` for column sorting                        | :white_check_mark: | <small>(see table demo)</small> | [Docs][sort-docs]            | [Usage][sort-usage]            |
+| [table][src-table]                     |                                                           | :white_check_mark: | [Demo][demo-table]              | [Docs][table-docs]           | [Usage][table-usage]           |
+| tabs                                   |                                                           | :hammer:           |                                 |                              |                                |
+| textarea                               | See `input`                                               |                    | <small>(see input demo)</small> |                              |                                |
+| [toggle][src-toggle]                   |                                                           | :white_check_mark: | [Demo][demo-toggle]             | [Docs][toggle-docs]          |                                |
+| [tooltip][src-tooltip]                 |                                                           | :white_check_mark: | [Demo][demo-tooltip]            | [Docs][tooltip-docs]         |                                |
 
 
 ### Pipes
@@ -330,6 +330,7 @@ This project follows the [all-contributors](https://github.com/kentcdodds/all-co
 [demo-csv-entry]:        https://getterminus.github.io/ui-demos-master/components/csv-entry
 [demo-date-range]:       https://getterminus.github.io/ui-demos-master/components/date-range
 [demo-datepicker]:       https://getterminus.github.io/ui-demos-master/components/datepicker
+[demo-expansion-panel]:  https://getterminus.github.io/ui-demos-master/components/expansion-panel
 [demo-file-upload]:      https://getterminus.github.io/ui-demos-master/components/file-upload
 [demo-icon-button]:      https://getterminus.github.io/ui-demos-master/components/icon-button
 [demo-icon]:             https://getterminus.github.io/ui-demos-master/components/icon
@@ -374,6 +375,7 @@ This project follows the [all-contributors](https://github.com/kentcdodds/all-co
 [src-copy]:               ./terminus-ui/copy/src/
 [src-csv-entry]:          ./terminus-ui/csv-entry/src/
 [src-date-range]:         ./terminus-ui/date-range/src/
+[src-expansion-panel]:    ./terminus-ui/expansion-panel/src/
 [src-file-upload]:        ./terminus-ui/file-upload/src/
 [src-icon-button]:        ./terminus-ui/icon-button/src/
 [src-icon]:               ./terminus-ui/src/icon/src/
@@ -415,6 +417,7 @@ This project follows the [all-contributors](https://github.com/kentcdodds/all-co
 [csv-entry-docs]:       http://uilibrary-docs.terminus.ninja/master/components/TsCSVEntryComponent.html
 [date-range-docs]:      http://uilibrary-docs.terminus.ninja/master/components/TsDateRangeComponent.html
 [datepicker-docs]:      http://uilibrary-docs.terminus.ninja/master/components/TsDatepickerComponent.html
+[expansion-panel-docs]: http://uilibrary-docs.terminus.ninja/master/components/TsExpansionPanelComponent.html
 [file-upload-docs]:     http://uilibrary-docs.terminus.ninja/master/components/TsFileUploadComponent.html
 [icon-button-docs]:     http://uilibrary-docs.terminus.ninja/master/components/TsIconButtonComponent.html
 [icon-docs]:            http://uilibrary-docs.terminus.ninja/master/components/TsIconComponent.html
@@ -449,26 +452,27 @@ This project follows the [all-contributors](https://github.com/kentcdodds/all-co
 [demo-latest]: https://getterminus.github.io/ui-demos-master/
 
 <!-- TS Usage Docs -->
-[autocomplete-usage]: http://uilibrary-docs.terminus.ninja/master/components/TsAutocompleteComponent.html#readme
-[autofocus-usage]:    http://uilibrary-docs.terminus.ninja/master/directives/TsAutofocusDirective.html#readme
-[card-usage]:         http://uilibrary-docs.terminus.ninja/master/components/TsCardComponent.html#readme
-[chart-usage]:        http://uilibrary-docs.terminus.ninja/master/components/TsChartComponent.html#readme
-[checkbox-usage]:     http://uilibrary-docs.terminus.ninja/master/components/TsCheckboxComponent.html#readme
-[confirmation-usage]: http://uilibrary-docs.terminus.ninja/master/directives/TsConfirmationDirective.html#readme
-[csv-entry-usage]:    http://uilibrary-docs.terminus.ninja/master/components/TsCSVEntryComponent.html#readme
-[date-range-usage]:   http://uilibrary-docs.terminus.ninja/master/components/TsDateRangeComponent.html#readme
-[datepicker-usage]:   http://uilibrary-docs.terminus.ninja/master/components/TsDatepickerComponent.html#readme
-[file-upload-usage]:  http://uilibrary-docs.terminus.ninja/master/components/TsFileUploadComponent.html#readme
-[icon-button-usage]:  http://uilibrary-docs.terminus.ninja/master/components/TsIconButtonComponent.html#readme
-[icon-usage]:         http://uilibrary-docs.terminus.ninja/master/components/TsIconComponent.html#readme
-[input-usage]:        http://uilibrary-docs.terminus.ninja/master/components/TsInputComponent.html#readme
-[link-usage]:         http://uilibrary-docs.terminus.ninja/master/components/TsLinkComponent.html#readme
-[logo-usage]:         http://uilibrary-docs.terminus.ninja/master/components/TsLogoComponent.html#readme
-[menu-usage]:         http://uilibrary-docs.terminus.ninja/master/components/TsMenuComponent.html#readme
-[paginator-usage]:    http://uilibrary-docs.terminus.ninja/master/components/TsPaginatorComponent.html#readme
-[navigation-usage]:   http://uilibrary-docs.terminus.ninja/master/components/TsNavigationComponent.html#readme
-[radio-group-usage]:  http://uilibrary-docs.terminus.ninja/master/components/TsRadioGroupComponent.html#readme
-[scrollbars-usage]:   http://uilibrary-docs.terminus.ninja/master/directives/TsScrollbarsComponent.html#readme
-[sort-usage]:         http://uilibrary-docs.terminus.ninja/master/directives/TsSortDirective.html#readme
-[table-usage]:        http://uilibrary-docs.terminus.ninja/master/components/TsTableComponent.html#readme
-[validators-usage]:   http://uilibrary-docs.terminus.ninja/master/injectables/TsValidatorsService.html#readme
+[autocomplete-usage]:    http://uilibrary-docs.terminus.ninja/master/components/TsAutocompleteComponent.html#readme
+[autofocus-usage]:       http://uilibrary-docs.terminus.ninja/master/directives/TsAutofocusDirective.html#readme
+[card-usage]:            http://uilibrary-docs.terminus.ninja/master/components/TsCardComponent.html#readme
+[chart-usage]:           http://uilibrary-docs.terminus.ninja/master/components/TsChartComponent.html#readme
+[checkbox-usage]:        http://uilibrary-docs.terminus.ninja/master/components/TsCheckboxComponent.html#readme
+[confirmation-usage]:    http://uilibrary-docs.terminus.ninja/master/directives/TsConfirmationDirective.html#readme
+[csv-entry-usage]:       http://uilibrary-docs.terminus.ninja/master/components/TsCSVEntryComponent.html#readme
+[date-range-usage]:      http://uilibrary-docs.terminus.ninja/master/components/TsDateRangeComponent.html#readme
+[datepicker-usage]:      http://uilibrary-docs.terminus.ninja/master/components/TsDatepickerComponent.html#readme
+[expansion-panel-usage]: http://uilibrary-docs.terminus.ninja/master/components/TsExpansionPanelComponent.html#readme
+[file-upload-usage]:     http://uilibrary-docs.terminus.ninja/master/components/TsFileUploadComponent.html#readme
+[icon-button-usage]:     http://uilibrary-docs.terminus.ninja/master/components/TsIconButtonComponent.html#readme
+[icon-usage]:            http://uilibrary-docs.terminus.ninja/master/components/TsIconComponent.html#readme
+[input-usage]:           http://uilibrary-docs.terminus.ninja/master/components/TsInputComponent.html#readme
+[link-usage]:            http://uilibrary-docs.terminus.ninja/master/components/TsLinkComponent.html#readme
+[logo-usage]:            http://uilibrary-docs.terminus.ninja/master/components/TsLogoComponent.html#readme
+[menu-usage]:            http://uilibrary-docs.terminus.ninja/master/components/TsMenuComponent.html#readme
+[paginator-usage]:       http://uilibrary-docs.terminus.ninja/master/components/TsPaginatorComponent.html#readme
+[navigation-usage]:      http://uilibrary-docs.terminus.ninja/master/components/TsNavigationComponent.html#readme
+[radio-group-usage]:     http://uilibrary-docs.terminus.ninja/master/components/TsRadioGroupComponent.html#readme
+[scrollbars-usage]:      http://uilibrary-docs.terminus.ninja/master/directives/TsScrollbarsComponent.html#readme
+[sort-usage]:            http://uilibrary-docs.terminus.ninja/master/directives/TsSortDirective.html#readme
+[table-usage]:           http://uilibrary-docs.terminus.ninja/master/components/TsTableComponent.html#readme
+[validators-usage]:      http://uilibrary-docs.terminus.ninja/master/injectables/TsValidatorsService.html#readme

--- a/demo/app/app.module.ts
+++ b/demo/app/app.module.ts
@@ -48,6 +48,7 @@ import { TsConfirmationModule } from '@terminus/ui/confirmation';
 import { TsCopyModule } from '@terminus/ui/copy';
 import { TsCSVEntryModule } from '@terminus/ui/csv-entry';
 import { TsDateRangeModule } from '@terminus/ui/date-range';
+import { TsExpansionPanelModule } from '@terminus/ui/expansion-panel';
 import { TsFileUploadModule } from '@terminus/ui/file-upload';
 import { TsIconButtonModule } from '@terminus/ui/icon-button';
 import { TsIconModule } from '@terminus/ui/icon';
@@ -93,6 +94,7 @@ import { ConfirmationComponent } from './components/confirmation/confirmation.co
 import { CopyComponent } from './components/copy/copy.component';
 import { CSVEntryComponent } from './components/csv-entry/csv-entry.component';
 import { DateRangeComponent } from './components/date-range/date-range.component';
+import { ExpansionPanelComponent } from './components/expansion-panel/expansion-panel.component';
 import { FileUploadComponent } from './components/file-upload/file-upload.component';
 import { IconButtonComponent } from './components/icon-button/icon-button.component';
 import { IconComponent } from './components/icon/icon.component';
@@ -145,6 +147,7 @@ import { ValidationComponent } from './components/validation/validation.componen
     TsCopyModule,
     TsCSVEntryModule,
     TsDateRangeModule,
+    TsExpansionPanelModule,
     TsFileUploadModule,
     TsIconButtonModule,
     TsIconModule,
@@ -193,6 +196,7 @@ import { ValidationComponent } from './components/validation/validation.componen
     CopyComponent,
     CSVEntryComponent,
     DateRangeComponent,
+    ExpansionPanelComponent,
     FileUploadComponent,
     IconButtonComponent,
     IconComponent,

--- a/demo/app/components/components.constant.ts
+++ b/demo/app/components/components.constant.ts
@@ -11,6 +11,7 @@ import { ConfirmationComponent } from './confirmation/confirmation.component';
 import { CopyComponent } from './copy/copy.component';
 import { CSVEntryComponent } from './csv-entry/csv-entry.component';
 import { DateRangeComponent } from './date-range/date-range.component';
+import { ExpansionPanelComponent } from './expansion-panel/expansion-panel.component';
 import { FileUploadComponent } from './file-upload/file-upload.component';
 import { IconButtonComponent } from './icon-button/icon-button.component';
 import { IconComponent } from './icon/icon.component';
@@ -114,6 +115,13 @@ export const componentsList: Routes = [
     component: DateRangeComponent,
     data: {
       name: 'Date Range',
+    },
+  },
+  {
+    path: 'expansion-panel',
+    component: ExpansionPanelComponent,
+    data: {
+      name: 'Expansion Panel',
     },
   },
   {

--- a/demo/app/components/expansion-panel/expansion-panel.component.html
+++ b/demo/app/components/expansion-panel/expansion-panel.component.html
@@ -1,0 +1,232 @@
+
+<div tsVerticalSpacing>
+  <h3 tsVerticalSpacing>Single panel</h3>
+
+  <ts-expansion-panel>
+    <ts-expansion-panel-trigger>
+      Here is my trigger!
+    </ts-expansion-panel-trigger>
+
+    <p>
+      And here is my standard panel content.
+    </p>
+
+    <p>
+      Delectus ex maiores deleniti dolor earum minima possimus. Minima excepturi vel quos accusamus. Cupiditate cum ut iure modi.
+    </p>
+
+    <p>
+      Consequatur fugiat eius placeat tenetur consectetur labore. Laborum architecto animi. Inventore quod unde ea quae doloribus maxime.
+    </p>
+  </ts-expansion-panel>
+
+</div>
+
+
+<div tsVerticalSpacing>
+  <h3 tsVerticalSpacing>Accordion</h3>
+
+  <ts-checkbox [(ngModel)]="allowMultiple" tsVerticalSpacing>
+    Allow multiple panels to be open
+  </ts-checkbox>
+
+  <ts-accordion [multi]="allowMultiple">
+    <ts-expansion-panel>
+      <ts-expansion-panel-trigger>
+        <ts-expansion-panel-trigger-title>
+          Panel 1
+        </ts-expansion-panel-trigger-title>
+        <ts-expansion-panel-trigger-description>
+          Quod voluptatem corporis soluta assumenda.
+        </ts-expansion-panel-trigger-description>
+      </ts-expansion-panel-trigger>
+
+      And here is my standard panel content.
+    </ts-expansion-panel>
+
+    <ts-expansion-panel>
+      <ts-expansion-panel-trigger>
+        <ts-expansion-panel-trigger-title>
+          Panel 2
+        </ts-expansion-panel-trigger-title>
+        <ts-expansion-panel-trigger-description>
+          Nemo magnam commodi unde.
+        </ts-expansion-panel-trigger-description>
+      </ts-expansion-panel-trigger>
+
+      And here is my standard panel content.
+    </ts-expansion-panel>
+
+    <ts-expansion-panel>
+      <ts-expansion-panel-trigger>
+        <ts-expansion-panel-trigger-title>
+          Panel 3
+        </ts-expansion-panel-trigger-title>
+        <ts-expansion-panel-trigger-description>
+          Quod voluptatem corporis soluta assumenda.
+        </ts-expansion-panel-trigger-description>
+      </ts-expansion-panel-trigger>
+
+      And here is my standard panel content.
+    </ts-expansion-panel>
+  </ts-accordion>
+</div>
+
+
+<div tsVerticalSpacing>
+  <h3 tsVerticalSpacing>Accordion with a disabled panel</h3>
+
+  <ts-accordion>
+    <ts-expansion-panel>
+      <ts-expansion-panel-trigger>
+        Panel 1
+      </ts-expansion-panel-trigger>
+
+      <p>
+      And here is my standard panel content.
+      </p>
+    </ts-expansion-panel>
+
+    <ts-expansion-panel [isDisabled]="true">
+      <ts-expansion-panel-trigger>
+        <ts-expansion-panel-trigger-title>
+          Panel 2
+        </ts-expansion-panel-trigger-title>
+        <ts-expansion-panel-trigger-description>
+          And here is the description
+        </ts-expansion-panel-trigger-description>
+      </ts-expansion-panel-trigger>
+
+      <p>
+      And here is my standard panel content.
+      </p>
+    </ts-expansion-panel>
+  </ts-accordion>
+</div>
+
+
+
+
+<div tsVerticalSpacing>
+  <h3 tsVerticalSpacing>Event emitters</h3>
+
+  <ts-checkbox [(ngModel)]="loadPanel" tsVerticalSpacing>
+    Load panel (ngIf)
+  </ts-checkbox>
+
+  <ts-expansion-panel
+    *ngIf="loadPanel"
+    (opened)="panelOpened()"
+    (closed)="panelClosed()"
+    (expandedChange)="panelExpandedChange($event)"
+    (destroyed)="panelDestroyed()"
+    (afterExpand)="afterPanelExpanded()"
+    (afterCollapse)="afterPanelCollapsed()"
+  >
+    <ts-expansion-panel-trigger>
+      Panel Trigger
+    </ts-expansion-panel-trigger>
+
+    And here is my standard panel content.
+  </ts-expansion-panel>
+
+</div>
+
+
+<div tsVerticalSpacing>
+  <h3 tsVerticalSpacing>Panel with custom trigger heights</h3>
+
+  <ts-expansion-panel>
+    <ts-expansion-panel-trigger
+      collapsedHeight="100px"
+      expandedHeight="200px"
+    >
+      Panel Trigger (100px -> 200px)
+    </ts-expansion-panel-trigger>
+
+    And here is my standard panel content.
+  </ts-expansion-panel>
+
+</div>
+
+
+<div tsVerticalSpacing>
+  <h3 tsVerticalSpacing>Panel with lazy loaded template</h3>
+
+  <ts-expansion-panel>
+    <ts-expansion-panel-trigger>
+      Panel Trigger
+    </ts-expansion-panel-trigger>
+
+    <ng-template tsExpansionPanelContent>
+      Here is my deferred template!
+    </ng-template>
+  </ts-expansion-panel>
+
+</div>
+
+
+<div tsVerticalSpacing>
+  <h3 tsVerticalSpacing>Accordion as a stepper</h3>
+
+  <ts-accordion [hideToggle]="true">
+    <ts-expansion-panel [isExpanded]="activeStep === 0">
+      <ts-expansion-panel-trigger>
+        Step 1
+      </ts-expansion-panel-trigger>
+
+      And here is my standard panel content.
+
+      <ts-expansion-panel-action-row>
+        <ts-button (click)="nextStep()">
+          Next
+        </ts-button>
+      </ts-expansion-panel-action-row>
+    </ts-expansion-panel>
+
+    <ts-expansion-panel [isExpanded]="activeStep === 1">
+      <ts-expansion-panel-trigger>
+        <ts-expansion-panel-trigger-title>
+          Step 2
+        </ts-expansion-panel-trigger-title>
+        <ts-expansion-panel-trigger-description>
+          And here is the description
+        </ts-expansion-panel-trigger-description>
+      </ts-expansion-panel-trigger>
+
+      And here is my standard panel content.
+
+      <ts-expansion-panel-action-row>
+        <ts-button format="hollow" (click)="previousStep()">
+          Previous
+        </ts-button>
+        <ts-button (click)="nextStep()">
+          Next
+        </ts-button>
+      </ts-expansion-panel-action-row>
+    </ts-expansion-panel>
+
+    <ts-expansion-panel [isExpanded]="activeStep === 2">
+      <ts-expansion-panel-trigger>
+        <ts-expansion-panel-trigger-title>
+          Step 3
+        </ts-expansion-panel-trigger-title>
+        <ts-expansion-panel-trigger-description>
+          Quod voluptatem corporis soluta assumenda. Nemo magnam commodi unde.
+        </ts-expansion-panel-trigger-description>
+      </ts-expansion-panel-trigger>
+
+      And here is my standard panel content.
+
+      <ts-expansion-panel-action-row>
+        <ts-button format="hollow" (click)="previousStep()">
+          Previous
+        </ts-button>
+        <ts-button (click)="nextStep()">
+          End
+        </ts-button>
+      </ts-expansion-panel-action-row>
+    </ts-expansion-panel>
+  </ts-accordion>
+
+</div>

--- a/demo/app/components/expansion-panel/expansion-panel.component.ts
+++ b/demo/app/components/expansion-panel/expansion-panel.component.ts
@@ -1,0 +1,51 @@
+import { Component } from '@angular/core';
+
+
+@Component({
+  selector: 'demo-expansion-panel',
+  templateUrl: './expansion-panel.component.html',
+})
+export class ExpansionPanelComponent {
+  loadPanel = true;
+  allowMultiple = false;
+  activeStep = 0;
+
+
+  panelOpened() {
+    console.log('DEMO: Panel opened');
+  }
+
+  panelClosed() {
+    console.log('DEMO: Panel closed');
+  }
+
+  panelExpandedChange(event) {
+    console.log('DEMO: Panel expanded state changed: ', event);
+  }
+
+  panelDestroyed() {
+    console.log('DEMO: Panel destroyed');
+  }
+
+  afterPanelExpanded() {
+    console.log('DEMO: Panel expand animation finished');
+  }
+
+  afterPanelCollapsed() {
+    console.log('DEMO: Panel collapse animation finished');
+  }
+
+
+  nextStep() {
+    this.activeStep++;
+  }
+
+  previousStep() {
+    this.activeStep--;
+  }
+
+  setStep(index) {
+    this.activeStep = index;
+  }
+
+}

--- a/terminus-ui/expansion-panel/package.json
+++ b/terminus-ui/expansion-panel/package.json
@@ -1,0 +1,10 @@
+{
+  "ngPackage": {
+    "lib": {
+      "entryFile": "src/public-api.ts",
+      "umdModuleIds": {
+        "@terminus/ngx-tools": "terminus.ngxTools"
+      }
+    }
+  }
+}

--- a/terminus-ui/expansion-panel/src/accordion/accordion-base.ts
+++ b/terminus-ui/expansion-panel/src/accordion/accordion-base.ts
@@ -1,0 +1,31 @@
+import { InjectionToken } from '@angular/core';
+import { CdkAccordion } from '@angular/cdk/accordion';
+
+
+/**
+ * Base interface for a {@link TsAccordionComponent}
+ */
+export interface TsAccordionBase extends CdkAccordion {
+  /**
+   * Handle keyboard events coming in from the panel triggers
+   */
+  handleTriggerKeydown: (event: KeyboardEvent) => void;
+
+  /**
+   * Handle focus events on the panel triggers
+   */
+  handleTriggerFocus: (trigger: any) => void;
+
+  /**
+   * Determine if the toggle icon should be hidden
+   */
+  hideToggle: boolean;
+}
+
+
+/**
+ * Token used to provide a {@link TsAccordionComponent} to {@link TsExpansionPanelComponent}.
+ *
+ * Used primarily to avoid circular imports between `TsAccordionComponent` and `TsExpansionPanelComponent`.
+ */
+export const TS_ACCORDION = new InjectionToken<TsAccordionBase>('TS_ACCORDION');

--- a/terminus-ui/expansion-panel/src/accordion/accordion.component.spec.ts
+++ b/terminus-ui/expansion-panel/src/accordion/accordion.component.spec.ts
@@ -1,0 +1,203 @@
+import { Type } from '@angular/core';
+import { ComponentFixture } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import * as testComponents from '@terminus/ui/expansion-panel/testing';
+import {
+  createComponent as createComponentInner,
+  createKeyboardEvent,
+} from '@terminus/ngx-tools/testing';
+import {
+  END,
+  ENTER,
+  HOME,
+  SPACE,
+  A,
+} from '@terminus/ngx-tools/keycodes';
+import {
+  getPanelInstance,
+  togglePanel,
+  getAccordionInstance,
+  getTriggerElement,
+  getAccordionElement,
+} from '@terminus/ui/expansion-panel/testing';
+
+import { TsExpansionPanelModule } from './../expansion-panel.module';
+
+
+function createComponent<T>(component: Type<T>): ComponentFixture<T> {
+  return createComponentInner<T>(component, undefined, [TsExpansionPanelModule, NoopAnimationsModule]);
+}
+
+
+
+describe(`TsAccordionComponent`, function() {
+
+  test(`should be able to enforce a single panel open at a time`, function() {
+    const fixture = createComponent<testComponents.Accordion>(testComponents.Accordion);
+    fixture.detectChanges();
+    const panel1 = getPanelInstance(fixture);
+    const panel2 = getPanelInstance(fixture, 1);
+
+    expect(panel1.expanded).toEqual(false);
+    expect(panel2.expanded).toEqual(false);
+
+    togglePanel(fixture);
+    expect(panel1.expanded).toEqual(true);
+    expect(panel2.expanded).toEqual(false);
+
+    togglePanel(fixture, 1);
+    expect(panel1.expanded).toEqual(false);
+    expect(panel2.expanded).toEqual(true);
+
+    expect.assertions(6);
+  });
+
+
+  test(`should allow multiple panels to be open`, function() {
+    const fixture = createComponent<testComponents.AccordionMulti>(testComponents.AccordionMulti);
+    fixture.detectChanges();
+    const panel1 = getPanelInstance(fixture);
+    const panel2 = getPanelInstance(fixture, 1);
+
+    expect(panel1.expanded).toEqual(false);
+    expect(panel2.expanded).toEqual(false);
+
+    togglePanel(fixture);
+    expect(panel1.expanded).toEqual(true);
+    expect(panel2.expanded).toEqual(false);
+
+    togglePanel(fixture, 1);
+    expect(panel1.expanded).toEqual(true);
+    expect(panel2.expanded).toEqual(true);
+
+    expect.assertions(6);
+  });
+
+
+  test(`should be able to open or close all panels when multi is true`, function() {
+    const fixture = createComponent<testComponents.AccordionMulti>(testComponents.AccordionMulti);
+    fixture.detectChanges();
+    const accordion = getAccordionInstance(fixture);
+    const panel1 = getPanelInstance(fixture);
+    const panel2 = getPanelInstance(fixture, 1);
+
+    expect(panel1.expanded).toEqual(false);
+    expect(panel2.expanded).toEqual(false);
+
+    accordion.openAll();
+    expect(panel1.expanded).toEqual(true);
+    expect(panel2.expanded).toEqual(true);
+
+    accordion.closeAll();
+    expect(panel1.expanded).toEqual(false);
+    expect(panel2.expanded).toEqual(false);
+
+    expect.assertions(6);
+  });
+
+
+  test(`should be able to hide all toggle icons`, function() {
+    const fixture = createComponent<testComponents.HideToggleAccordion>(testComponents.HideToggleAccordion);
+    fixture.detectChanges();
+    const triggerElement1: HTMLElement = getTriggerElement(fixture);
+    const toggleIcon1 = triggerElement1.querySelector('.ts-expansion-panel__indicator');
+
+    const triggerElement2: HTMLElement = getTriggerElement(fixture);
+    const toggleIcon2 = triggerElement2.querySelector('.ts-expansion-panel__indicator');
+
+    expect(toggleIcon1).toBeNull();
+    expect(toggleIcon2).toBeNull();
+  });
+
+
+  describe(`Keyboard controls`, function() {
+
+    test(`should focus first trigger when HOME is used and the last when END is used`, function() {
+      const fixture = createComponent<testComponents.Accordion>(testComponents.Accordion);
+      fixture.detectChanges();
+      const accordion = getAccordionElement(fixture);
+      const trigger1 = getTriggerElement(fixture);
+      const trigger2 = getTriggerElement(fixture, 1);
+
+      expect(document.activeElement === trigger1).toEqual(false);
+      expect(document.activeElement === trigger2).toEqual(false);
+
+      // Non-special key to complete coverage
+      const keyEvent = createKeyboardEvent('keydown', A, trigger1);
+      trigger1.dispatchEvent(keyEvent);
+      fixture.detectChanges();
+
+      const homeEvent = createKeyboardEvent('keydown', HOME, trigger1);
+      trigger1.dispatchEvent(homeEvent);
+      fixture.detectChanges();
+
+      expect(document.activeElement === trigger1).toEqual(true);
+      expect(document.activeElement === trigger2).toEqual(false);
+
+      const endEvent = createKeyboardEvent('keydown', END, trigger1);
+      trigger1.dispatchEvent(endEvent);
+      fixture.detectChanges();
+
+      expect(document.activeElement === trigger1).toEqual(false);
+      expect(document.activeElement === trigger2).toEqual(true);
+    });
+
+
+    // NOTE: ngx-tools `createKeyboardEvent` function seems to generate an event
+    // where `event.metaKey` is true which does not work for this test.
+    test(`should toggle a panel when SPACE or ENTER is used`, function() {
+      const fixture = createComponent<testComponents.Accordion>(testComponents.Accordion);
+      fixture.detectChanges();
+      const accordion = getAccordionElement(fixture);
+
+      const panel1 = getPanelInstance(fixture);
+      const trigger1 = getTriggerElement(fixture);
+
+      const panel2 = getPanelInstance(fixture, 1);
+      const trigger2 = getTriggerElement(fixture, 1);
+
+      const spaceEvent = document.createEvent('KeyboardEvent');
+      spaceEvent.initEvent('keydown', true, false);
+      Object.defineProperties(spaceEvent, {
+        keyCode: { get: () => SPACE },
+        key: { get: () => 'Space' },
+      });
+      const enterEvent = document.createEvent('KeyboardEvent');
+      enterEvent.initEvent('keydown', true, false);
+      Object.defineProperties(enterEvent, {
+        keyCode: { get: () => ENTER },
+        key: { get: () => 'Enter' },
+      });
+
+      trigger1.dispatchEvent(spaceEvent);
+      fixture.detectChanges();
+
+      expect(panel1.expanded).toEqual(true);
+      expect(panel2.expanded).toEqual(false);
+
+      trigger2.dispatchEvent(enterEvent);
+      fixture.detectChanges();
+
+      expect(panel1.expanded).toEqual(false);
+      expect(panel2.expanded).toEqual(true);
+    });
+
+  });
+
+
+  describe(`Events`, function() {
+
+    test(`should emit when destroyed`, function() {
+      const fixture = createComponent<testComponents.AccordionDestroyed>(testComponents.AccordionDestroyed);
+      fixture.detectChanges();
+      const host = fixture.componentInstance;
+      host.destroyed = jest.fn();
+      const accordion = getAccordionInstance(fixture);
+      accordion.ngOnDestroy();
+
+      expect(host.destroyed).toHaveBeenCalledTimes(1);
+    });
+
+  });
+
+});

--- a/terminus-ui/expansion-panel/src/accordion/accordion.component.ts
+++ b/terminus-ui/expansion-panel/src/accordion/accordion.component.ts
@@ -1,0 +1,145 @@
+import {
+  AfterContentInit,
+  ChangeDetectionStrategy,
+  Component,
+  ContentChildren,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  Output,
+  QueryList,
+  ViewEncapsulation,
+} from '@angular/core';
+import { CdkAccordion } from '@angular/cdk/accordion';
+import { FocusKeyManager } from '@angular/cdk/a11y';
+import {
+  END,
+  HOME,
+} from '@terminus/ngx-tools/keycodes';
+
+import {
+  TS_ACCORDION,
+  TsAccordionBase,
+} from './accordion-base';
+import { TsExpansionPanelTriggerComponent } from './../trigger/expansion-panel-trigger.component';
+import { TsExpansionPanelComponent } from '../expansion-panel.component';
+
+
+/**
+ * Component to allow multiple {@link TsExpansionPanelComponent}'s to function as an accordion.
+ *
+ * @example
+ * <ts-accordion
+ *               [multi]="true"
+ *               [hideToggle]="true"
+ *               (destroyed)="accordionDestroyed()"
+ * >
+ *               <ts-expansion-panel>
+ *                 ...
+ *               </ts-expansion-panel>
+ *
+ *               <ts-expansion-panel>
+ *                 ...
+ *               </ts-expansion-panel>
+ *
+ *               <ts-expansion-panel>
+ *                 ...
+ *               </ts-expansion-panel>
+ * </ts-accordion>
+ *
+ * <example-url>https://getterminus.github.io/ui-demos-master/components/expansion-panel</example-url>
+ */
+@Component({
+  selector: 'ts-accordion',
+  template: `<ng-content></ng-content>`,
+  // NOTE: @Inputs are defined here rather than using decorators since we are extending the @Inputs of the base class
+  // tslint:disable: use-input-property-decorator
+  inputs: ['multi'],
+  providers: [
+    {
+      provide: TS_ACCORDION,
+      useExisting: TsAccordionComponent,
+    },
+  ],
+  host: {
+    class: 'ts-accordion',
+  },
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'tsAccordion',
+})
+export class TsAccordionComponent extends CdkAccordion implements TsAccordionBase, AfterContentInit, OnDestroy {
+  /**
+   * Store a reference to the key manager
+   */
+  private keyManager!: FocusKeyManager<TsExpansionPanelTriggerComponent>;
+
+  /**
+   * Collect a list of all triggers
+   */
+  @ContentChildren(TsExpansionPanelTriggerComponent, {descendants: true})
+  public triggers!: QueryList<TsExpansionPanelTriggerComponent>;
+
+  /**
+   * Determine if the toggle indicator should be hidden
+   */
+  @Input()
+  public set hideToggle(value: boolean) {
+    this._hideToggle = value;
+  }
+  public get hideToggle(): boolean {
+    return this._hideToggle;
+  }
+  private _hideToggle = false;
+
+  /**
+   * The event emitted as the accordion is destroyed
+   */
+  @Output()
+  public destroyed: EventEmitter<void> = new EventEmitter();
+
+
+  /**
+   * Initialize the key manager
+   */
+  public ngAfterContentInit(): void {
+    this.keyManager = new FocusKeyManager(this.triggers).withWrap();
+  }
+
+
+  /**
+   * Alert consumers when the accordion is destroyed
+   */
+  public ngOnDestroy(): void {
+    this.destroyed.emit();
+  }
+
+  /**
+   * Handle keyboard events coming in from the panel triggers
+   */
+  public handleTriggerKeydown(event: KeyboardEvent): void {
+    const {keyCode} = event;
+    const manager = this.keyManager;
+
+    if (keyCode === HOME) {
+      manager.setFirstItemActive();
+      event.preventDefault();
+    } else if (keyCode === END) {
+      manager.setLastItemActive();
+      event.preventDefault();
+    } else {
+      this.keyManager.onKeydown(event);
+    }
+  }
+
+
+  /**
+   * Handle focus events for the trigger
+   *
+   * @param trigger - The trigger component that is receiving focus
+   */
+  public handleTriggerFocus(trigger: TsExpansionPanelTriggerComponent): void {
+    this.keyManager.updateActiveItem(trigger);
+  }
+
+}

--- a/terminus-ui/expansion-panel/src/expansion-animations.ts
+++ b/terminus-ui/expansion-panel/src/expansion-animations.ts
@@ -1,0 +1,84 @@
+import {
+  animate,
+  animateChild,
+  AnimationTriggerMetadata,
+  group,
+  query,
+  state,
+  style,
+  transition,
+  trigger,
+} from '@angular/animations';
+
+
+/**
+ * Time and timing curve for expansion panel animation
+ */
+export const TS_EXPANSION_PANEL_ANIMATION_TIMING = '225ms cubic-bezier(0.4,0.0,0.2,1)';
+
+
+/**
+ * Animations used by the Material expansion panel.
+ *
+ * A bug in angular animation's `state` when ViewContainers are moved using ViewContainerRef.move()
+ * causes the animation state of moved components to become `void` upon exit, and not update again
+ * upon reentry into the DOM.  This can lead to a situation for the expansion panel where the state
+ * of the panel is `expanded` or `collapsed` but the animation state is `void`.
+ *
+ * To correctly handle animating to the next state, we animate between `void` and `collapsed` which
+ * are defined to have the same styles. Since angular animates from the current styles to the
+ * destination state's style definition, in situations where we are moving from `void`'s styles to
+ * `collapsed` this acts a noop since no style values change.
+ *
+ * In the case where angular's animation state is out of sync with the expansion panel's state, the
+ * expansion panel being `expanded` and angular animations being `void`, the animation from the
+ * `expanded`'s effective styles (though in a `void` animation state) to the collapsed state will
+ * occur as expected.
+ *
+ * Angular Bug: https://github.com/angular/angular/issues/18847
+ */
+export const tsExpansionPanelAnimations: {
+  readonly indicatorRotate: AnimationTriggerMetadata;
+  readonly expansionTriggerHeight: AnimationTriggerMetadata;
+  readonly bodyExpansion: AnimationTriggerMetadata;
+} = {
+  /**
+   * Animation that rotates the indicator arrow
+   */
+  indicatorRotate: trigger('indicatorRotate', [
+    state('collapsed, void', style({transform: 'rotate(0deg)'})),
+    state('expanded', style({transform: 'rotate(180deg)'})),
+    transition('expanded <=> collapsed, void => collapsed',
+      animate(TS_EXPANSION_PANEL_ANIMATION_TIMING)),
+  ]),
+
+  /**
+   * Animation that expands and collapses the panel trigger height
+   */
+  expansionTriggerHeight: trigger('expansionHeight', [
+    state('collapsed, void', style({
+      height: '{{collapsedHeight}}',
+    }), {
+      params: {collapsedHeight: '48px'},
+    }),
+    state('expanded', style({
+      height: '{{expandedHeight}}',
+    }), {
+      params: {expandedHeight: '64px'},
+    }),
+    transition('expanded <=> collapsed, void => collapsed', group([
+      query('@indicatorRotate', animateChild(), {optional: true}),
+      animate(TS_EXPANSION_PANEL_ANIMATION_TIMING),
+    ])),
+  ]),
+
+  /**
+   * Animation that expands and collapses the panel content
+   */
+  bodyExpansion: trigger('bodyExpansion', [
+    state('collapsed, void', style({height: '0px', visibility: 'hidden'})),
+    state('expanded', style({height: '*', visibility: 'visible'})),
+    transition('expanded <=> collapsed, void => collapsed',
+    animate(TS_EXPANSION_PANEL_ANIMATION_TIMING)),
+  ]),
+};

--- a/terminus-ui/expansion-panel/src/expansion-panel-action-row.ts
+++ b/terminus-ui/expansion-panel/src/expansion-panel-action-row.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+
+
+/**
+ * {@link TsExpansionPanelComponent} action row that will be rendered at the bottom of the panel.
+ *
+ * @example
+ * <ts-expansion-panel>
+ *               <ts-expansion-panel-trigger>
+ *                 Panel trigger
+ *               </ts-expansion-panel-trigger>
+ *
+ *               Panel content
+ *
+ *               <ts-expansion-panel-action-row>
+ *                 <button>Next</button>
+ *               </ts-expansion-panel-action-row>
+ * </ts-expansion-panel>
+ *
+ * <example-url>https://getterminus.github.io/ui-demos-master/components/expansion-panel</example-url>
+ */
+@Component({
+  selector: 'ts-expansion-panel-action-row',
+  template:  `<ng-content></ng-content>`,
+  host: {
+    class: 'ts-expansion-panel__action-row',
+  },
+})
+export class TsExpansionPanelActionRowComponent {}

--- a/terminus-ui/expansion-panel/src/expansion-panel-content.directive.ts
+++ b/terminus-ui/expansion-panel/src/expansion-panel-content.directive.ts
@@ -1,0 +1,28 @@
+import {
+  Directive,
+  TemplateRef,
+} from '@angular/core';
+
+
+/**
+ * {@link TsExpansionPanelComponent} content that will be rendered lazily when the panel is opened for the first time.
+ *
+ * @example
+ * <ts-expansion-panel>
+ *               <ts-expansion-panel-trigger>
+ *                 Panel trigger
+ *               </ts-expansion-panel-trigger>
+ *
+ *               <ng-template tsExpansionPanelContent>
+ *                 Panel content
+ *               </ng-template>
+ * </ts-expansion-panel>
+ *
+ * <example-url>https://getterminus.github.io/ui-demos-master/components/expansion-panel</example-url>
+ */
+@Directive({
+  selector: 'ng-template[tsExpansionPanelContent]',
+})
+export class TsExpansionPanelContentDirective {
+  constructor(public template: TemplateRef<any>) {}
+}

--- a/terminus-ui/expansion-panel/src/expansion-panel.component.html
+++ b/terminus-ui/expansion-panel/src/expansion-panel.component.html
@@ -1,0 +1,19 @@
+<ng-content select="ts-expansion-panel-trigger"></ng-content>
+
+<div
+  class="ts-expansion-panel__content"
+  role="region"
+  [@bodyExpansion]="currentExpandedState"
+  (@bodyExpansion.done)="bodyAnimationDone.next($event)"
+  [attr.aria-labelledby]="triggerId"
+  [attr.aria-hidden]="!expanded"
+  [id]="id"
+  #panelBody
+>
+  <div class="ts-expansion-panel__body">
+    <ng-content></ng-content>
+    <ng-template [cdkPortalOutlet]="portal"></ng-template>
+  </div>
+
+  <ng-content select="ts-expansion-panel-action-row"></ng-content>
+</div>

--- a/terminus-ui/expansion-panel/src/expansion-panel.component.md
+++ b/terminus-ui/expansion-panel/src/expansion-panel.component.md
@@ -1,0 +1,373 @@
+<h1>Expansion Panel</h1>
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [Basic usage](#basic-usage)
+  - [Title and description](#title-and-description)
+  - [Disable a panel](#disable-a-panel)
+  - [Default a panel open](#default-a-panel-open)
+  - [Lazy loaded content](#lazy-loaded-content)
+  - [Panel events](#panel-events)
+  - [Custom trigger heights](#custom-trigger-heights)
+  - [Manual panel control](#manual-panel-control)
+- [Accordion](#accordion)
+  - [Allow mutiple panels to be open](#allow-mutiple-panels-to-be-open)
+  - [Accordion events](#accordion-events)
+  - [Accordion as a stepper](#accordion-as-a-stepper)
+  - [Hide toggle](#hide-toggle)
+  - [Action row](#action-row)
+  - [Open or close all panels](#open-or-close-all-panels)
+- [Test Helpers](#test-helpers)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
+
+
+## Basic usage
+
+The most basic usage is a single panel with a trigger:
+
+```html
+<ts-expansion-panel>
+  <ts-expansion-panel-trigger>
+    Here is my trigger!
+  </ts-expansion-panel-trigger>
+
+  <p>And here is my standard panel content.</p>
+</ts-expansion-panel>
+```
+
+> NOTE: Without a trigger, the panel will not be visible.
+
+
+### Title and description
+
+Trigger text can be split into `title` and `description` using the `TsExpansionPanelTitleComponent` and
+`TsExpansionPanelDescriptionComponent` respectively.
+
+```html
+<!-- Standard trigger -->
+<ts-expansion-panel-trigger>
+  Here is my trigger!
+</ts-expansion-panel-trigger>
+
+
+<!-- Trigger with title and description -->
+<ts-expansion-panel-trigger>
+  <ts-expansion-panel-trigger-title>
+    My title
+  </ts-expansion-panel-trigger-title>
+
+  <ts-expansion-panel-trigger-description>
+    My description
+  </ts-expansion-panel-trigger-description>
+</ts-expansion-panel-trigger>
+```
+
+
+### Disable a panel
+
+The `isDisabled` flag will disable a panel and it's trigger.
+
+```html
+<ts-expansion-panel [isDisabled]="true">
+  <ts-expansion-panel-trigger>
+    Here is my trigger!
+  </ts-expansion-panel-trigger>
+
+  <p>I will never be seen.</p>
+</ts-expansion-panel>
+```
+
+
+### Default a panel open
+
+The `isExpanded` flag will change the state of a panel. This can be used to default to a specific state or to dynamically change the state.
+
+```html
+<ts-expansion-panel [isExpanded]="true">
+  <ts-expansion-panel-trigger>
+    Here is my trigger!
+  </ts-expansion-panel-trigger>
+
+  <p>I'll be visible by default!</p>
+</ts-expansion-panel>
+```
+
+
+### Lazy loaded content
+
+Panel content can be lazily loaded by using a template with the `tsExpansionPanelContent` directive. The template will not be loaded until
+the panel is opened for the first time. The content will remain in the DOM until the panel is destroyed.
+
+```html
+<ts-expansion-panel>
+  <ts-expansion-panel-trigger>
+    Here is my trigger!
+  </ts-expansion-panel-trigger>
+
+  <ng-template tsExpansionPanelContent>
+    Here is my deferred template!
+  </ng-template>
+</ts-expansion-panel>
+```
+
+
+### Panel events
+
+| Event            | Description                                        | Payload   |
+|:-----------------|:---------------------------------------------------|:----------|
+| `opened`         | Fired when the panel is opened                     | `void`    |
+| `afterExpand`    | Fired after the panel expansion animation finishes | `void`    |
+| `closed`         | Fired when the panel is closed                     | `void`    |
+| `afterCollapse`  | Fired after the panel collapse animation finishes  | `void`    |
+| `expandedChange` | Fired when the panel state changes                 | `boolean` |
+| `destroyed`      | Fired when the panel is destroyed                  | `void`    |
+
+```html
+<ts-expansion-panel (opened)="myFunction()">
+  ...
+</ts-expansion-panel>
+```
+
+
+### Custom trigger heights
+
+Custom heights can be set for a trigger's collapsed and/or expanded state.
+
+```html
+<ts-expansion-panel>
+  <!-- When collapsed the trigger will be 100px tall
+       When expanded the trigger will be 200px tall -->
+  <ts-expansion-panel-trigger
+    collapsedHeight="100px"
+    expandedHeight="200px"
+  >
+    Panel Trigger (100px -> 200px)
+  </ts-expansion-panel-trigger>
+
+  And here is my standard panel content.
+</ts-expansion-panel>
+```
+
+### Manual panel control
+
+Panels can be programatically opened, closed or toggled through a reference to the instance.
+
+```typescript
+@ViewChild(TsExpansionPanelComponent)
+public panel: TsExpansionPanelComponent;
+
+...
+
+panel.open();
+panel.close();
+panel.toggle();
+```
+
+> NOTE: Disabled panels cannot be controlled with these methods. Disabled panels can _only_ be controlled via the `isExpanded` input.
+
+
+## Accordion
+
+An accordion is created by wrapping two or more `TsExpansionPanelComponent`s inside a `TsAccordionComponent`.
+
+```html
+<ts-accordion>
+  <ts-expansion-panel>
+    ...
+  </ts-expansion-panel>
+
+  <ts-expansion-panel>
+    ...
+  </ts-expansion-panel>
+</ts-accordion>
+```
+
+
+### Allow mutiple panels to be open
+
+By default an accordion can only have a single panel open at a time. This functionality can be change with the `multi` input.
+
+```html
+<ts-accordion [multi]="true">
+  <ts-expansion-panel>
+    ...
+  </ts-expansion-panel>
+
+  <ts-expansion-panel>
+    ...
+  </ts-expansion-panel>
+</ts-accordion>
+```
+
+
+### Accordion events
+
+| Event       | Description                           | Payload |
+|:------------|:--------------------------------------|:--------|
+| `destroyed` | Fired when the accordion is destroyed | `void`  |
+
+```html
+<ts-accordion (destroyed)="myFunction()">
+  ...
+</ts-accordion>
+```
+
+### Accordion as a stepper
+
+An accordion can function as a stepper which can be useful for guided flows. To facilitate this we can use a combination of `hideToggle` and
+the `ts-expansion-panel-action-row`.
+
+```html
+<!-- Hide the toggle icon since this is a programatically controlled flow -->
+<ts-accordion [hideToggle]="true">
+  <!-- STEP 1 -->
+  <ts-expansion-panel [isExpanded]="activeStep === 0">
+    <ts-expansion-panel-trigger>
+      Step 1
+    </ts-expansion-panel-trigger>
+
+    And here is my standard panel content.
+
+    <ts-expansion-panel-action-row>
+      <ts-button (click)="nextStep()">
+        Next
+      </ts-button>
+    </ts-expansion-panel-action-row>
+  </ts-expansion-panel>
+
+  <!-- STEP 2 -->
+  <ts-expansion-panel [isExpanded]="activeStep === 1">
+    <ts-expansion-panel-trigger>
+      Step 2
+    </ts-expansion-panel-trigger>
+
+    And here is my standard panel content.
+
+    <ts-expansion-panel-action-row>
+      <ts-button format="hollow" (click)="previousStep()">
+        Previous
+      </ts-button>
+      <ts-button (click)="nextStep()">
+        Next
+      </ts-button>
+    </ts-expansion-panel-action-row>
+  </ts-expansion-panel>
+
+  <!-- STEP 3 -->
+  <ts-expansion-panel [isExpanded]="activeStep === 2">
+    <ts-expansion-panel-trigger>
+      Step 3
+    </ts-expansion-panel-trigger>
+
+    And here is my standard panel content.
+
+    <ts-expansion-panel-action-row>
+      <ts-button format="hollow" (click)="previousStep()">
+        Previous
+      </ts-button>
+      <ts-button (click)="nextStep()">
+        End
+      </ts-button>
+    </ts-expansion-panel-action-row>
+  </ts-expansion-panel>
+</ts-accordion>
+```
+
+### Hide toggle
+
+When an accordion is controlled programatically, the toggle icon can be hidden to avoid confusion for the user. Setting `hideToggle` on the
+accordion will hide the toggle icon for *all panels within*.
+
+> NOTE: This should _only_ be used in cases when the accordion is functioning as a stepper.
+
+```html
+<ts-accordion [hideToggle]="true">
+  <ts-expansion-panel>
+    ...
+  </ts-expansion-panel>
+
+  <ts-expansion-panel>
+    ...
+  </ts-expansion-panel>
+</ts-accordion>
+```
+
+
+### Action row
+
+The action row is useful when an accordion is functioning as a stepper. Controls added within the action row will be right aligned as panel
+controls.
+
+> NOTE: See [Accordion as a stepper](#accordion-as-a-stepper) for a complete example.
+
+```html
+<ts-expansion-panel>
+  <ts-expansion-panel-trigger>
+    Step 1
+  </ts-expansion-panel-trigger>
+
+  And here is my standard panel content.
+
+  <ts-expansion-panel-action-row>
+    <button (click)="nextStep()">Next</button>
+  </ts-expansion-panel-action-row>
+</ts-expansion-panel>
+```
+
+
+### Open or close all panels
+
+An accordion can programatically open or close all panels at once.
+
+```typescript
+@ViewChild(TsAccordionComponent)
+public accordion: TsAccordionComponent;
+
+...
+
+accordion.openAll();
+accordion.closeAll();
+```
+
+> NOTE: These methods will *not* change the state of disabled panels.
+
+
+
+
+
+
+## Test Helpers
+
+Some helpers are exposed to assist with testing. These are imported from `@terminus/ui/expansion-panel/testing`;
+
+[[source]][test-helpers-src]
+
+| Function                       |
+|--------------------------------|
+| `getAllPanelDebugElements`     |
+| `getAllPanelInstances`         |
+| `getPanelDebugElement`         |
+| `getPanelInstance`             |
+| `getPanelElement`              |
+| `getPanelBodyElement`          |
+| `getPanelBodyContentElement`   |
+| `getAllAccordionDebugElements` |
+| `getAllAccordionInstances`     |
+| `getAccordionInstance`         |
+| `getAccordionDebugElement`     |
+| `getAccordionElement`          |
+| `getTriggerDebugElement`       |
+| `getTriggerInstance`           |
+| `getTriggerElement`            |
+| `getTriggerTitleElement`       |
+| `getTriggerDescriptionElement` |
+| `getPanelActionRow`            |
+| `togglePanel`                  |
+
+
+[test-helpers-src]: https://github.com/GetTerminus/terminus-ui/blob/master/terminus-ui/expansion-panel/testing/src/test-helpers.ts

--- a/terminus-ui/expansion-panel/src/expansion-panel.component.scss
+++ b/terminus-ui/expansion-panel/src/expansion-panel.component.scss
@@ -1,0 +1,68 @@
+@import './../../scss/helpers/color';
+@import './../../scss/helpers/spacing';
+@import './../../scss/helpers/a11y';
+@import './../../scss/helpers/animation';
+@import './../../scss/helpers/shadows';
+
+
+
+
+.ts-expansion-panel {
+  $border-radius: 4px;
+  @include cdk-high-contrast {
+    outline: solid 1px;
+  }
+  background: color(pure);
+  border-radius: $border-radius;
+  box-shadow: 0 3px 1px -2px rgba(0, 0, 0, .2), 0 2px 2px 0 rgba(0, 0, 0, .14), 0 1px 5px 0 rgba(0, 0, 0, .12);
+  box-sizing: content-box;
+  color: color(pure, dark);
+  display: block;
+  margin: 0;
+  overflow: hidden;
+  transition:
+    margin 225ms $g-animation-fast-out-slow-in-timing-function,
+    box-shadow g-elevation-transition-duration $g-animation-fast-out-slow-in-timing-function;
+
+  .ts-accordion & {
+    border-radius: 0;
+
+    &:first-of-type {
+      border-top-left-radius: $border-radius;
+      border-top-right-radius: $border-radius;
+    }
+
+    &:last-of-type {
+      border-bottom-left-radius: $border-radius;
+      border-bottom-right-radius: $border-radius;
+    }
+  }
+
+  &.ng-animate-disabled,
+  .ng-animate-disabled &,
+  &.ts-expansion-panel--animation-noopable {
+    transition: none;
+  }
+}
+
+.ts-expansion-panel__content {
+  display: flex;
+  flex-direction: column;
+  overflow: visible;
+}
+
+.ts-expansion-panel__body {
+  padding: 0 spacing(large) spacing();
+}
+
+.ts-expansion-panel__action-row {
+  border-top: 1px solid color(utility, light);
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  padding: spacing() spacing(small, 1) spacing() spacing(large);
+
+  .ts-button {
+    margin-left: spacing(small, 1);
+  }
+}

--- a/terminus-ui/expansion-panel/src/expansion-panel.component.spec.ts
+++ b/terminus-ui/expansion-panel/src/expansion-panel.component.spec.ts
@@ -1,0 +1,319 @@
+import { createComponent as createComponentInner } from '@terminus/ngx-tools/testing';
+import { Type } from '@angular/core';
+import { ComponentFixture } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import * as testComponents from '@terminus/ui/expansion-panel/testing';
+import {
+  getPanelActionRow,
+  getPanelBodyContentElement,
+  getPanelDebugElement,
+  getPanelElement,
+  getPanelInstance,
+  getTriggerDescriptionElement,
+  getTriggerElement,
+  getTriggerInstance,
+  getTriggerTitleElement,
+  togglePanel,
+} from '@terminus/ui/expansion-panel/testing';
+
+import { TsExpansionPanelModule } from './expansion-panel.module';
+
+
+function createComponent<T>(component: Type<T>): ComponentFixture<T> {
+  return createComponentInner<T>(component, undefined, [TsExpansionPanelModule, NoopAnimationsModule]);
+}
+
+
+describe(`TsExpansionPanelComponent`, function() {
+
+  describe(`Single panel`, function() {
+
+    test(`should defer rendering content when ng-template is used`, function() {
+      const fixture = createComponent<testComponents.DeferredContent>(testComponents.DeferredContent);
+      fixture.detectChanges();
+      const body = getPanelBodyContentElement(fixture);
+
+      expect(body.textContent).toEqual('');
+
+      // Open the panel
+      togglePanel(fixture).then(() => {
+        expect(body.textContent.trim()).toEqual('My content');
+      });
+
+      expect.assertions(2);
+    });
+
+
+    test(`should be able to default to open`, function() {
+      const fixture = createComponent<testComponents.DefaultOpen>(testComponents.DefaultOpen);
+      fixture.detectChanges();
+      const triggerElement: HTMLElement = getTriggerElement(fixture);
+      const panelContainerElement: HTMLElement = getPanelElement(fixture);
+      const panel = getPanelInstance(fixture);
+
+      expect(panel.expanded).toEqual(true);
+      expect(panel.isExpanded).toEqual(true);
+      expect(triggerElement.classList).toContain('ts-expansion-panel__trigger--expanded');
+      expect(panelContainerElement.classList).toContain('ts-expansion-panel--expanded');
+    });
+
+
+    test(`should be able to disable the panel via input`, function() {
+      const fixture = createComponent<testComponents.DisabledPanel>(testComponents.DisabledPanel);
+      fixture.detectChanges();
+      const triggerElement: HTMLElement = getTriggerElement(fixture);
+      const panel = getPanelInstance(fixture);
+
+      expect(triggerElement.getAttribute('aria-disabled')).toEqual('true');
+      expect(panel.isDisabled).toEqual(true);
+    });
+
+
+    test(`should support an action row below panel content`, function() {
+      const fixture = createComponent<testComponents.ActionRow>(testComponents.ActionRow);
+      fixture.detectChanges();
+      const row = getPanelActionRow(fixture);
+
+      expect(row).toBeTruthy();
+      expect(row.textContent).toContain('Foo');
+    });
+
+
+    test(`should be able to programmatically open, close and toggle`, function() {
+      const fixture = createComponent<testComponents.ProgrammaticControl>(testComponents.ProgrammaticControl);
+      fixture.detectChanges();
+      const panel = getPanelInstance(fixture);
+
+      expect(panel.expanded).toEqual(false);
+
+      panel.open();
+      expect(panel.expanded).toEqual(true);
+
+      panel.close();
+      expect(panel.expanded).toEqual(false);
+
+      panel.toggle();
+      expect(panel.expanded).toEqual(true);
+
+      panel.toggle();
+      expect(panel.expanded).toEqual(false);
+
+      expect.assertions(5);
+    });
+
+
+    test(`should be able to programmatically control disabled panels`, function() {
+      const fixture = createComponent<testComponents.DisabledPanel>(testComponents.DisabledPanel);
+      fixture.detectChanges();
+      const panel = getPanelInstance(fixture);
+      const triggerElement: HTMLElement = getTriggerElement(fixture);
+      const panelContainerElement: HTMLElement = getPanelElement(fixture);
+
+
+      expect(panel.expanded).toEqual(false);
+      panel.expanded = true;
+      fixture.detectChanges();
+
+      expect(triggerElement.classList).toContain('ts-expansion-panel__trigger--expanded');
+      expect(panelContainerElement.classList).toContain('ts-expansion-panel--expanded');
+    });
+
+
+    test(`should call focus monitor when panel closes while it has focus`, function() {
+      const fixture = createComponent<testComponents.DefaultOpen>(testComponents.DefaultOpen);
+      fixture.detectChanges();
+      const trigger = getTriggerInstance(fixture);
+      const panel = getPanelInstance(fixture);
+      Object.defineProperties(panel, {
+        contentContainsFocus: { get: () => true },
+      });
+      trigger['focusMonitor'].focusVia = jest.fn();
+
+      panel.expanded = false;
+      fixture.detectChanges();
+      expect(trigger['focusMonitor'].focusVia).toHaveBeenCalled();
+    });
+
+
+    describe(`Events`, function() {
+
+      test(`should emit opened and closed events`, function() {
+        const fixture = createComponent<testComponents.Events>(testComponents.Events);
+        fixture.detectChanges();
+        const host = fixture.componentInstance;
+        host.opened = jest.fn();
+        host.closed = jest.fn();
+        host.expandedChange = jest.fn();
+
+        togglePanel(fixture);
+        expect(host.opened).toHaveBeenCalledTimes(1);
+        expect(host.expandedChange).toHaveBeenCalledWith(true);
+
+        togglePanel(fixture);
+        expect(host.closed).toHaveBeenCalledTimes(1);
+        expect(host.expandedChange).toHaveBeenCalledWith(false);
+      });
+
+
+      test(`should emit events when animations finish`, function() {
+        const fixture = createComponent<testComponents.Events>(testComponents.Events);
+        fixture.detectChanges();
+        const host = fixture.componentInstance;
+        host.afterCollapse = jest.fn();
+        host.afterExpand = jest.fn();
+
+        togglePanel(fixture).then(() => {
+          expect(host.afterExpand).toHaveBeenCalledTimes(1);
+        });
+
+        togglePanel(fixture).then(() => {
+          expect(host.afterCollapse).toHaveBeenCalledTimes(1);
+        });
+
+        expect.assertions(2);
+      });
+
+
+      test(`should emit when destroyed`, function() {
+        const fixture = createComponent<testComponents.Events>(testComponents.Events);
+        fixture.detectChanges();
+        const host = fixture.componentInstance;
+        const panel = getPanelInstance(fixture);
+        host.destroyed = jest.fn();
+
+        panel.ngOnDestroy();
+        expect(host.destroyed).toHaveBeenCalledTimes(1);
+      });
+
+    });
+
+  });
+
+
+  describe(`Panel trigger`, function() {
+
+    test(`should support title and descriptions`, function() {
+      const fixture = createComponent<testComponents.TriggerTitleDescription>(testComponents.TriggerTitleDescription);
+      fixture.detectChanges();
+      const triggerElement: HTMLElement = getTriggerElement(fixture);
+      const title = getTriggerTitleElement(fixture);
+      const description = getTriggerDescriptionElement(fixture);
+
+      expect(title.textContent.trim()).toEqual('My title');
+      expect(description.textContent.trim()).toEqual('My description');
+    });
+
+
+    test(`should have customizable collapsed and expanded heights`, function() {
+      const fixture = createComponent<testComponents.CustomHeights>(testComponents.CustomHeights);
+      fixture.detectChanges();
+      const triggerElement: HTMLElement = getTriggerElement(fixture);
+
+      // Open the panel
+      togglePanel(fixture).then(() => {
+        expect(triggerElement.getAttribute('style')).toContain('height:66px');
+      });
+
+      // Close the panel
+      togglePanel(fixture).then(() => {
+        expect(triggerElement.getAttribute('style')).toContain('height:33px');
+      });
+
+      expect.assertions(2);
+    });
+
+
+    test(`should be able to set custom heights & toggle visibility via provider configuration`, function() {
+      const fixture = createComponent<testComponents.CustomDefaults>(testComponents.CustomDefaults);
+      fixture.detectChanges();
+      const triggerElement: HTMLElement = getTriggerElement(fixture);
+
+      // Open the panel
+      togglePanel(fixture).then(() => {
+        expect(triggerElement.getAttribute('style')).toContain('height:88px');
+      });
+
+      // Close the panel
+      togglePanel(fixture).then(() => {
+        expect(triggerElement.getAttribute('style')).toContain('height:55px');
+      });
+
+      const toggleIcon = triggerElement.querySelector('.ts-expansion-panel__indicator');
+      expect(toggleIcon).toBeNull();
+      expect.assertions(3);
+    });
+
+
+    test(`should be able to hide the toggle icon`, function() {
+      const fixture = createComponent<testComponents.HideToggle>(testComponents.HideToggle);
+      fixture.detectChanges();
+      const triggerElement: HTMLElement = getTriggerElement(fixture);
+      const toggleIcon = triggerElement.querySelector('.ts-expansion-panel__indicator');
+
+      expect(toggleIcon).toBeNull();
+    });
+
+
+    test(`should pass program through to focus monitor`, function() {
+      const fixture = createComponent<testComponents.SinglePanel>(testComponents.SinglePanel);
+      fixture.detectChanges();
+      const trigger = getTriggerInstance(fixture);
+      trigger['focusMonitor'].focusVia = jest.fn();
+
+      trigger.focus();
+      expect(trigger['focusMonitor'].focusVia.mock.calls[0][1]).toEqual('program');
+
+      trigger.focus('keyboard');
+      expect(trigger['focusMonitor'].focusVia.mock.calls[1][1]).toEqual('keyboard');
+    });
+
+  });
+
+
+
+
+  describe(`Accessibility`, function() {
+
+    test(`should have the correct role and aria labels on triggers`, function() {
+      const fixture = createComponent<testComponents.SinglePanel>(testComponents.SinglePanel);
+      fixture.detectChanges();
+      const triggerElement = getTriggerElement(fixture);
+
+      expect(triggerElement.getAttribute('aria-controls')).toEqual(expect.stringContaining('cdk-accordion-child-'));
+      expect(triggerElement.getAttribute('role')).toEqual('button');
+    });
+
+
+    test(`should have the correct role and aria labels on panels`, function() {
+      const fixture = createComponent<testComponents.SinglePanel>(testComponents.SinglePanel);
+      fixture.detectChanges();
+      const panelDebugElement = getPanelDebugElement(fixture);
+      const panelElement = panelDebugElement.nativeElement.querySelector('.ts-expansion-panel__content');
+
+      expect(panelElement.getAttribute('role')).toEqual('region');
+      expect(panelElement.getAttribute('aria-labelledby')).toEqual(expect.stringContaining('ts-expansion-panel-trigger-'));
+      expect(panelElement.getAttribute('aria-hidden')).toEqual('true');
+
+      togglePanel(fixture);
+
+      expect(panelElement.getAttribute('aria-hidden')).toEqual('false');
+    });
+
+  });
+
+
+  describe(`contentContainsFocus`, function() {
+
+    test(`should return false if the panel doesn't exist`, function() {
+      const fixture = createComponent<testComponents.SinglePanel>(testComponents.SinglePanel);
+      fixture.detectChanges();
+      const panel = getPanelInstance(fixture);
+      panel.panelBody = undefined as any;
+      fixture.detectChanges();
+
+      expect(panel.contentContainsFocus).toEqual(false);
+    });
+
+  });
+
+});

--- a/terminus-ui/expansion-panel/src/expansion-panel.component.ts
+++ b/terminus-ui/expansion-panel/src/expansion-panel.component.ts
@@ -1,0 +1,323 @@
+import {
+  AfterContentInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ContentChild,
+  ElementRef,
+  EventEmitter,
+  Inject,
+  InjectionToken,
+  Input,
+  OnChanges,
+  OnDestroy,
+  Optional,
+  Output,
+  SimpleChanges,
+  SkipSelf,
+  ViewChild,
+  ViewContainerRef,
+  ViewEncapsulation,
+} from '@angular/core';
+import { AnimationEvent } from '@angular/animations';
+import { ANIMATION_MODULE_TYPE } from '@angular/platform-browser/animations';
+import { CdkAccordionItem } from '@angular/cdk/accordion';
+import { UniqueSelectionDispatcher } from '@angular/cdk/collections';
+import { TemplatePortal } from '@angular/cdk/portal';
+import {
+  TsDocumentService,
+  untilComponentDestroyed,
+} from '@terminus/ngx-tools';
+import {
+  distinctUntilChanged,
+  filter,
+  startWith,
+  take,
+} from 'rxjs/operators';
+import { Subject } from 'rxjs';
+
+import { tsExpansionPanelAnimations } from './expansion-animations';
+import { TsExpansionPanelContentDirective } from './expansion-panel-content.directive';
+import { TS_ACCORDION, TsAccordionBase } from './accordion/accordion-base';
+
+
+/**
+ * The possible states for a {@link TsExpansionPanelComponent}
+ */
+export type TsExpansionPanelState = 'expanded' | 'collapsed';
+
+
+/**
+ * Object that can be used to override the default options for all of the expansion panels in a module.
+ */
+export interface TsExpansionPanelDefaultOptions {
+  /**
+   * Height of the trigger while the panel is expanded
+   */
+  expandedHeight: string;
+
+  /**
+   * Height of the trigger while the panel is collapsed
+   */
+  collapsedHeight: string;
+
+  /**
+   * Whether the toggle indicator should be hidden
+   */
+  hideToggle: boolean;
+}
+
+
+/**
+ * Injection token that can be used to configure the defalt options for the expansion panel component.
+ */
+export const TS_EXPANSION_PANEL_DEFAULT_OPTIONS = new InjectionToken<TsExpansionPanelDefaultOptions>('TS_EXPANSION_PANEL_DEFAULT_OPTIONS');
+
+/**
+ * Unique ID for each panel trigger ID
+ */
+let nextUniqueId = 0;
+
+
+/**
+ * An expansion panel component to show/hide content
+ *
+ * @example
+ * <ts-expansion-panel
+ *               [hideToggle]="true"
+ *               [isExpanded]="true"
+ *               [isDisabled]="true"
+ *               (opened)="panelOpened()"
+ *               (closed)="panelClosed()"
+ *               (expandedChange)="panelStateChanged($event)"
+ *               (destroyed)="componentDestroyed()"
+ *               (afterCollapse)="collapseAnimationDone"
+ *               (afterExpand)="expandAnimationDone()"
+ * >
+ *               <ts-expansion-panel-trigger>
+ *                 Panel trigger
+ *               </ts-expansion-panel-trigger>
+ *
+ *               Panel content
+ * </ts-expansion-panel>
+ *
+ * <example-url>https://getterminus.github.io/ui-demos-master/components/expansion-panel</example-url>
+ */
+@Component({
+  selector: 'ts-expansion-panel',
+  templateUrl: './expansion-panel.component.html',
+  styleUrls: ['./expansion-panel.component.scss'],
+  // NOTE: @Outputs are defined here rather than using decorators since we are extending the @Outputs of the base class
+  // tslint:disable: use-output-property-decorator
+  outputs: ['opened', 'closed', 'expandedChange', 'destroyed'],
+  animations: [tsExpansionPanelAnimations.bodyExpansion],
+  host: {
+    class: 'ts-expansion-panel',
+    '[class.ts-expansion-panel--expanded]': 'expanded',
+    '[class.ts-expansion-panel--animation-noopable]': 'animationMode === "NoopAnimations"',
+  },
+  providers: [
+    // Provide TsAccordionComponent as undefined to prevent nested expansion panels from registering to the same accordion.
+    {
+      provide: TS_ACCORDION,
+      useValue: undefined,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'tsExpansionPanel',
+})
+export class TsExpansionPanelComponent extends CdkAccordionItem implements AfterContentInit, OnChanges, OnDestroy {
+  /**
+   * Stream of body animation done events
+   */
+  public bodyAnimationDone = new Subject<AnimationEvent>();
+
+  /**
+   * A stored reference to the document
+   */
+  private document: Document;
+
+  /**
+   * The ID for the associated trigger element. Used for a11y labelling.
+   */
+  public triggerId = `ts-expansion-panel-trigger-${nextUniqueId++}`;
+
+  /**
+   * Portal holding the user's content
+   */
+  public portal: TemplatePortal | undefined;
+
+  /**
+   * Stream that emits for changes in `@Input` properties
+   */
+  readonly inputChanges = new Subject<SimpleChanges>();
+
+  /**
+   * Optionally defined accordion the expansion panel belongs to
+   *
+   * NOTE: This should be `TsAccordionBase | undefined` but the underlying class doesn't define it as possibly undefined so we cannot
+   * do so here.
+   */
+  public accordion: TsAccordionBase;
+
+  /**
+   * Get the current expanded state
+   */
+  public get currentExpandedState(): TsExpansionPanelState {
+    return this.expanded ? 'expanded' : 'collapsed';
+  }
+
+  /**
+   * Determine whether the expansion panel's content contains the currently-focused element
+   */
+  public get contentContainsFocus(): boolean {
+    if (this.panelBody && this.document) {
+      const focusedElement = this.document.activeElement;
+      const bodyElement = this.panelBody.nativeElement;
+      return focusedElement === bodyElement || bodyElement.contains(focusedElement);
+    }
+
+    return false;
+  }
+
+  /**
+   * Reference to a passed in template (for lazy loading)
+   */
+  @ContentChild(TsExpansionPanelContentDirective)
+  public lazyContent!: TsExpansionPanelContentDirective;
+
+  /**
+   * The element containing the panel's user-provided content
+   */
+  @ViewChild('panelBody')
+  public panelBody!: ElementRef<HTMLElement>;
+
+  /**
+   * Determine if the toggle indicator should be hidden
+   */
+  @Input()
+  public set hideToggle(value: boolean) {
+    this._hideToggle = value;
+  }
+  public get hideToggle(): boolean {
+    return this._hideToggle || (this.accordion && this.accordion.hideToggle);
+  }
+  private _hideToggle = false;
+
+  /**
+   * Define if the panel should be disabled
+   *
+   * NOTE: CdkAccordionItem defines an input called `disabled`.
+   * This alias is to conform to our existing naming convention.
+   */
+  @Input()
+  public set isDisabled(value: boolean) {
+    this.disabled = value;
+  }
+  public get isDisabled(): boolean {
+    return this.disabled;
+  }
+
+  /**
+   * Define if the panel should be open
+   *
+   * NOTE: CdkAccordionItem defines an input called `expanded`.
+   * This alias is to conform to our existing naming convention.
+   */
+  @Input()
+  public set isExpanded(value: boolean) {
+    this.expanded = value;
+  }
+  public get isExpanded(): boolean {
+    return this.expanded;
+  }
+
+  /**
+   * The event emitted after the panel body's expansion animation finishes
+   */
+  @Output()
+  readonly afterExpand: EventEmitter<void> = new EventEmitter();
+
+  /**
+   * The event emitted after the panel body's collapse animation finishes
+   */
+  @Output()
+  readonly afterCollapse: EventEmitter<void> = new EventEmitter();
+
+
+  constructor(
+    @Optional() @SkipSelf() @Inject(TS_ACCORDION) accordion: TsAccordionBase,
+    _changeDetectorRef: ChangeDetectorRef,
+    _uniqueSelectionDispatcher: UniqueSelectionDispatcher,
+    private _viewContainerRef: ViewContainerRef,
+    private documentService: TsDocumentService,
+    @Optional() @Inject(ANIMATION_MODULE_TYPE) public animationMode?: string,
+    @Inject(TS_EXPANSION_PANEL_DEFAULT_OPTIONS) @Optional() defaultOptions?: TsExpansionPanelDefaultOptions,
+  ) {
+    super(accordion, _changeDetectorRef, _uniqueSelectionDispatcher);
+
+    this.accordion = accordion;
+    this.document = documentService.document;
+
+    // We need a Subject with distinctUntilChanged, because the `done` event fires twice on some browsers.
+    // See https://github.com/angular/angular/issues/24084
+    this.bodyAnimationDone.pipe(
+      untilComponentDestroyed(this),
+      distinctUntilChanged((x, y) => {
+        return x.fromState === y.fromState && x.toState === y.toState;
+      }),
+    ).subscribe((event) => {
+      // istanbul ignore else
+      if (event.fromState !== 'void') {
+        if (event.toState === 'expanded') {
+          this.afterExpand.emit();
+        } else if (event.toState === 'collapsed') {
+          this.afterCollapse.emit();
+        }
+      }
+    });
+
+    if (defaultOptions) {
+      this.hideToggle = defaultOptions.hideToggle;
+    }
+  }
+
+
+  /**
+   * If a lazy-loaded template exists, inject it after the panel is opened
+   */
+  public ngAfterContentInit(): void {
+    // istanbul ignore else
+    if (this.lazyContent) {
+      // Render the content as soon as the panel becomes open.
+      this.opened.pipe(
+        // tslint:disable: no-non-null-assertion
+        startWith<void>(null!),
+        // tslint:enable: no-non-null-assertion
+        filter(() => this.expanded && !this.portal),
+        take(1),
+      ).subscribe(() => {
+        this.portal = new TemplatePortal(this.lazyContent.template, this._viewContainerRef);
+      });
+    }
+  }
+
+
+  /**
+   * Send any input changes through the Subject stream
+   */
+  public ngOnChanges(changes: SimpleChanges): void {
+    this.inputChanges.next(changes);
+  }
+
+
+  /**
+   * Destroy the parent and finalize any subscriptions
+   */
+  public ngOnDestroy(): void {
+    super.ngOnDestroy();
+    this.inputChanges.complete();
+  }
+
+}

--- a/terminus-ui/expansion-panel/src/expansion-panel.module.ts
+++ b/terminus-ui/expansion-panel/src/expansion-panel.module.ts
@@ -1,0 +1,51 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CdkAccordionModule } from '@angular/cdk/accordion';
+import { PortalModule } from '@angular/cdk/portal';
+
+import { TsExpansionPanelComponent } from './expansion-panel.component';
+import { TsExpansionPanelContentDirective } from './expansion-panel-content.directive';
+import { TsExpansionPanelTriggerComponent } from './trigger/expansion-panel-trigger.component';
+import { TsExpansionPanelTriggerTitleComponent } from './trigger/expansion-panel-trigger-title.component';
+import { TsExpansionPanelTriggerDescriptionComponent } from './trigger/expansion-panel-trigger-description.component';
+import { TsExpansionPanelActionRowComponent } from './expansion-panel-action-row';
+import { TsAccordionComponent } from './accordion/accordion.component';
+
+
+export * from './expansion-panel.component';
+export * from './expansion-panel-content.directive';
+export * from './expansion-panel-action-row';
+export * from './trigger/expansion-panel-trigger.component';
+export * from './trigger/expansion-panel-trigger-title.component';
+export * from './trigger/expansion-panel-trigger-description.component';
+export * from './accordion/accordion.component';
+export * from './accordion/accordion-base';
+export * from './expansion-animations';
+
+
+@NgModule({
+  imports: [
+    CommonModule,
+    CdkAccordionModule,
+    PortalModule,
+  ],
+  declarations: [
+    TsExpansionPanelComponent,
+    TsExpansionPanelTriggerComponent,
+    TsExpansionPanelTriggerTitleComponent,
+    TsExpansionPanelTriggerDescriptionComponent,
+    TsExpansionPanelContentDirective,
+    TsExpansionPanelActionRowComponent,
+    TsAccordionComponent,
+  ],
+  exports: [
+    TsExpansionPanelComponent,
+    TsExpansionPanelTriggerComponent,
+    TsExpansionPanelTriggerTitleComponent,
+    TsExpansionPanelTriggerDescriptionComponent,
+    TsExpansionPanelContentDirective,
+    TsExpansionPanelActionRowComponent,
+    TsAccordionComponent,
+  ],
+})
+export class TsExpansionPanelModule {}

--- a/terminus-ui/expansion-panel/src/public-api.ts
+++ b/terminus-ui/expansion-panel/src/public-api.ts
@@ -1,0 +1,1 @@
+export * from './expansion-panel.module';

--- a/terminus-ui/expansion-panel/src/trigger/expansion-panel-trigger-description.component.ts
+++ b/terminus-ui/expansion-panel/src/trigger/expansion-panel-trigger-description.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+
+@Component({
+  selector: 'ts-expansion-panel-trigger-description',
+  template: `<ng-content></ng-content>`,
+  host: {
+    class: 'ts-expansion-panel__trigger-description',
+  },
+})
+export class TsExpansionPanelTriggerDescriptionComponent {}

--- a/terminus-ui/expansion-panel/src/trigger/expansion-panel-trigger-title.component.ts
+++ b/terminus-ui/expansion-panel/src/trigger/expansion-panel-trigger-title.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+
+
+@Component({
+  selector: 'ts-expansion-panel-trigger-title',
+  template: `<ng-content></ng-content>`,
+  host: {
+    class: 'ts-expansion-panel__trigger-title',
+  },
+})
+export class TsExpansionPanelTriggerTitleComponent {}

--- a/terminus-ui/expansion-panel/src/trigger/expansion-panel-trigger.component.html
+++ b/terminus-ui/expansion-panel/src/trigger/expansion-panel-trigger.component.html
@@ -1,0 +1,14 @@
+<span
+  class="ts-expansion-panel__trigger-content"
+  role="button"
+>
+  <ng-content select="ts-expansion-panel-trigger-title"></ng-content>
+  <ng-content select="ts-expansion-panel-trigger-description"></ng-content>
+  <ng-content></ng-content>
+</span>
+
+<span
+  class="ts-expansion-panel__indicator"
+  [@indicatorRotate]="currentPanelExpandedState"
+  *ngIf="shouldShowToggle"
+></span>

--- a/terminus-ui/expansion-panel/src/trigger/expansion-panel-trigger.component.scss
+++ b/terminus-ui/expansion-panel/src/trigger/expansion-panel-trigger.component.scss
@@ -1,0 +1,89 @@
+@import './../../../scss/helpers/typography';
+@import './../../../scss/helpers/spacing';
+@import './../../../scss/helpers/color';
+
+
+.ts-expansion-panel__trigger {
+  @include typography(body);
+  align-items: center;
+  border-radius: inherit;
+  display: flex;
+  flex-direction: row;
+  padding: 0 spacing(large);
+
+  &:focus,
+  &:hover {
+    outline: none;
+  }
+
+  &.ts-expansion-panel__trigger--expanded:focus,
+  &.ts-expansion-panel__trigger--expanded:hover {
+    background: inherit;
+  }
+
+  &[aria-disabled='true'] {
+    color: color(utility, light);
+
+    .ts-expansion-panel__trigger-title,
+    .ts-expansion-panel__trigger-description {
+      color: inherit;
+    }
+  }
+
+  &:not([aria-disabled='true']) {
+    cursor: pointer;
+  }
+}
+
+
+@media (hover: none) {
+  .ts-expansion-panel:not(.ts-expansion-panel--expanded):not([aria-disabled='true']) .ts-expansion-panel__trigger:hover {
+    background: color(pure);
+  }
+}
+
+.ts-expansion-panel__trigger-content {
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+  overflow: hidden;
+}
+
+.ts-expansion-panel__trigger-title,
+.ts-expansion-panel__trigger-description {
+  display: flex;
+  flex-grow: 0;
+  margin-right: spacing(large, 1);
+}
+
+.ts-expansion-panel__trigger-description {
+  color: color(utility, dark);
+  flex-grow: 2;
+}
+
+/**
+ * Creates the expansion indicator arrow. Done using ::after rather than having
+ * additional nodes in the template.
+ */
+
+.ts-expansion-panel__indicator::after {
+  border-style: solid;
+  border-width: 0 2px 2px 0;
+  color: color(utility);
+  content: '';
+  display: inline-block;
+  padding: 3px;
+  transform: rotate(45deg);
+  vertical-align: middle;
+}
+
+
+.ts-expansion-panel:not(.ts-expansion-panel--expanded) .ts-expansion-panel__trigger {
+  &:not([aria-disabled='true']) {
+    &.cdk-keyboard-focused,
+    &.cdk-program-focused,
+    &:hover {
+      background: color(utility, xlight);
+    }
+  }
+}

--- a/terminus-ui/expansion-panel/testing/package.json
+++ b/terminus-ui/expansion-panel/testing/package.json
@@ -1,0 +1,7 @@
+{
+  "ngPackage": {
+    "lib": {
+      "entryFile": "src/public-api.ts"
+    }
+  }
+}

--- a/terminus-ui/expansion-panel/testing/src/public-api.ts
+++ b/terminus-ui/expansion-panel/testing/src/public-api.ts
@@ -1,0 +1,2 @@
+export * from './test-components';
+export * from './test-helpers';

--- a/terminus-ui/expansion-panel/testing/src/test-components.ts
+++ b/terminus-ui/expansion-panel/testing/src/test-components.ts
@@ -1,0 +1,317 @@
+// tslint:disable: component-class-suffix
+import { Component, NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { TsExpansionPanelModule, TS_EXPANSION_PANEL_DEFAULT_OPTIONS } from '@terminus/ui/expansion-panel';
+import { noop } from '@terminus/ngx-tools';
+
+
+@Component({
+  template: `
+    <ts-accordion>
+      <ts-expansion-panel>
+        <ts-expansion-panel-trigger>
+          Trigger 1
+        </ts-expansion-panel-trigger>
+
+        Content 1
+      </ts-expansion-panel>
+
+      <ts-expansion-panel>
+        <ts-expansion-panel-trigger>
+          Trigger 2
+        </ts-expansion-panel-trigger>
+
+        Content 2
+      </ts-expansion-panel>
+    </ts-accordion>
+  `,
+})
+export class Accordion {}
+
+@Component({
+  template: `
+    <ts-accordion (destroyed)="destroyed()">
+      <ts-expansion-panel>
+        <ts-expansion-panel-trigger>
+          Trigger 1
+        </ts-expansion-panel-trigger>
+
+        Content 1
+      </ts-expansion-panel>
+
+      <ts-expansion-panel>
+        <ts-expansion-panel-trigger>
+          Trigger 2
+        </ts-expansion-panel-trigger>
+
+        Content 2
+      </ts-expansion-panel>
+    </ts-accordion>
+  `,
+})
+export class AccordionDestroyed {
+  destroyed = noop;
+}
+
+@Component({
+  template: `
+    <ts-accordion [multi]="true">
+      <ts-expansion-panel>
+        <ts-expansion-panel-trigger>
+          Trigger 1
+        </ts-expansion-panel-trigger>
+
+        Content 1
+      </ts-expansion-panel>
+
+      <ts-expansion-panel>
+        <ts-expansion-panel-trigger>
+          Trigger 2
+        </ts-expansion-panel-trigger>
+
+        Content 2
+      </ts-expansion-panel>
+    </ts-accordion>
+  `,
+})
+export class AccordionMulti {}
+
+@Component({
+  template: `
+    <ts-expansion-panel>
+      <ts-expansion-panel-trigger>
+        My trigger
+      </ts-expansion-panel-trigger>
+
+      My content
+
+      <ts-expansion-panel-action-row>
+        <button>Foo</button>
+      </ts-expansion-panel-action-row>
+    </ts-expansion-panel>
+  `,
+})
+export class ActionRow {}
+
+@Component({
+  template: `
+    <ts-expansion-panel>
+      <ts-expansion-panel-trigger
+        [collapsedHeight]="collapsed"
+        [expandedHeight]="expanded"
+      >
+        My trigger
+      </ts-expansion-panel-trigger>
+
+      My content
+    </ts-expansion-panel>
+  `,
+})
+export class CustomHeights {
+  collapsed = '33px';
+  expanded = '66px';
+}
+
+@Component({
+  template: `
+    <ts-expansion-panel>
+      <ts-expansion-panel-trigger>
+        My trigger
+      </ts-expansion-panel-trigger>
+
+      My content
+    </ts-expansion-panel>
+  `,
+  providers: [
+    {
+      provide: TS_EXPANSION_PANEL_DEFAULT_OPTIONS,
+      useValue: {
+        expandedHeight: '88px',
+        collapsedHeight: '55px',
+        hideToggle: true,
+      },
+    },
+  ],
+})
+export class CustomDefaults {}
+
+@Component({
+  template: `
+    <ts-expansion-panel [isExpanded]="true">
+      <ts-expansion-panel-trigger>
+        My trigger
+      </ts-expansion-panel-trigger>
+
+      My content
+    </ts-expansion-panel>
+  `,
+})
+export class DefaultOpen {}
+
+@Component({
+  template: `
+    <ts-expansion-panel>
+      <ts-expansion-panel-trigger>
+        My trigger
+      </ts-expansion-panel-trigger>
+
+      <ng-template tsExpansionPanelContent>
+        My content
+      </ng-template>
+    </ts-expansion-panel>
+  `,
+})
+export class DeferredContent {}
+
+@Component({
+  template: `
+    <ts-expansion-panel [isDisabled]="true">
+      <ts-expansion-panel-trigger>
+        My trigger
+      </ts-expansion-panel-trigger>
+
+      My content
+    </ts-expansion-panel>
+  `,
+})
+export class DisabledPanel {}
+
+@Component({
+  template: `
+    <ts-expansion-panel
+      (opened)="opened()"
+      (closed)="closed()"
+      (expandedChange)="expandedChange($event)"
+      (afterExpand)="afterExpand()"
+      (afterCollapse)="afterCollapse()"
+      (destroyed)="destroyed()"
+    >
+      <ts-expansion-panel-trigger>
+        My trigger
+      </ts-expansion-panel-trigger>
+
+      My content
+    </ts-expansion-panel>
+  `,
+})
+export class Events {
+  opened = noop;
+  closed = noop;
+  afterExpand = noop;
+  afterCollapse = noop;
+  destroyed = noop;
+  expandedChange = (v) => {};
+}
+
+@Component({
+  template: `
+    <ts-expansion-panel [hideToggle]="true">
+      <ts-expansion-panel-trigger>
+        My trigger
+      </ts-expansion-panel-trigger>
+
+      My content
+    </ts-expansion-panel>
+  `,
+})
+export class HideToggle {}
+
+@Component({
+  template: `
+    <ts-accordion [hideToggle]="true">
+      <ts-expansion-panel>
+        <ts-expansion-panel-trigger>
+          Trigger 1
+        </ts-expansion-panel-trigger>
+
+        Content 1
+      </ts-expansion-panel>
+
+      <ts-expansion-panel>
+        <ts-expansion-panel-trigger>
+          Trigger 2
+        </ts-expansion-panel-trigger>
+
+        Content 2
+      </ts-expansion-panel>
+    </ts-accordion>
+  `,
+})
+export class HideToggleAccordion {}
+
+@Component({
+  template: `
+    <ts-expansion-panel>
+      <ts-expansion-panel-trigger>
+        My trigger
+      </ts-expansion-panel-trigger>
+
+      My content
+    </ts-expansion-panel>
+  `,
+})
+export class ProgrammaticControl {}
+
+@Component({
+  template: `
+    <ts-expansion-panel>
+      <ts-expansion-panel-trigger>
+        My trigger
+      </ts-expansion-panel-trigger>
+
+      My content
+    </ts-expansion-panel>
+  `,
+})
+export class SinglePanel {}
+
+@Component({
+  template: `
+    <ts-expansion-panel>
+      <ts-expansion-panel-trigger>
+       <ts-expansion-panel-trigger-title>
+         My title
+       </ts-expansion-panel-trigger-title>
+       <ts-expansion-panel-trigger-description>
+         My description
+       </ts-expansion-panel-trigger-description>
+      </ts-expansion-panel-trigger>
+
+      My content
+    </ts-expansion-panel>
+  `,
+})
+export class TriggerTitleDescription {}
+
+
+
+
+/**
+ * NOTE: Currently all exported Components must belong to a module.
+ * So this is our useless module to avoid the build error.
+ */
+@NgModule({
+  imports: [
+    CommonModule,
+    TsExpansionPanelModule,
+  ],
+  declarations: [
+    Accordion,
+    AccordionDestroyed,
+    AccordionMulti,
+    ActionRow,
+    CustomHeights,
+    CustomDefaults,
+    DefaultOpen,
+    DeferredContent,
+    DisabledPanel,
+    Events,
+    HideToggle,
+    HideToggleAccordion,
+    ProgrammaticControl,
+    SinglePanel,
+    TriggerTitleDescription,
+  ],
+})
+export class TsExpansionPanelTestComponentsModule {}

--- a/terminus-ui/expansion-panel/testing/src/test-helpers.ts
+++ b/terminus-ui/expansion-panel/testing/src/test-helpers.ts
@@ -1,0 +1,262 @@
+import { ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
+import {
+  TsAccordionComponent,
+  TsExpansionPanelComponent,
+  TsExpansionPanelTriggerComponent,
+} from '@terminus/ui/expansion-panel';
+
+
+/**
+ * Get an array of all DebugElements for TsExpansionPanelComponents
+ *
+ * @param fixture - The component fixture
+ * @return An array of DebugElements
+ */
+export function getAllPanelDebugElements(fixture: ComponentFixture<any>): DebugElement[] {
+  return fixture.debugElement.queryAll(By.css('ts-expansion-panel'));
+}
+
+/**
+ * Get an array of all TsExpansionPanelComponent instances
+ *
+ * @param fixture - The component fixture
+ * @return An array of TsExpansionPanelComponent
+ */
+export function getAllPanelInstances(fixture: ComponentFixture<any>): TsExpansionPanelComponent[] {
+  const debugElements = getAllPanelDebugElements(fixture);
+  if (debugElements.length < 1) {
+    throw new Error(`getAllPanelInstances did not find any instances`);
+  }
+  return debugElements.map((debugElement) => debugElement.componentInstance);
+}
+
+/**
+ * Get the DebugElement for a TsExpansionPanelComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsExpansionPanelComponent
+ * @return The DebugElement
+ */
+export function getPanelDebugElement(fixture: ComponentFixture<any>, index = 0): DebugElement {
+  const all = getAllPanelDebugElements(fixture);
+  if (!all[index]) {
+    throw new Error(`getPanelDebugElement could not find a debug element at index '${index}'`);
+  }
+  return all[index];
+}
+
+/**
+ * Get the component instance for a TsExpansionPanelComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsExpansionPanelComponent
+ * @return The instance
+ */
+export function getPanelInstance(fixture: ComponentFixture<any>, index = 0): TsExpansionPanelComponent {
+  const debugElement = getPanelDebugElement(fixture, index);
+  return debugElement.componentInstance;
+}
+
+/**
+ * Get the element for a TsExpansionPanelComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsExpansionPanelComponent
+ * @return The element
+ */
+export function getPanelElement(fixture: ComponentFixture<any>, index = 0): HTMLElement {
+  const debugElement = getPanelDebugElement(fixture, index);
+  return debugElement.nativeElement;
+}
+
+/**
+ * Get the element for a TsExpansionPanelComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsExpansionPanelComponent
+ * @return The element
+ */
+export function getPanelBodyElement(fixture: ComponentFixture<any>, index = 0): HTMLElement {
+  const instance = getPanelInstance(fixture, index);
+  return instance.panelBody.nativeElement;
+}
+
+/**
+ * Get the element for a TsExpansionPanelComponent content container
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsExpansionPanelComponent
+ * @return The element
+ */
+export function getPanelBodyContentElement(fixture: ComponentFixture<any>, index = 0): HTMLElement {
+  const debugElement = getPanelDebugElement(fixture, index);
+  const contentElement = debugElement.query(By.css('.ts-expansion-panel__body'));
+  return contentElement.nativeElement;
+}
+
+/**
+ * Get an array of all DebugElements for TsAccordionComponents
+ *
+ * @param fixture - The component fixture
+ * @return An array of DebugElements
+ */
+export function getAllAccordionDebugElements(fixture: ComponentFixture<any>): DebugElement[] {
+  return fixture.debugElement.queryAll(By.css('ts-accordion'));
+}
+
+/**
+ * Get an array of all TsAccordionComponent instances
+ *
+ * @param fixture - The component fixture
+ * @return An array of TsAccordionComponent
+ */
+export function getAllAccordionInstances(fixture: ComponentFixture<any>): TsAccordionComponent[] {
+  const debugElements = getAllAccordionDebugElements(fixture);
+  if (debugElements.length < 1) {
+    throw new Error(`getAllAccordionInstances did not find any instances`);
+  }
+  return debugElements.map((debugElement) => debugElement.componentInstance);
+}
+
+/**
+ * Get the component instance for a TsAccordionComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsAccordionComponent
+ * @return The instance
+ */
+export function getAccordionInstance(fixture: ComponentFixture<any>, index = 0): TsAccordionComponent {
+  const all = getAllAccordionInstances(fixture);
+  if (!all[index]) {
+    throw new Error(`getAllAccordionInstance could not find an accordion at index '${index}'`);
+  }
+  return all[index];
+}
+
+/**
+ * Get the DebugElement for a TsAccordionComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsAccordionComponent
+ * @return The DebugElement
+ */
+export function getAccordionDebugElement(fixture: ComponentFixture<any>, index = 0): DebugElement {
+  const all = getAllAccordionDebugElements(fixture);
+  if (!all[index]) {
+    throw new Error(`getAccordionDebugElement could not find an accordion at index '${index}'`);
+  }
+  return all[index];
+}
+
+/**
+ * Get the element for a TsAccordionComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsAccordionComponent
+ * @return The element
+ */
+export function getAccordionElement(fixture: ComponentFixture<any>, index = 0): HTMLElement {
+  const debugElement = getAccordionDebugElement(fixture, index);
+  return debugElement.nativeElement;
+}
+
+/**
+ * Get the element for a TsExpansionPanelTriggerComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsExpansionPanelComponent
+ * @return The element
+ */
+export function getTriggerDebugElement(fixture: ComponentFixture<any>, panelIndex = 0): DebugElement {
+  const panelDebugElement = getPanelDebugElement(fixture, panelIndex);
+  const triggerDebugElement = panelDebugElement.query(By.css('ts-expansion-panel-trigger'));
+  if (!triggerDebugElement) {
+    throw new Error(`getTriggerDebugElement found no triggers within the panel at index '${panelIndex}'`);
+  }
+  return triggerDebugElement;
+}
+
+/**
+ * Get the instance for a TsExpansionPanelTriggerComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsExpansionPanelComponent
+ * @return The instance
+ */
+export function getTriggerInstance(fixture: ComponentFixture<any>, panelIndex = 0): TsExpansionPanelTriggerComponent {
+  const triggerDebugElement = getTriggerDebugElement(fixture, panelIndex);
+  return triggerDebugElement.componentInstance;
+}
+
+/**
+ * Get the element for a TsExpansionPanelTriggerComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsExpansionPanelComponent
+ * @return The element
+ */
+export function getTriggerElement(fixture: ComponentFixture<any>, panelIndex = 0): HTMLElement {
+  const triggerDebugElement = getTriggerDebugElement(fixture, panelIndex);
+  return triggerDebugElement.nativeElement;
+}
+
+/**
+ * Get the element for a TsExpansionPanelTriggerTitleComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsExpansionPanelComponent
+ * @return The element
+ */
+export function getTriggerTitleElement(fixture: ComponentFixture<any>, panelIndex = 0): HTMLElement {
+  const triggerDebugElement = getTriggerDebugElement(fixture, panelIndex);
+  const title = triggerDebugElement.query(By.css('.ts-expansion-panel__trigger-title'));
+  if (!title) {
+    throw new Error(`getTriggerTitleElement found no title within the trigger at index '${panelIndex}'`);
+  }
+  return title.nativeElement;
+}
+
+/**
+ * Get the element for a TsExpansionPanelTriggerDescriptionComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsExpansionPanelComponent
+ * @return The element
+ */
+export function getTriggerDescriptionElement(fixture: ComponentFixture<any>, panelIndex = 0): HTMLElement {
+  const triggerDebugElement = getTriggerDebugElement(fixture, panelIndex);
+  const description = triggerDebugElement.query(By.css('.ts-expansion-panel__trigger-description'));
+  if (!description) {
+    throw new Error(`getTriggerTitleElement found no description within the trigger at index '${panelIndex}'`);
+  }
+  return description.nativeElement;
+}
+
+/**
+ * Get the element for a TsExpansionPanelActionRowComponent
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsExpansionPanelComponent
+ * @return The element
+ */
+export function getPanelActionRow(fixture: ComponentFixture<any>, index = 0): HTMLElement {
+  const debugElement = getPanelDebugElement(fixture, index);
+  const row = debugElement.query(By.css('.ts-expansion-panel__action-row'));
+  return row.nativeElement;
+}
+
+/**
+ * Return the difference in time in words
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsExpansionPanelComponent
+ * @return The whenStable promise
+ */
+export function togglePanel(fixture: ComponentFixture<any>, panelIndex = 0): Promise<any> {
+  const triggerElement = getTriggerElement(fixture, panelIndex);
+  triggerElement.click();
+  fixture.detectChanges();
+  return fixture.whenStable();
+}

--- a/terminus-ui/input/src/input.module.ts
+++ b/terminus-ui/input/src/input.module.ts
@@ -15,6 +15,7 @@ import { TsIconModule } from '@terminus/ui/icon';
 import { TsValidationMessagesModule } from '@terminus/ui/validation-messages';
 import { TsValidatorsService } from '@terminus/ui/validators';
 import { TsDatePipe } from '@terminus/ui/pipes';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { TsInputComponent } from './input.component';
 import { TS_DATE_FORMATS } from './date-adapter';
@@ -27,6 +28,7 @@ export * from './input.component';
 @NgModule({
   imports: [
     CommonModule,
+    BrowserAnimationsModule,
     FlexLayoutModule,
     FormsModule,
     MatDatepickerModule,

--- a/terminus-ui/scss/helpers/_animation.scss
+++ b/terminus-ui/scss/helpers/_animation.scss
@@ -23,9 +23,13 @@ $g-material-background-easing: cubic-bezier(.25, .8, .25, 1) !default;
 $g-material-shadow-easing: cubic-bezier(.4, 0, .2, 1) !default;
 
 
-
 // Currently used in form-field and select components
 $swift-ease-out-duration: 400ms !default;
 $swift-ease-out-timing-function: cubic-bezier(.25, .8, .25, 1) !default;
 $swift-ease-in-duration: 300ms !default;
 $swift-ease-in-timing-function: cubic-bezier(.55, 0, .55, .2) !default;
+
+
+// Currently used in expansion panel component
+$g-animation-fast-out-slow-in-timing-function: cubic-bezier(.4, 0, .2, 1) !default;
+$g-elevation-transition-duration: 280ms !default;

--- a/terminus-ui/scss/helpers/_color.scss
+++ b/terminus-ui/scss/helpers/_color.scss
@@ -31,7 +31,7 @@ $color__utility--xdark: #3e3c43 !default;
  * @color
  * @section UI: Utility
  */
-$color__utility--dark: #48464d !default;
+$color__utility--dark: #757575 !default;
 
 /**
  * Utility

--- a/terminus-ui/select/src/select.module.ts
+++ b/terminus-ui/select/src/select.module.ts
@@ -26,6 +26,7 @@ import { TsSelectOptionDisplayDirective } from './option/option-display.directiv
 
 export * from './select.component';
 export * from './select-trigger.component';
+export * from './select-animations';
 export * from './option/option.component';
 export * from './option/option-display.directive';
 export * from './optgroup/optgroup.component';

--- a/terminus-ui/src/public-api.ts
+++ b/terminus-ui/src/public-api.ts
@@ -8,6 +8,7 @@ export * from '@terminus/ui/confirmation';
 export * from '@terminus/ui/copy';
 export * from '@terminus/ui/csv-entry';
 export * from '@terminus/ui/date-range';
+export * from '@terminus/ui/expansion-panel';
 export * from '@terminus/ui/file-upload';
 export * from '@terminus/ui/form-field';
 export * from '@terminus/ui/icon-button';

--- a/terminus-ui/tsconfig.spec.json
+++ b/terminus-ui/tsconfig.spec.json
@@ -7,6 +7,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "types": [
+      "jsdom",
       "jest"
     ],
     "paths": {

--- a/tooling/cz-config.js
+++ b/tooling/cz-config.js
@@ -26,6 +26,7 @@ module.exports = {
     {name: 'Copy'},
     {name: 'CSVEntry'},
     {name: 'DateRange'},
+    {name: 'ExpansionPanel'},
     {name: 'FileUpload'},
     {name: 'FormField'},
     {name: 'Icon'},

--- a/tooling/jest-global-mocks.ts
+++ b/tooling/jest-global-mocks.ts
@@ -49,3 +49,29 @@ Object.defineProperty(document.body.style, 'transform', {
       configurable: true,
     }),
 });
+
+/**
+ * This allows us to test Angular animation states
+ *
+ * ISSUE: https://github.com/thymikee/jest-preset-angular/issues/170
+ * Workaround: https://github.com/angular/angular/issues/24094
+ */
+ if (document.body.style.animation === undefined && CSSStyleDeclaration) {
+   CSSStyleDeclaration.prototype.animation = '';
+ }
+
+ if (document.body.style['animation-name'] === undefined && CSSStyleDeclaration) {
+   CSSStyleDeclaration.prototype['animation-name'] = '';
+   CSSStyleDeclaration.prototype['animationName'] = '';
+ }
+
+ if (document.body.style['animation-duration'] === undefined && CSSStyleDeclaration) {
+   CSSStyleDeclaration.prototype['animation-duration'] = '';
+   CSSStyleDeclaration.prototype['animationDuration'] = '';
+ }
+
+ if (document.body.style['animation-play-state'] === undefined && CSSStyleDeclaration) {
+   CSSStyleDeclaration.prototype['animation-play-state'] = '';
+   CSSStyleDeclaration.prototype['animationPlayState'] = '';
+ }
+


### PR DESCRIPTION
Closes #289 

- Exported select animations that were causing build warning
- Update mid-range utility gray to better reflect material color spacing
- Create expansion panel component
- Create accordion component


Full requirement list: https://github.com/GetTerminus/terminus-ui/issues/289

---

### Examples

![paneldemo](https://user-images.githubusercontent.com/270193/53743054-fe450300-3e67-11e9-897d-843f347df177.gif)

![customheight](https://user-images.githubusercontent.com/270193/53743409-bd99b980-3e68-11e9-90a6-321abfe242dc.gif)

![acoordiondemo](https://user-images.githubusercontent.com/270193/53743066-01d88a00-3e68-11e9-8549-f06cad933825.gif)

<img width="557" alt="disabled" src="https://user-images.githubusercontent.com/270193/53743069-03a24d80-3e68-11e9-91bd-256cb1fed4d9.png">

![stepperpanel](https://user-images.githubusercontent.com/270193/53743253-61cf3080-3e68-11e9-81b0-766e751637e5.gif)
