### PR TITLE
chore(CI): enforce consistent yarn version, CI installing from yarn.lock

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,1 @@
-yarn-path "./node_modules/yarn/bin/yarn"
+yarn-path "./bin/yarn"

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+yarn-path "./node_modules/yarn/bin/yarn"

--- a/package.json
+++ b/package.json
@@ -236,6 +236,7 @@
     "typescript": "3.1.6",
     "validate-commit-msg": "^2.14.0",
     "weak": "^1.0.1",
+    "yarn": "^1.13.0",
     "zone.js": "^0.8.29"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16627,6 +16627,11 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
+yarn@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.13.0.tgz#affa9c956739548024068532a902cf18c9cb523f"
+  integrity sha512-Unfw2eefv8imt4ZMPhvFVP44WCz38huDxkHs+Yqrx4wBTK75Tr0mh3V4rh+2Nw5iQq0rcM/VafotCZo9qTb5DA==
+
 yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"


### PR DESCRIPTION
ISSUES CLOSED: #1384

- Enforce consistent yarn version by using binary installed in project
- CI now installs purely from lockfile ensuring dependencies aren't changed during release