### PR TITLE
refactor(AllModules): ordered all imports via tslint

### DIFF
--- a/terminus-ui/autocomplete/src/autocomplete.component.spec.ts
+++ b/terminus-ui/autocomplete/src/autocomplete.component.spec.ts
@@ -4,8 +4,8 @@ import {
   MatAutocompleteSelectedEvent,
   MatAutocompleteTrigger,
 } from '@angular/material/autocomplete';
-import createMockInstance from 'jest-create-mock-instance';
 import { ChangeDetectorRefMock } from '@terminus/ngx-tools/testing';
+import createMockInstance from 'jest-create-mock-instance';
 
 import {
   TsAutocompleteComponent,

--- a/terminus-ui/autocomplete/src/autocomplete.component.ts
+++ b/terminus-ui/autocomplete/src/autocomplete.component.ts
@@ -21,21 +21,21 @@ import {
   MatAutocompleteSelectedEvent,
   MatAutocompleteTrigger,
 } from '@angular/material/autocomplete';
-import { debounceTime, distinctUntilChanged, filter } from 'rxjs/operators';
-import { BehaviorSubject } from 'rxjs';
-import {
-  coerceArray,
-  coerceBooleanProperty,
-  coerceNumberProperty,
-} from '@terminus/ngx-tools/coercion';
 import {
   arrayContainsObject,
   isBoolean,
   isFunction,
   untilComponentDestroyed,
 } from '@terminus/ngx-tools';
+import {
+  coerceArray,
+  coerceBooleanProperty,
+  coerceNumberProperty,
+} from '@terminus/ngx-tools/coercion';
 import { TS_SPACING } from '@terminus/ui/spacing';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
+import { BehaviorSubject } from 'rxjs';
+import { debounceTime, distinctUntilChanged, filter } from 'rxjs/operators';
 
 
 export interface KeyboardEvent {

--- a/terminus-ui/autocomplete/src/autocomplete.module.ts
+++ b/terminus-ui/autocomplete/src/autocomplete.module.ts
@@ -1,5 +1,6 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
 import {
   FormsModule,
   ReactiveFormsModule,
@@ -8,10 +9,9 @@ import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { FlexLayoutModule } from '@angular/flex-layout';
-import { TsValidationMessagesModule } from '@terminus/ui/validation-messages';
-import { TsInputModule } from '@terminus/ui/input';
 import { TsIconModule } from '@terminus/ui/icon';
+import { TsInputModule } from '@terminus/ui/input';
+import { TsValidationMessagesModule } from '@terminus/ui/validation-messages';
 
 import { TsAutocompleteComponent } from './autocomplete.component';
 

--- a/terminus-ui/autofocus/src/autofocus.module.ts
+++ b/terminus-ui/autofocus/src/autofocus.module.ts
@@ -1,5 +1,5 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 
 import { TsAutofocusDirective } from './autofocus.directive';
 

--- a/terminus-ui/button/src/button.component.spec.ts
+++ b/terminus-ui/button/src/button.component.spec.ts
@@ -1,13 +1,13 @@
 import { Component, ViewChild } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import {
-  createMouseEvent,
   createComponent,
+  createMouseEvent,
 } from '@terminus/ngx-tools/testing';
 
+import { ComponentFixture, tick } from '@angular/core/testing';
 import { TsButtonComponent } from './button.component';
 import { TsButtonModule } from './button.module';
-import { ComponentFixture, tick } from '@angular/core/testing';
 
 @Component({
   template: `

--- a/terminus-ui/button/src/button.component.ts
+++ b/terminus-ui/button/src/button.component.ts
@@ -13,11 +13,11 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import {
   isBoolean,
   TsWindowService,
 } from '@terminus/ngx-tools';
+import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import {
   TsStyleThemeTypes,
   tsStyleThemeTypesArray,

--- a/terminus-ui/button/src/button.module.ts
+++ b/terminus-ui/button/src/button.module.ts
@@ -1,5 +1,5 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { TsWindowService } from '@terminus/ngx-tools';

--- a/terminus-ui/card/src/card-title.directive.ts
+++ b/terminus-ui/card/src/card-title.directive.ts
@@ -7,9 +7,9 @@ import {
   Optional,
   SkipSelf,
 } from '@angular/core';
+import { isBoolean } from '@terminus/ngx-tools';
 import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
-import { isBoolean } from '@terminus/ngx-tools';
 
 import { TsCardComponent } from './card.component';
 

--- a/terminus-ui/card/src/card.component.spec.ts
+++ b/terminus-ui/card/src/card.component.spec.ts
@@ -4,9 +4,9 @@ import { By } from '@angular/platform-browser';
 
 import { createComponent } from '@terminus/ngx-tools/testing';
 
-import { TsCardComponent, TsCardBorderOptions } from './card.component';
-import { TsCardModule } from './card.module';
 import { TsStyleThemeTypes } from '../../utilities/src/public-api';
+import { TsCardBorderOptions, TsCardComponent } from './card.component';
+import { TsCardModule } from './card.module';
 
 @Component({
   template: `

--- a/terminus-ui/card/src/card.component.ts
+++ b/terminus-ui/card/src/card.component.ts
@@ -3,13 +3,13 @@ import {
   Component,
   ElementRef,
   Input,
+  isDevMode,
   TemplateRef,
   ViewEncapsulation,
-  isDevMode,
 } from '@angular/core';
-import { TsStyleThemeTypes } from '@terminus/ui/utilities';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { isBoolean } from '@terminus/ngx-tools';
+import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 
 
 /**

--- a/terminus-ui/card/src/card.module.ts
+++ b/terminus-ui/card/src/card.module.ts
@@ -1,10 +1,10 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { MatRippleModule } from '@angular/material/core';
 import { TsIconModule } from '@terminus/ui/icon';
 
-import { TsCardComponent } from './card.component';
 import { TsCardTitleDirective } from './card-title.directive';
+import { TsCardComponent } from './card.component';
 
 export * from './card.component';
 export * from './card-title.directive';

--- a/terminus-ui/chart/src/chart.component.spec.ts
+++ b/terminus-ui/chart/src/chart.component.spec.ts
@@ -10,9 +10,9 @@ import {
   TestBed,
 } from '@angular/core/testing';
 
-import { TsChartModule } from './chart.module';
-import { TsChartComponent, TsChartVisualizationOptions } from './chart.component';
 import { TsAmChartsService } from './amcharts.service';
+import { TsChartComponent, TsChartVisualizationOptions } from './chart.component';
+import { TsChartModule } from './chart.module';
 
 
 describe(`ChartComponent`, function() {

--- a/terminus-ui/chart/src/chart.module.ts
+++ b/terminus-ui/chart/src/chart.module.ts
@@ -1,8 +1,8 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 
+import { TS_AMCHARTS_TOKEN, TsAmChartsService } from './amcharts.service';
 import { TsChartComponent } from './chart.component';
-import { TsAmChartsService, TS_AMCHARTS_TOKEN } from './amcharts.service';
 
 export * from './chart.component';
 export * from './amcharts.service';

--- a/terminus-ui/checkbox/src/checkbox.component.spec.ts
+++ b/terminus-ui/checkbox/src/checkbox.component.spec.ts
@@ -1,10 +1,10 @@
 import { Component, ViewChild } from '@angular/core';
-import { By } from '@angular/platform-browser';
 import {
   ComponentFixture,
   TestBed,
   TestModuleMetadata,
 } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import {
   ChangeDetectorRefMock,
   configureTestBedWithoutReset,

--- a/terminus-ui/checkbox/src/checkbox.component.ts
+++ b/terminus-ui/checkbox/src/checkbox.component.ts
@@ -13,13 +13,13 @@ import {
   MatCheckbox,
   MatCheckboxChange,
 } from '@angular/material/checkbox';
+import { isBoolean } from '@terminus/ngx-tools';
 import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import {
   ControlValueAccessorProviderFactory,
   TsReactiveFormBaseComponent,
   TsStyleThemeTypes,
 } from '@terminus/ui/utilities';
-import { isBoolean } from '@terminus/ngx-tools';
 
 
 /**

--- a/terminus-ui/checkbox/src/checkbox.module.ts
+++ b/terminus-ui/checkbox/src/checkbox.module.ts
@@ -1,5 +1,5 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 

--- a/terminus-ui/checkbox/testing/src/test-helpers.ts
+++ b/terminus-ui/checkbox/testing/src/test-helpers.ts
@@ -1,4 +1,4 @@
-import { Predicate, DebugElement } from '@angular/core';
+import { DebugElement, Predicate } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { TsCheckboxComponent } from '@terminus/ui/checkbox';

--- a/terminus-ui/confirmation/src/confirmation-modal.component.ts
+++ b/terminus-ui/confirmation/src/confirmation-modal.component.ts
@@ -3,8 +3,8 @@ import {
   Component,
   ViewEncapsulation,
 } from '@angular/core';
-import { Subject } from 'rxjs';
 import { TS_SPACING } from '@terminus/ui/spacing';
+import { Subject } from 'rxjs';
 
 
 /**

--- a/terminus-ui/confirmation/src/confirmation.directive.spec.ts
+++ b/terminus-ui/confirmation/src/confirmation.directive.spec.ts
@@ -1,4 +1,7 @@
 // tslint:disable: no-non-null-assertion
+import { OverlayModule } from '@angular/cdk/overlay';
+import { PortalModule } from '@angular/cdk/portal';
+import { CommonModule } from '@angular/common';
 import {
   Component,
   EventEmitter,
@@ -13,11 +16,8 @@ import {
   ComponentFixture,
   TestBed,
 } from '@angular/core/testing';
-import { expectNativeEl } from '@terminus/ngx-tools/testing';
-import { OverlayModule } from '@angular/cdk/overlay';
-import { PortalModule } from '@angular/cdk/portal';
 import { FlexLayoutModule } from '@angular/flex-layout';
-import { CommonModule } from '@angular/common';
+import { expectNativeEl } from '@terminus/ngx-tools/testing';
 import { TsButtonComponent } from '@terminus/ui/button';
 
 import { TsConfirmationDirective } from './confirmation.directive';

--- a/terminus-ui/confirmation/src/confirmation.directive.ts
+++ b/terminus-ui/confirmation/src/confirmation.directive.ts
@@ -1,4 +1,11 @@
 import {
+  ConnectedPositionStrategy,
+  Overlay,
+  OverlayConfig,
+  OverlayRef,
+} from '@angular/cdk/overlay';
+import { ComponentPortal } from '@angular/cdk/portal';
+import {
   ChangeDetectorRef,
   Directive,
   ElementRef,
@@ -9,17 +16,10 @@ import {
   OnInit,
   Output,
 } from '@angular/core';
-import {
-  ConnectedPositionStrategy,
-  Overlay,
-  OverlayConfig,
-  OverlayRef,
-} from '@angular/cdk/overlay';
-import { ComponentPortal } from '@angular/cdk/portal';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { untilComponentDestroyed } from '@terminus/ngx-tools';
-import { merge } from 'rxjs/operators';
+import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsButtonComponent } from '@terminus/ui/button';
+import { merge } from 'rxjs/operators';
 
 import { TsConfirmationModalComponent } from './confirmation-modal.component';
 

--- a/terminus-ui/confirmation/src/confirmation.module.ts
+++ b/terminus-ui/confirmation/src/confirmation.module.ts
@@ -1,11 +1,11 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { OverlayModule } from '@angular/cdk/overlay';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { TsButtonModule } from '@terminus/ui/button';
 
-import { TsConfirmationDirective } from './confirmation.directive';
 import { TsConfirmationModalComponent } from './confirmation-modal.component';
+import { TsConfirmationDirective } from './confirmation.directive';
 
 export * from './confirmation-modal.component';
 export * from './confirmation.directive';

--- a/terminus-ui/copy/src/copy.component.spec.ts
+++ b/terminus-ui/copy/src/copy.component.spec.ts
@@ -1,9 +1,9 @@
+import { noop } from '@terminus/ngx-tools';
 import {
   ElementRefMock,
   TsDocumentServiceMock,
   TsWindowServiceMock,
 } from '@terminus/ngx-tools/testing';
-import { noop } from '@terminus/ngx-tools';
 
 import { TsCopyComponent } from './copy.component';
 

--- a/terminus-ui/copy/src/copy.component.ts
+++ b/terminus-ui/copy/src/copy.component.ts
@@ -11,8 +11,8 @@ import {
   TsDocumentService,
   TsWindowService,
 } from '@terminus/ngx-tools';
-import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 
 
 /**

--- a/terminus-ui/copy/src/copy.module.ts
+++ b/terminus-ui/copy/src/copy.module.ts
@@ -1,9 +1,9 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { MatRippleModule } from '@angular/material/core';
-import { TsTooltipModule } from '@terminus/ui/tooltip';
 import { TsIconModule } from '@terminus/ui/icon';
+import { TsTooltipModule } from '@terminus/ui/tooltip';
 
 import { TsCopyComponent } from './copy.component';
 

--- a/terminus-ui/csv-entry/src/csv-entry.component.spec.ts
+++ b/terminus-ui/csv-entry/src/csv-entry.component.spec.ts
@@ -9,22 +9,22 @@ import {
   TestBed,
   TestModuleMetadata,
 } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
 import { ValidatorFn, Validators } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { A, ENTER, TAB } from '@terminus/ngx-tools/keycodes';
 import {
   configureTestBedWithoutReset,
   createFakeEvent,
   dispatchKeyboardEvent,
   dispatchMouseEvent,
 } from '@terminus/ngx-tools/testing';
-import { ENTER, TAB, A } from '@terminus/ngx-tools/keycodes';
 import { TsValidatorsService } from '@terminus/ui/validators';
 
-import { TsCSVEntryModule } from './csv-entry.module';
 import {
   TsCSVEntryComponent,
   TsCSVFormContents,
 } from './csv-entry.component';
+import { TsCSVEntryModule } from './csv-entry.module';
 
 
 

--- a/terminus-ui/csv-entry/src/csv-entry.component.ts
+++ b/terminus-ui/csv-entry/src/csv-entry.component.ts
@@ -11,24 +11,24 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import {
-  coerceBooleanProperty,
-  coerceNumberProperty,
-} from '@terminus/ngx-tools/coercion';
-import {
-  isBoolean,
-  TsDocumentService,
-  untilComponentDestroyed,
-} from '@terminus/ngx-tools';
-import {
   FormArray,
   FormBuilder,
   FormControl,
   FormGroup,
   ValidatorFn,
 } from '@angular/forms';
-import { debounceTime } from 'rxjs/operators';
+import {
+  isBoolean,
+  TsDocumentService,
+  untilComponentDestroyed,
+} from '@terminus/ngx-tools';
+import {
+  coerceBooleanProperty,
+  coerceNumberProperty,
+} from '@terminus/ngx-tools/coercion';
 import { TS_SPACING } from '@terminus/ui/spacing';
 import { stripControlCharacters } from '@terminus/ui/utilities';
+import { debounceTime } from 'rxjs/operators';
 
 
 

--- a/terminus-ui/csv-entry/src/csv-entry.module.ts
+++ b/terminus-ui/csv-entry/src/csv-entry.module.ts
@@ -1,10 +1,10 @@
 import { CommonModule } from '@angular/common';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { NgModule } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TsButtonModule } from '@terminus/ui/button';
-import { TsIconButtonModule } from '@terminus/ui/icon-button';
 import { TsIconModule } from '@terminus/ui/icon';
+import { TsIconButtonModule } from '@terminus/ui/icon-button';
 import { TsTooltipModule } from '@terminus/ui/tooltip';
 
 import { TsCSVEntryComponent } from './csv-entry.component';

--- a/terminus-ui/date-range/src/date-range.component.spec.ts
+++ b/terminus-ui/date-range/src/date-range.component.spec.ts
@@ -1,10 +1,10 @@
 // tslint:disable: no-non-null-assertion
-import { ReactiveFormsModule } from '@angular/forms';
+import { Provider, Type } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
 } from '@angular/core/testing';
-import { Type, Provider } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { typeInElement } from '@terminus/ngx-tools/testing';
 import * as testComponents from '@terminus/ui/date-range/testing';

--- a/terminus-ui/date-range/src/date-range.component.ts
+++ b/terminus-ui/date-range/src/date-range.component.ts
@@ -14,13 +14,13 @@ import {
   FormControl,
   FormGroup,
 } from '@angular/forms';
-import { BehaviorSubject } from 'rxjs';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import {
   isBoolean,
   untilComponentDestroyed,
 } from '@terminus/ngx-tools';
+import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
+import { BehaviorSubject } from 'rxjs';
 
 
 /**

--- a/terminus-ui/date-range/src/date-range.module.ts
+++ b/terminus-ui/date-range/src/date-range.module.ts
@@ -1,5 +1,5 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { TsInputModule } from '@terminus/ui/input';
 

--- a/terminus-ui/date-range/testing/src/test-helpers.ts
+++ b/terminus-ui/date-range/testing/src/test-helpers.ts
@@ -1,13 +1,13 @@
+import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
 import {
   FormBuilder,
   FormGroup,
   Validators,
 } from '@angular/forms';
-import { DebugElement } from '@angular/core';
-import { TsInputComponent } from '@terminus/ui/input';
+import { By } from '@angular/platform-browser';
 import { TsDateRangeComponent } from '@terminus/ui/date-range';
+import { TsInputComponent } from '@terminus/ui/input';
 
 
 /**

--- a/terminus-ui/expansion-panel/src/accordion/accordion-base.ts
+++ b/terminus-ui/expansion-panel/src/accordion/accordion-base.ts
@@ -1,5 +1,5 @@
-import { InjectionToken } from '@angular/core';
 import { CdkAccordion } from '@angular/cdk/accordion';
+import { InjectionToken } from '@angular/core';
 
 
 /**

--- a/terminus-ui/expansion-panel/src/accordion/accordion.component.spec.ts
+++ b/terminus-ui/expansion-panel/src/accordion/accordion.component.spec.ts
@@ -1,24 +1,24 @@
 import { Type } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import * as testComponents from '@terminus/ui/expansion-panel/testing';
 import {
-  createComponent as createComponentInner,
-  createKeyboardEvent,
-} from '@terminus/ngx-tools/testing';
-import {
+  A,
   END,
   ENTER,
   HOME,
   SPACE,
-  A,
 } from '@terminus/ngx-tools/keycodes';
 import {
-  getPanelInstance,
-  togglePanel,
-  getAccordionInstance,
-  getTriggerElement,
+  createComponent as createComponentInner,
+  createKeyboardEvent,
+} from '@terminus/ngx-tools/testing';
+import * as testComponents from '@terminus/ui/expansion-panel/testing';
+import {
   getAccordionElement,
+  getAccordionInstance,
+  getPanelInstance,
+  getTriggerElement,
+  togglePanel,
 } from '@terminus/ui/expansion-panel/testing';
 
 import { TsExpansionPanelModule } from './../expansion-panel.module';

--- a/terminus-ui/expansion-panel/src/accordion/accordion.component.ts
+++ b/terminus-ui/expansion-panel/src/accordion/accordion.component.ts
@@ -1,3 +1,5 @@
+import { FocusKeyManager } from '@angular/cdk/a11y';
+import { CdkAccordion } from '@angular/cdk/accordion';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
@@ -10,19 +12,17 @@ import {
   QueryList,
   ViewEncapsulation,
 } from '@angular/core';
-import { CdkAccordion } from '@angular/cdk/accordion';
-import { FocusKeyManager } from '@angular/cdk/a11y';
 import {
   END,
   HOME,
 } from '@terminus/ngx-tools/keycodes';
 
+import { TsExpansionPanelComponent } from '../expansion-panel.component';
+import { TsExpansionPanelTriggerComponent } from './../trigger/expansion-panel-trigger.component';
 import {
   TS_ACCORDION,
   TsAccordionBase,
 } from './accordion-base';
-import { TsExpansionPanelTriggerComponent } from './../trigger/expansion-panel-trigger.component';
-import { TsExpansionPanelComponent } from '../expansion-panel.component';
 
 
 /**

--- a/terminus-ui/expansion-panel/src/expansion-panel.component.spec.ts
+++ b/terminus-ui/expansion-panel/src/expansion-panel.component.spec.ts
@@ -1,7 +1,7 @@
-import { createComponent as createComponentInner } from '@terminus/ngx-tools/testing';
 import { Type } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { createComponent as createComponentInner } from '@terminus/ngx-tools/testing';
 import * as testComponents from '@terminus/ui/expansion-panel/testing';
 import {
   getPanelActionRow,

--- a/terminus-ui/expansion-panel/src/expansion-panel.component.ts
+++ b/terminus-ui/expansion-panel/src/expansion-panel.component.ts
@@ -1,3 +1,7 @@
+import { AnimationEvent } from '@angular/animations';
+import { CdkAccordionItem } from '@angular/cdk/accordion';
+import { UniqueSelectionDispatcher } from '@angular/cdk/collections';
+import { TemplatePortal } from '@angular/cdk/portal';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
@@ -19,26 +23,22 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
 } from '@angular/core';
-import { AnimationEvent } from '@angular/animations';
 import { ANIMATION_MODULE_TYPE } from '@angular/platform-browser/animations';
-import { CdkAccordionItem } from '@angular/cdk/accordion';
-import { UniqueSelectionDispatcher } from '@angular/cdk/collections';
-import { TemplatePortal } from '@angular/cdk/portal';
 import {
   TsDocumentService,
   untilComponentDestroyed,
 } from '@terminus/ngx-tools';
+import { Subject } from 'rxjs';
 import {
   distinctUntilChanged,
   filter,
   startWith,
   take,
 } from 'rxjs/operators';
-import { Subject } from 'rxjs';
 
+import { TS_ACCORDION, TsAccordionBase } from './accordion/accordion-base';
 import { tsExpansionPanelAnimations } from './expansion-animations';
 import { TsExpansionPanelContentDirective } from './expansion-panel-content.directive';
-import { TS_ACCORDION, TsAccordionBase } from './accordion/accordion-base';
 
 
 /**

--- a/terminus-ui/expansion-panel/src/expansion-panel.module.ts
+++ b/terminus-ui/expansion-panel/src/expansion-panel.module.ts
@@ -1,15 +1,15 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { CdkAccordionModule } from '@angular/cdk/accordion';
 import { PortalModule } from '@angular/cdk/portal';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 
-import { TsExpansionPanelComponent } from './expansion-panel.component';
-import { TsExpansionPanelContentDirective } from './expansion-panel-content.directive';
-import { TsExpansionPanelTriggerComponent } from './trigger/expansion-panel-trigger.component';
-import { TsExpansionPanelTriggerTitleComponent } from './trigger/expansion-panel-trigger-title.component';
-import { TsExpansionPanelTriggerDescriptionComponent } from './trigger/expansion-panel-trigger-description.component';
-import { TsExpansionPanelActionRowComponent } from './expansion-panel-action-row';
 import { TsAccordionComponent } from './accordion/accordion.component';
+import { TsExpansionPanelActionRowComponent } from './expansion-panel-action-row';
+import { TsExpansionPanelContentDirective } from './expansion-panel-content.directive';
+import { TsExpansionPanelComponent } from './expansion-panel.component';
+import { TsExpansionPanelTriggerDescriptionComponent } from './trigger/expansion-panel-trigger-description.component';
+import { TsExpansionPanelTriggerTitleComponent } from './trigger/expansion-panel-trigger-title.component';
+import { TsExpansionPanelTriggerComponent } from './trigger/expansion-panel-trigger.component';
 
 
 export * from './expansion-panel.component';

--- a/terminus-ui/expansion-panel/src/trigger/expansion-panel-trigger.component.ts
+++ b/terminus-ui/expansion-panel/src/trigger/expansion-panel-trigger.component.ts
@@ -5,10 +5,6 @@ import {
 } from '@angular/cdk/a11y';
 import { hasModifierKey } from '@angular/cdk/keycodes';
 import {
-  ENTER,
-  SPACE,
-} from '@terminus/ngx-tools/keycodes';
-import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -20,12 +16,16 @@ import {
   Optional,
   ViewEncapsulation,
 } from '@angular/core';
+import { untilComponentDestroyed } from '@terminus/ngx-tools';
+import {
+  ENTER,
+  SPACE,
+} from '@terminus/ngx-tools/keycodes';
 import {
   EMPTY,
   merge,
 } from 'rxjs';
 import { filter } from 'rxjs/operators';
-import { untilComponentDestroyed } from '@terminus/ngx-tools';
 
 import { tsExpansionPanelAnimations } from './../expansion-animations';
 import {

--- a/terminus-ui/expansion-panel/testing/src/test-components.ts
+++ b/terminus-ui/expansion-panel/testing/src/test-components.ts
@@ -1,9 +1,9 @@
 // tslint:disable: component-class-suffix
-import { Component, NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { Component, NgModule } from '@angular/core';
 
-import { TsExpansionPanelModule, TS_EXPANSION_PANEL_DEFAULT_OPTIONS } from '@terminus/ui/expansion-panel';
 import { noop } from '@terminus/ngx-tools';
+import { TS_EXPANSION_PANEL_DEFAULT_OPTIONS, TsExpansionPanelModule } from '@terminus/ui/expansion-panel';
 
 
 @Component({

--- a/terminus-ui/expansion-panel/testing/src/test-helpers.ts
+++ b/terminus-ui/expansion-panel/testing/src/test-helpers.ts
@@ -1,6 +1,6 @@
+import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
 import {
   TsAccordionComponent,
   TsExpansionPanelComponent,

--- a/terminus-ui/file-upload/src/file-upload.component.spec.ts
+++ b/terminus-ui/file-upload/src/file-upload.component.spec.ts
@@ -8,6 +8,7 @@ import {
   TestModuleMetadata,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { A, ENTER } from '@terminus/ngx-tools/keycodes';
 import {
   configureTestBedWithoutReset,
   createFakeEvent,
@@ -15,15 +16,14 @@ import {
   dispatchKeyboardEvent,
   dispatchMouseEvent,
 } from '@terminus/ngx-tools/testing';
-import { ENTER, A } from '@terminus/ngx-tools/keycodes';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 
-import { TsFileImageDimensionConstraints } from './image-dimension-constraints';
-import { TsFileUploadComponent } from './file-upload.component';
-import { TsFileAcceptedMimeTypes, TS_ACCEPTED_MIME_TYPES } from './mime-types';
-import { TsFileUploadModule } from './file-upload.module';
-import { TsSelectedFile } from './selected-file';
 import { FormControl } from '@angular/forms';
+import { TsFileUploadComponent } from './file-upload.component';
+import { TsFileUploadModule } from './file-upload.module';
+import { TsFileImageDimensionConstraints } from './image-dimension-constraints';
+import { TS_ACCEPTED_MIME_TYPES, TsFileAcceptedMimeTypes } from './mime-types';
+import { TsSelectedFile } from './selected-file';
 
 
 // tslint:disable: max-line-length

--- a/terminus-ui/file-upload/src/file-upload.component.ts
+++ b/terminus-ui/file-upload/src/file-upload.component.ts
@@ -33,7 +33,6 @@ import {
   coerceNumberProperty,
 } from '@terminus/ngx-tools/coercion';
 import { ENTER } from '@terminus/ngx-tools/keycodes';
-import { filter } from 'rxjs/operators';
 import { TS_SPACING } from '@terminus/ui/spacing';
 import {
   ControlValueAccessorProviderFactory,
@@ -43,11 +42,12 @@ import {
   TsReactiveFormBaseComponent,
   TsStyleThemeTypes,
 } from '@terminus/ui/utilities';
+import { filter } from 'rxjs/operators';
 
-import { TsSelectedFile } from './selected-file';
-import { TsFileAcceptedMimeTypes, TS_ACCEPTED_MIME_TYPES } from './mime-types';
-import { TsFileImageDimensionConstraints } from './image-dimension-constraints';
 import { TsDropProtectionService } from './drop-protection.service';
+import { TsFileImageDimensionConstraints } from './image-dimension-constraints';
+import { TS_ACCEPTED_MIME_TYPES, TsFileAcceptedMimeTypes } from './mime-types';
+import { TsSelectedFile } from './selected-file';
 
 
 export interface ImageRatio {

--- a/terminus-ui/file-upload/src/file-upload.module.ts
+++ b/terminus-ui/file-upload/src/file-upload.module.ts
@@ -1,18 +1,18 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
+import { FormsModule } from '@angular/forms';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { TsDatePipe } from '@terminus/ui/pipes';
 import { TsDocumentService } from '@terminus/ngx-tools';
 import { TsButtonModule } from '@terminus/ui/button';
-import { TsIconButtonModule } from '@terminus/ui/icon-button';
 import { TsIconModule } from '@terminus/ui/icon';
+import { TsIconButtonModule } from '@terminus/ui/icon-button';
+import { TsDatePipe } from '@terminus/ui/pipes';
 import { TsTooltipModule } from '@terminus/ui/tooltip';
 import { TsValidationMessagesModule } from '@terminus/ui/validation-messages';
 
-import { TsFileUploadComponent } from './file-upload.component';
 import { TsDropProtectionService } from './drop-protection.service';
+import { TsFileUploadComponent } from './file-upload.component';
 
 export * from './drop-protection.service';
 export * from './file-upload.component';

--- a/terminus-ui/file-upload/src/selected-file.spec.ts
+++ b/terminus-ui/file-upload/src/selected-file.spec.ts
@@ -1,6 +1,6 @@
 
-import { TsFileAcceptedMimeTypes } from './mime-types';
 import { TsFileImageDimensionConstraints } from './image-dimension-constraints';
+import { TsFileAcceptedMimeTypes } from './mime-types';
 import { TsSelectedFile } from './selected-file';
 
 

--- a/terminus-ui/file-upload/src/selected-file.ts
+++ b/terminus-ui/file-upload/src/selected-file.ts
@@ -1,11 +1,11 @@
 import { isDevMode } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
+import { isString } from '@terminus/ngx-tools';
+import { ImageRatio } from './file-upload.module';
 import { TsFileImageDimensionConstraints } from './image-dimension-constraints';
 import { TsImageDimensions } from './image-dimensions';
-import { TsFileAcceptedMimeTypes, TS_ACCEPTED_MIME_TYPES } from './mime-types';
-import { ImageRatio } from './file-upload.module';
-import { isString } from '@terminus/ngx-tools';
+import { TS_ACCEPTED_MIME_TYPES, TsFileAcceptedMimeTypes } from './mime-types';
 
 
 /**

--- a/terminus-ui/form-field/src/form-field-control.ts
+++ b/terminus-ui/form-field/src/form-field-control.ts
@@ -1,4 +1,4 @@
-import { NgControl, FormControl } from '@angular/forms';
+import { FormControl, NgControl } from '@angular/forms';
 import { Observable } from 'rxjs';
 
 

--- a/terminus-ui/form-field/src/form-field.component.spec.ts
+++ b/terminus-ui/form-field/src/form-field.component.spec.ts
@@ -1,27 +1,27 @@
 import {
-  FormControl,
-  FormsModule,
-  ReactiveFormsModule,
-  Validators,
-} from '@angular/forms';
-import {
-  ComponentFixture,
-  TestBed,
-} from '@angular/core/testing';
-import {
   Component,
   OnInit,
   Provider,
   Type,
   ViewChild,
 } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import {
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
+import {
+  FormControl,
+  FormsModule,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { TsDocumentServiceMock, createFakeEvent } from '@terminus/ngx-tools/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TsDocumentService } from '@terminus/ngx-tools';
+import { createFakeEvent, TsDocumentServiceMock } from '@terminus/ngx-tools/testing';
 import { TsInputComponent, TsInputModule } from '@terminus/ui/input';
 
-import { TsFormFieldModule, TsFormFieldComponent } from './form-field.module';
+import { TsFormFieldComponent, TsFormFieldModule } from './form-field.module';
 
 
 // tslint:disable: no-use-before-declare

--- a/terminus-ui/form-field/src/form-field.component.ts
+++ b/terminus-ui/form-field/src/form-field.component.ts
@@ -15,6 +15,13 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import {
+  isBoolean,
+  TsDocumentService,
+} from '@terminus/ngx-tools';
+import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import { TS_SPACING } from '@terminus/ui/spacing';
+import { TsStyleThemeTypes } from '@terminus/ui/utilities';
+import {
   EMPTY,
   fromEvent,
   merge,
@@ -23,13 +30,6 @@ import {
   startWith,
   take,
 } from 'rxjs/operators';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
-import {
-  isBoolean,
-  TsDocumentService,
-} from '@terminus/ngx-tools';
-import { TS_SPACING } from '@terminus/ui/spacing';
-import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 
 import { TsFormFieldControl } from './form-field-control';
 import { TsPrefixDirective } from './prefix.directive';

--- a/terminus-ui/form-field/src/form-field.module.ts
+++ b/terminus-ui/form-field/src/form-field.module.ts
@@ -1,12 +1,12 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { TsValidationMessagesModule } from '@terminus/ui/validation-messages';
 
 import { TsFormFieldComponent } from './form-field.component';
+import { TsLabelDirective } from './label.directive';
 import { TsPrefixDirective } from './prefix.directive';
 import { TsSuffixDirective } from './suffix.directive';
-import { TsLabelDirective } from './label.directive';
 
 export * from './form-field.component';
 export * from './prefix.directive';

--- a/terminus-ui/icon-button/src/icon-button.module.ts
+++ b/terminus-ui/icon-button/src/icon-button.module.ts
@@ -1,5 +1,5 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatRippleModule } from '@angular/material/core';
 import { TsIconModule } from '@terminus/ui/icon';

--- a/terminus-ui/icon/src/icon.component.spec.ts
+++ b/terminus-ui/icon/src/icon.component.spec.ts
@@ -4,8 +4,8 @@ import {
   TestBed,
   TestModuleMetadata,
 } from '@angular/core/testing';
-import { configureTestBedWithoutReset } from '@terminus/ngx-tools/testing';
 import { By } from '@angular/platform-browser';
+import { configureTestBedWithoutReset } from '@terminus/ngx-tools/testing';
 
 import { TsIconComponent } from './icon.component';
 import { TsIconModule } from './icon.module';

--- a/terminus-ui/icon/src/icon.component.ts
+++ b/terminus-ui/icon/src/icon.component.ts
@@ -5,8 +5,8 @@ import {
   isDevMode,
   ViewEncapsulation,
 } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
 import { MatIconRegistry } from '@angular/material/icon';
+import { DomSanitizer } from '@angular/platform-browser';
 import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 

--- a/terminus-ui/icon/src/icon.module.ts
+++ b/terminus-ui/icon/src/icon.module.ts
@@ -1,5 +1,5 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 
 import { TsIconComponent } from './icon.component';

--- a/terminus-ui/input/src/input.component.spec.ts
+++ b/terminus-ui/input/src/input.component.spec.ts
@@ -1,38 +1,38 @@
 // tslint:disable: no-non-null-assertion no-use-before-declare component-class-suffix
+import { AutofillMonitor } from '@angular/cdk/text-field';
 import {
   ElementRef,
   Provider,
   Type,
 } from '@angular/core';
 import {
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
+import {
   FormControl,
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
-import {
-  ComponentFixture,
-  TestBed,
-} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TsDocumentService } from '@terminus/ngx-tools';
+import { A } from '@terminus/ngx-tools/keycodes';
 import {
   createKeyboardEvent,
   TsDocumentServiceMock,
   typeInElement,
 } from '@terminus/ngx-tools/testing';
-import { TsDocumentService } from '@terminus/ngx-tools';
-import { A } from '@terminus/ngx-tools/keycodes';
-import { By } from '@angular/platform-browser';
-import { Subject, Observable } from 'rxjs';
-import { AutofillMonitor } from '@angular/cdk/text-field';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TsFormFieldComponent, TsFormFieldModule } from '@terminus/ui/form-field';
+import { Observable, Subject } from 'rxjs';
 
-import { TsInputModule } from './input.module';
 import * as TestComponents from '@terminus/ui/input/testing';
 import {
   getInputElement,
-  sendInput,
   getInputInstance,
+  sendInput,
 } from '@terminus/ui/input/testing';
+import { TsInputModule } from './input.module';
 
 
 describe(`TsInputComponent`, function() {

--- a/terminus-ui/input/src/input.component.ts
+++ b/terminus-ui/input/src/input.component.ts
@@ -1,3 +1,5 @@
+import { Platform } from '@angular/cdk/platform';
+import { AutofillMonitor } from '@angular/cdk/text-field';
 import {
   AfterContentInit,
   AfterViewInit,
@@ -27,6 +29,11 @@ import {
   NgControl,
 } from '@angular/forms';
 import {
+  DateAdapter,
+  MAT_DATE_FORMATS,
+} from '@angular/material/core';
+import { MatDatepicker } from '@angular/material/datepicker';
+import {
   hasRequiredControl,
   isBoolean,
   isNumber,
@@ -37,27 +44,20 @@ import {
   coerceBooleanProperty,
   coerceNumberProperty,
 } from '@terminus/ngx-tools/coercion';
-import { Platform } from '@angular/cdk/platform';
-import { AutofillMonitor } from '@angular/cdk/text-field';
-import { MatDatepicker } from '@angular/material/datepicker';
-import { createTextMaskInputElement } from 'text-mask-core/dist/textMaskCore';
-import createNumberMask from 'text-mask-addons/dist/createNumberMask';
-import createAutoCorrectedDatePipe from 'text-mask-addons/dist/createAutoCorrectedDatePipe';
-import {
-  DateAdapter,
-  MAT_DATE_FORMATS,
-} from '@angular/material/core';
-import {
-  isValid as isValidDate,
-} from 'date-fns';
-import { Subject } from 'rxjs';
-import { TS_SPACING } from '@terminus/ui/spacing';
-import { TsDatePipe } from '@terminus/ui/pipes';
 import { TsFormFieldControl } from '@terminus/ui/form-field';
+import { TsDatePipe } from '@terminus/ui/pipes';
+import { TS_SPACING } from '@terminus/ui/spacing';
 import {
   inputHasChanged,
   TsStyleThemeTypes,
 } from '@terminus/ui/utilities';
+import {
+  isValid as isValidDate,
+} from 'date-fns';
+import { Subject } from 'rxjs';
+import createAutoCorrectedDatePipe from 'text-mask-addons/dist/createAutoCorrectedDatePipe';
+import createNumberMask from 'text-mask-addons/dist/createNumberMask';
+import { createTextMaskInputElement } from 'text-mask-core/dist/textMaskCore';
 
 import {
   TS_DATE_FORMATS,

--- a/terminus-ui/input/src/input.module.ts
+++ b/terminus-ui/input/src/input.module.ts
@@ -1,24 +1,24 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
 import {
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
-import { FlexLayoutModule } from '@angular/flex-layout';
-import { MatDatepickerModule } from '@angular/material/datepicker';
 import {
   MAT_DATE_FORMATS,
   NativeDateModule,
 } from '@angular/material/core';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TsFormFieldModule } from '@terminus/ui/form-field';
 import { TsIconModule } from '@terminus/ui/icon';
+import { TsDatePipe } from '@terminus/ui/pipes';
 import { TsValidationMessagesModule } from '@terminus/ui/validation-messages';
 import { TsValidatorsService } from '@terminus/ui/validators';
-import { TsDatePipe } from '@terminus/ui/pipes';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-import { TsInputComponent } from './input.component';
 import { TS_DATE_FORMATS } from './date-adapter';
+import { TsInputComponent } from './input.component';
 
 export * from './date-adapter';
 export * from './input-value-accessor';

--- a/terminus-ui/input/testing/src/test-components.ts
+++ b/terminus-ui/input/testing/src/test-components.ts
@@ -13,9 +13,9 @@ import {
 } from '@angular/forms';
 import { TsFormFieldComponent } from '@terminus/ui/form-field';
 import {
-  TsInputModule,
   TsInputAutocompleteTypes,
   TsInputComponent,
+  TsInputModule,
   TsInputTypes,
   TsMaskShortcutOptions,
 } from '@terminus/ui/input';

--- a/terminus-ui/link/src/link.component.ts
+++ b/terminus-ui/link/src/link.component.ts
@@ -5,8 +5,8 @@ import {
   isDevMode,
   ViewEncapsulation,
 } from '@angular/core';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { isBoolean } from '@terminus/ngx-tools';
+import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 
 
 /**

--- a/terminus-ui/link/src/link.module.ts
+++ b/terminus-ui/link/src/link.module.ts
@@ -1,5 +1,5 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { TsIconModule } from '@terminus/ui/icon';
 

--- a/terminus-ui/loading-overlay/src/loading-overlay.directive.ts
+++ b/terminus-ui/loading-overlay/src/loading-overlay.directive.ts
@@ -1,3 +1,4 @@
+import { ComponentPortal, DomPortalHost } from '@angular/cdk/portal';
 import {
   ApplicationRef,
   ComponentFactoryResolver,
@@ -10,12 +11,11 @@ import {
   OnDestroy,
   OnInit,
 } from '@angular/core';
-import { ComponentPortal, DomPortalHost } from '@angular/cdk/portal';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import {
   isBoolean,
   TsWindowService,
 } from '@terminus/ngx-tools';
+import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 
 import { TsLoadingOverlayComponent } from './loading-overlay.component';
 

--- a/terminus-ui/loading-overlay/src/loading-overlay.module.ts
+++ b/terminus-ui/loading-overlay/src/loading-overlay.module.ts
@@ -1,5 +1,5 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 
 import { TsLoadingOverlayComponent } from './loading-overlay.component';
 import { TsLoadingOverlayDirective } from './loading-overlay.directive';

--- a/terminus-ui/login-form/src/login-form.component.ts
+++ b/terminus-ui/login-form/src/login-form.component.ts
@@ -12,15 +12,15 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import {
-  FormGroup,
   FormBuilder,
+  FormGroup,
   Validators,
 } from '@angular/forms';
-import { TsInputComponent } from '@terminus/ui/input';
-import { TsCheckboxComponent } from '@terminus/ui/checkbox';
-import { TsValidatorsService } from '@terminus/ui/validators';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { isBoolean } from '@terminus/ngx-tools';
+import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import { TsCheckboxComponent } from '@terminus/ui/checkbox';
+import { TsInputComponent } from '@terminus/ui/input';
+import { TsValidatorsService } from '@terminus/ui/validators';
 
 
 /**

--- a/terminus-ui/login-form/src/login-form.module.ts
+++ b/terminus-ui/login-form/src/login-form.module.ts
@@ -1,13 +1,13 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
-import { TsValidatorsService } from '@terminus/ui/validators';
-import { TsInputModule } from '@terminus/ui/input';
-import { TsCheckboxModule } from '@terminus/ui/checkbox';
+import { ReactiveFormsModule } from '@angular/forms';
 import { TsButtonModule } from '@terminus/ui/button';
-import { TsSpacingModule } from '@terminus/ui/spacing';
+import { TsCheckboxModule } from '@terminus/ui/checkbox';
+import { TsInputModule } from '@terminus/ui/input';
 import { TsLinkModule } from '@terminus/ui/link';
+import { TsSpacingModule } from '@terminus/ui/spacing';
+import { TsValidatorsService } from '@terminus/ui/validators';
 
 import { TsLoginFormComponent } from './login-form.component';
 

--- a/terminus-ui/logo/src/logo.component.ts
+++ b/terminus-ui/logo/src/logo.component.ts
@@ -3,8 +3,8 @@ import {
   Component,
   Input,
   isDevMode,
-  ViewEncapsulation,
   OnInit,
+  ViewEncapsulation,
 } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 

--- a/terminus-ui/logo/src/logo.module.ts
+++ b/terminus-ui/logo/src/logo.module.ts
@@ -1,5 +1,5 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 
 import { TsLogoComponent } from './logo.component';
 

--- a/terminus-ui/menu/src/menu.component.ts
+++ b/terminus-ui/menu/src/menu.component.ts
@@ -11,10 +11,10 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { MatMenuTrigger } from '@angular/material/menu';
+import { isBoolean } from '@terminus/ngx-tools';
+import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsButtonFormatTypes } from '@terminus/ui/button';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
-import { isBoolean } from '@terminus/ngx-tools';
 
 
 /**

--- a/terminus-ui/menu/src/menu.module.ts
+++ b/terminus-ui/menu/src/menu.module.ts
@@ -1,9 +1,9 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MatMenuModule } from '@angular/material/menu';
+import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
-import { TsIconModule } from '@terminus/ui/icon';
+import { MatMenuModule } from '@angular/material/menu';
 import { TsButtonModule } from '@terminus/ui/button';
+import { TsIconModule } from '@terminus/ui/icon';
 
 import { TsMenuComponent } from './menu.component';
 

--- a/terminus-ui/navigation/src/navigation.component.ts
+++ b/terminus-ui/navigation/src/navigation.component.ts
@@ -14,8 +14,8 @@ import {
   ViewChildren,
   ViewEncapsulation,
 } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
 import { groupBy } from '@terminus/ngx-tools';
+import { BehaviorSubject } from 'rxjs';
 
 
 /**

--- a/terminus-ui/navigation/src/navigation.module.ts
+++ b/terminus-ui/navigation/src/navigation.module.ts
@@ -1,11 +1,11 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
-import { RouterModule } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatMenuModule } from '@angular/material/menu';
-import { TsPipesModule } from '@terminus/ui/pipes';
+import { RouterModule } from '@angular/router';
 import { TsIconModule } from '@terminus/ui/icon';
+import { TsPipesModule } from '@terminus/ui/pipes';
 import { TsTooltipModule } from '@terminus/ui/tooltip';
 
 import { TsNavigationComponent } from './navigation.component';

--- a/terminus-ui/paginator/src/paginator.component.spec.ts
+++ b/terminus-ui/paginator/src/paginator.component.spec.ts
@@ -3,7 +3,7 @@ import {
   SimpleChanges,
 } from '@angular/core';
 import { ChangeDetectorRefMock } from '@terminus/ngx-tools/testing';
-import { TsSelectComponent, TsSelectChange } from '@terminus/ui/select';
+import { TsSelectChange, TsSelectComponent } from '@terminus/ui/select';
 
 import { TsPaginatorComponent } from './paginator.component';
 

--- a/terminus-ui/paginator/src/paginator.component.ts
+++ b/terminus-ui/paginator/src/paginator.component.ts
@@ -13,13 +13,13 @@ import {
   TemplateRef,
   ViewEncapsulation,
 } from '@angular/core';
+import { isBoolean } from '@terminus/ngx-tools';
 import {
   coerceBooleanProperty,
   coerceNumberProperty,
 } from '@terminus/ngx-tools/coercion';
 import { TsSelectChange } from '@terminus/ui/select';
 import { inputHasChanged, TsStyleThemeTypes } from '@terminus/ui/utilities';
-import { isBoolean } from '@terminus/ngx-tools';
 
 
 /**

--- a/terminus-ui/paginator/src/paginator.module.ts
+++ b/terminus-ui/paginator/src/paginator.module.ts
@@ -1,9 +1,9 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TsButtonModule } from '@terminus/ui/button';
-import { TsSelectModule } from '@terminus/ui/select';
 import { TsMenuModule } from '@terminus/ui/menu';
+import { TsSelectModule } from '@terminus/ui/select';
 import { TsTooltipModule } from '@terminus/ui/tooltip';
 
 import { TsPaginatorComponent } from './paginator.component';

--- a/terminus-ui/pipes/src/pipes.module.ts
+++ b/terminus-ui/pipes/src/pipes.module.ts
@@ -1,5 +1,5 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 
 import { TsDatePipe } from './date/date.pipe';
 import { TsRoundNumberPipe } from './round-number/round-number.pipe';

--- a/terminus-ui/radio-group/src/radio-group.component.ts
+++ b/terminus-ui/radio-group/src/radio-group.component.ts
@@ -11,6 +11,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { MatRadioChange } from '@angular/material/radio';
+import { DomSanitizer } from '@angular/platform-browser';
 import {
   hasRequiredControl,
   isBoolean,
@@ -18,7 +19,6 @@ import {
   untilComponentDestroyed,
 } from '@terminus/ngx-tools';
 import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
-import { DomSanitizer } from '@angular/platform-browser';
 import {
   ControlValueAccessorProviderFactory,
   TsReactiveFormBaseComponent,

--- a/terminus-ui/radio-group/src/radio-group.module.ts
+++ b/terminus-ui/radio-group/src/radio-group.module.ts
@@ -1,9 +1,9 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatRadioModule } from '@angular/material/radio';
+import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatRippleModule } from '@angular/material/core';
+import { MatRadioModule } from '@angular/material/radio';
 import { TsIconModule } from '@terminus/ui/icon';
 import { TsValidationMessagesModule } from '@terminus/ui/validation-messages';
 

--- a/terminus-ui/radio-group/testing/src/test-helpers.ts
+++ b/terminus-ui/radio-group/testing/src/test-helpers.ts
@@ -1,7 +1,7 @@
+import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { TsRadioGroupComponent } from '@terminus/ui/radio-group';
-import { DebugElement } from '@angular/core';
 
 
 /**

--- a/terminus-ui/scrollbars/src/scrollbars.component.ts
+++ b/terminus-ui/scrollbars/src/scrollbars.component.ts
@@ -9,13 +9,13 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
+import { isBoolean } from '@terminus/ngx-tools';
+import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import {
   Geometry,
   PerfectScrollbarDirective,
   Position,
 } from 'ngx-perfect-scrollbar';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
-import { isBoolean } from '@terminus/ngx-tools';
 
 
 /**

--- a/terminus-ui/scrollbars/src/scrollbars.module.ts
+++ b/terminus-ui/scrollbars/src/scrollbars.module.ts
@@ -1,5 +1,5 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { PerfectScrollbarModule } from 'ngx-perfect-scrollbar';
 
 import { TsScrollbarsComponent } from './scrollbars.component';

--- a/terminus-ui/search/src/search.module.ts
+++ b/terminus-ui/search/src/search.module.ts
@@ -1,9 +1,9 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
-import { TsInputModule } from '@terminus/ui/input';
+import { ReactiveFormsModule } from '@angular/forms';
 import { TsButtonModule } from '@terminus/ui/button';
+import { TsInputModule } from '@terminus/ui/input';
 
 import { TsSearchComponent } from './search.component';
 

--- a/terminus-ui/select/src/autocomplete/autocomplete-panel.component.ts
+++ b/terminus-ui/select/src/autocomplete/autocomplete-panel.component.ts
@@ -1,3 +1,4 @@
+import { ActiveDescendantKeyManager } from '@angular/cdk/a11y';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
@@ -12,14 +13,13 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { ActiveDescendantKeyManager } from '@angular/cdk/a11y';
 import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 
+import { TsSelectOptgroupComponent } from './../optgroup/optgroup.component';
 import {
   TS_OPTION_PARENT_COMPONENT,
   TsSelectOptionComponent,
 } from './../option/option.component';
-import { TsSelectOptgroupComponent } from './../optgroup/optgroup.component';
 
 
 /**

--- a/terminus-ui/select/src/autocomplete/autocomplete-trigger.directive.ts
+++ b/terminus-ui/select/src/autocomplete/autocomplete-trigger.directive.ts
@@ -1,4 +1,14 @@
 import {
+  FlexibleConnectedPositionStrategy,
+  Overlay,
+  OverlayConfig,
+  OverlayRef,
+  PositionStrategy,
+  ScrollStrategy,
+  ViewportRuler,
+} from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
+import {
   ChangeDetectorRef,
   Directive,
   ElementRef,
@@ -14,15 +24,19 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import {
-  FlexibleConnectedPositionStrategy,
-  Overlay,
-  OverlayConfig,
-  OverlayRef,
-  PositionStrategy,
-  ScrollStrategy,
-  ViewportRuler,
-} from '@angular/cdk/overlay';
-import { TemplatePortal } from '@angular/cdk/portal';
+  isBoolean,
+  TsDocumentService,
+} from '@terminus/ngx-tools';
+import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import {
+  DOWN_ARROW,
+  ENTER,
+  ESCAPE,
+  TAB,
+  UP_ARROW,
+} from '@terminus/ngx-tools/keycodes';
+import { TsFormFieldComponent } from '@terminus/ui/form-field';
+import { ControlValueAccessorProviderFactory } from '@terminus/ui/utilities';
 import {
   defer,
   fromEvent,
@@ -40,24 +54,10 @@ import {
   take,
   tap,
 } from 'rxjs/operators';
-import {
-  isBoolean,
-  TsDocumentService,
-} from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
-import {
-  DOWN_ARROW,
-  ENTER,
-  ESCAPE,
-  TAB,
-  UP_ARROW,
-} from '@terminus/ngx-tools/keycodes';
-import { TsFormFieldComponent } from '@terminus/ui/form-field';
-import { ControlValueAccessorProviderFactory } from '@terminus/ui/utilities';
 
+import { countGroupLabelsBeforeOption, getOptionScrollPosition } from '../option/option-utilities';
 import { TsOptionSelectionChange, TsSelectOptionComponent } from '../option/option.component';
 import { TsAutocompletePanelComponent } from './autocomplete-panel.component';
-import { countGroupLabelsBeforeOption, getOptionScrollPosition } from '../option/option-utilities';
 
 
 /**

--- a/terminus-ui/select/src/optgroup/optgroup.component.ts
+++ b/terminus-ui/select/src/optgroup/optgroup.component.ts
@@ -12,21 +12,21 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
+import { isBoolean } from '@terminus/ngx-tools';
 import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsCheckboxComponent } from '@terminus/ui/checkbox';
-import { isBoolean } from '@terminus/ngx-tools';
 
+import {
+  allOptionsAreSelected,
+  someOptionsAreSelected,
+  toggleAllOptions,
+} from './../option/option-utilities';
 import {
   TS_OPTGROUP_PARENT_COMPONENT,
   TS_OPTION_PARENT_COMPONENT,
   TsOptionParentComponent,
   TsSelectOptionComponent,
 } from './../option/option.component';
-import {
-  allOptionsAreSelected,
-  someOptionsAreSelected,
-  toggleAllOptions,
-} from './../option/option-utilities';
 
 
 // Unique ID for each instance

--- a/terminus-ui/select/src/option/option-utilities.spec.ts
+++ b/terminus-ui/select/src/option/option-utilities.spec.ts
@@ -4,23 +4,23 @@ import {
   Type,
 } from '@angular/core';
 import {
-  FormControl,
-  ReactiveFormsModule,
-} from '@angular/forms';
-import {
   ComponentFixture,
   TestBed,
 } from '@angular/core/testing';
+import {
+  FormControl,
+  ReactiveFormsModule,
+} from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { getSelectInstance } from '@terminus/ui/select/testing';
 
+import { TsSelectModule } from '../select.module';
 import {
   allOptionsAreSelected,
   getOptionScrollPosition,
   someOptionsAreSelected,
   toggleAllOptions,
 } from './option-utilities';
-import { TsSelectModule } from '../select.module';
 
 
 // tslint:disable: no-use-before-declare

--- a/terminus-ui/select/src/option/option-utilities.ts
+++ b/terminus-ui/select/src/option/option-utilities.ts
@@ -1,7 +1,7 @@
 import { QueryList } from '@angular/core';
 
-import { TsSelectOptionComponent } from './option.component';
 import { TsSelectOptgroupComponent } from './../optgroup/optgroup.component';
+import { TsSelectOptionComponent } from './option.component';
 
 
 /**

--- a/terminus-ui/select/src/option/option.component.ts
+++ b/terminus-ui/select/src/option/option.component.ts
@@ -1,3 +1,4 @@
+import { Highlightable } from '@angular/cdk/a11y';
 import {
   AfterContentInit,
   AfterViewChecked,
@@ -20,13 +21,12 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { NgModel } from '@angular/forms';
-import { Highlightable } from '@angular/cdk/a11y';
+import { isBoolean } from '@terminus/ngx-tools';
 import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { ENTER, SPACE } from '@terminus/ngx-tools/keycodes';
+import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 import { Subject } from 'rxjs';
 import { take } from 'rxjs/operators';
-import { TsStyleThemeTypes } from '@terminus/ui/utilities';
-import { isBoolean } from '@terminus/ngx-tools';
 
 import { TsSelectOption } from './../select.component';
 import { TsSelectOptionDisplayDirective } from './option-display.directive';

--- a/terminus-ui/select/src/select.component.spec.ts
+++ b/terminus-ui/select/src/select.component.spec.ts
@@ -3,10 +3,6 @@ import {
   Type,
 } from '@angular/core';
 import {
-  FormsModule,
-  ReactiveFormsModule,
-} from '@angular/forms';
-import {
   async,
   ComponentFixture,
   fakeAsync,
@@ -14,15 +10,11 @@ import {
   tick,
 } from '@angular/core/testing';
 import {
-  createFakeEvent,
-  createKeyboardEvent,
-  dispatchEvent,
-  dispatchKeyboardEvent,
-  dispatchMouseEvent,
-  typeInElement,
-} from '@terminus/ngx-tools/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+  FormsModule,
+  ReactiveFormsModule,
+} from '@angular/forms';
 import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   A,
   BACKSPACE,
@@ -35,6 +27,15 @@ import {
   TAB,
   UP_ARROW,
 } from '@terminus/ngx-tools/keycodes';
+import {
+  createFakeEvent,
+  createKeyboardEvent,
+  dispatchEvent,
+  dispatchKeyboardEvent,
+  dispatchMouseEvent,
+  typeInElement,
+} from '@terminus/ngx-tools/testing';
+import { createComponent as createComponentInner } from '@terminus/ngx-tools/testing';
 import * as testComponents from '@terminus/ui/select/testing';
 import {
   createKeydownEvent,
@@ -54,10 +55,9 @@ import {
   openSelect,
 } from '@terminus/ui/select/testing';
 import { getValidationMessageElement } from '@terminus/ui/validation-messages/testing';
-import { createComponent as createComponentInner } from '@terminus/ngx-tools/testing';
 
 import { TsSelectOptionComponent } from './option/option.component';
-import { TsSelectModule, TsSelectFormatFn, TsSelectOption } from './select.module';
+import { TsSelectFormatFn, TsSelectModule, TsSelectOption } from './select.module';
 
 
 function createComponent<T>(component: Type<T>): ComponentFixture<T> {

--- a/terminus-ui/select/src/select.component.ts
+++ b/terminus-ui/select/src/select.component.ts
@@ -1,3 +1,6 @@
+import { ActiveDescendantKeyManager } from '@angular/cdk/a11y';
+import { SelectionModel } from '@angular/cdk/collections';
+import { CdkConnectedOverlay, ViewportRuler } from '@angular/cdk/overlay';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
@@ -22,10 +25,11 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import {
-  coerceArray,
-  coerceBooleanProperty,
-  coerceNumberProperty,
-} from '@terminus/ngx-tools/coercion';
+  FormControl,
+  NgControl,
+} from '@angular/forms';
+import { MAT_CHECKBOX_CLICK_ACTION } from '@angular/material/checkbox';
+import { MatChipList } from '@angular/material/chips';
 import {
   hasRequiredControl,
   isBoolean,
@@ -34,6 +38,25 @@ import {
   TsDocumentService,
   untilComponentDestroyed,
 } from '@terminus/ngx-tools';
+import {
+  coerceArray,
+  coerceBooleanProperty,
+  coerceNumberProperty,
+} from '@terminus/ngx-tools/coercion';
+import {
+  A,
+  DOWN_ARROW,
+  END,
+  ENTER,
+  HOME,
+  LEFT_ARROW,
+  RIGHT_ARROW,
+  SPACE,
+  UP_ARROW,
+} from '@terminus/ngx-tools/keycodes';
+import { TsFormFieldControl } from '@terminus/ui/form-field';
+import { TS_SPACING } from '@terminus/ui/spacing';
+import { inputHasChanged, TsStyleThemeTypes } from '@terminus/ui/utilities';
 import {
   BehaviorSubject,
   defer,
@@ -51,36 +74,13 @@ import {
   take,
   takeUntil,
 } from 'rxjs/operators';
-import { SelectionModel } from '@angular/cdk/collections';
-import { CdkConnectedOverlay, ViewportRuler } from '@angular/cdk/overlay';
-import { ActiveDescendantKeyManager } from '@angular/cdk/a11y';
-import {
-  FormControl,
-  NgControl,
-} from '@angular/forms';
-import {
-  A,
-  DOWN_ARROW,
-  END,
-  ENTER,
-  HOME,
-  LEFT_ARROW,
-  RIGHT_ARROW,
-  SPACE,
-  UP_ARROW,
-} from '@terminus/ngx-tools/keycodes';
-import { MatChipList } from '@angular/material/chips';
-import { MAT_CHECKBOX_CLICK_ACTION } from '@angular/material/checkbox';
-import { TS_SPACING } from '@terminus/ui/spacing';
-import { TsFormFieldControl } from '@terminus/ui/form-field';
-import { inputHasChanged, TsStyleThemeTypes } from '@terminus/ui/utilities';
 
 
 import {
-  TS_OPTION_PARENT_COMPONENT,
-  TsOptionSelectionChange,
-  TsSelectOptionComponent,
-} from './option/option.component';
+  TsAutocompletePanelComponent,
+  TsAutocompletePanelSelectedEvent,
+} from './autocomplete/autocomplete-panel.component';
+import { TsAutocompleteTriggerDirective } from './autocomplete/autocomplete-trigger.directive';
 import { TsSelectOptgroupComponent } from './optgroup/optgroup.component';
 import {
   allOptionsAreSelected,
@@ -89,13 +89,13 @@ import {
   someOptionsAreSelected,
   toggleAllOptions,
 } from './option/option-utilities';
+import {
+  TS_OPTION_PARENT_COMPONENT,
+  TsOptionSelectionChange,
+  TsSelectOptionComponent,
+} from './option/option.component';
 import { tsSelectAnimations } from './select-animations';
 import { TsSelectTriggerComponent } from './select-trigger.component';
-import { TsAutocompleteTriggerDirective } from './autocomplete/autocomplete-trigger.directive';
-import {
-  TsAutocompletePanelComponent,
-  TsAutocompletePanelSelectedEvent,
-} from './autocomplete/autocomplete-panel.component';
 
 
 /**

--- a/terminus-ui/select/src/select.module.ts
+++ b/terminus-ui/select/src/select.module.ts
@@ -1,27 +1,27 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { OverlayModule } from '@angular/cdk/overlay';
-import { MatRippleModule } from '@angular/material/core';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatChipsModule } from '@angular/material/chips';
+import { MatRippleModule } from '@angular/material/core';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { TsValidationMessagesModule } from '@terminus/ui/validation-messages';
-import { TsIconModule } from '@terminus/ui/icon';
 import { TsCheckboxModule } from '@terminus/ui/checkbox';
-import { TsInputModule } from '@terminus/ui/input';
 import { TsFormFieldModule } from '@terminus/ui/form-field';
+import { TsIconModule } from '@terminus/ui/icon';
+import { TsInputModule } from '@terminus/ui/input';
+import { TsValidationMessagesModule } from '@terminus/ui/validation-messages';
 
-import { TsSelectComponent } from './select.component';
-import { TsSelectOptionComponent } from './option/option.component';
-import { TsSelectOptgroupComponent } from './optgroup/optgroup.component';
-import { TsSelectTriggerComponent } from './select-trigger.component';
 import { TsAutocompletePanelComponent } from './autocomplete/autocomplete-panel.component';
 import {
   TS_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY_PROVIDER,
   TsAutocompleteTriggerDirective,
 } from './autocomplete/autocomplete-trigger.directive';
+import { TsSelectOptgroupComponent } from './optgroup/optgroup.component';
 import { TsSelectOptionDisplayDirective } from './option/option-display.directive';
+import { TsSelectOptionComponent } from './option/option.component';
+import { TsSelectTriggerComponent } from './select-trigger.component';
+import { TsSelectComponent } from './select.component';
 
 
 export * from './select.component';

--- a/terminus-ui/select/testing/src/test-components.ts
+++ b/terminus-ui/select/testing/src/test-components.ts
@@ -1,12 +1,12 @@
 // tslint:disable: component-class-suffix
-import { Component, NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { Component, NgModule } from '@angular/core';
 import {
   FormControl,
   FormsModule,
   ReactiveFormsModule,
-  Validators,
   Validator,
+  Validators,
 } from '@angular/forms';
 import {
   TsSelectModule,

--- a/terminus-ui/select/testing/src/test-helpers.ts
+++ b/terminus-ui/select/testing/src/test-helpers.ts
@@ -1,12 +1,12 @@
+import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
 import { MatChip } from '@angular/material/chips';
+import { By } from '@angular/platform-browser';
 import {
   TsSelectComponent,
   TsSelectOptgroupComponent,
   TsSelectOptionComponent,
 } from '@terminus/ui/select';
-import { DebugElement } from '@angular/core';
 
 
 /**

--- a/terminus-ui/sort/src/sort-header.component.ts
+++ b/terminus-ui/sort/src/sort-header.component.ts
@@ -1,4 +1,5 @@
 // tslint:disable: use-input-property-decorator triple-equals
+import { CdkColumnDef } from '@angular/cdk/table';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -11,19 +12,18 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { CanDisable, mixinDisabled } from '@angular/material/core';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import {
   isBoolean,
   untilComponentDestroyed,
 } from '@terminus/ngx-tools';
-import { CdkColumnDef } from '@angular/cdk/table';
+import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { merge } from 'rxjs';
 
+import { tsSortAnimations } from './sort-animations';
+import { getSortHeaderNotContainedWithinSortError } from './sort-errors';
+import { TsSortHeaderIntl } from './sort-header-intl';
 import { TsSortDirective } from './sort.directive';
 import { TsSortableItem } from './sort.directive';
-import { TsSortHeaderIntl } from './sort-header-intl';
-import { getSortHeaderNotContainedWithinSortError } from './sort-errors';
-import { tsSortAnimations } from './sort-animations';
 
 
 // Boilerplate for applying mixins to the sort header.

--- a/terminus-ui/sort/src/sort.directive.ts
+++ b/terminus-ui/sort/src/sort.directive.ts
@@ -9,15 +9,15 @@ import {
   OnDestroy,
   Output,
 } from '@angular/core';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { CanDisable, mixinDisabled } from '@angular/material/core';
-import { Subject } from 'rxjs';
 import { isBoolean } from '@terminus/ngx-tools';
+import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import { Subject } from 'rxjs';
 
 import {
-  getSortInvalidDirectionError,
   getSortDuplicateSortableIdError,
   getSortHeaderMissingIdError,
+  getSortInvalidDirectionError,
 } from './sort-errors';
 
 

--- a/terminus-ui/sort/src/sort.module.ts
+++ b/terminus-ui/sort/src/sort.module.ts
@@ -1,8 +1,8 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 
-import { TsSortHeaderComponent } from './sort-header.component';
 import { TS_SORT_HEADER_INTL_PROVIDER } from './sort-header-intl';
+import { TsSortHeaderComponent } from './sort-header.component';
 import { TsSortDirective } from './sort.directive';
 
 export * from './sort-animations';

--- a/terminus-ui/sort/src/sort.spec.ts
+++ b/terminus-ui/sort/src/sort.spec.ts
@@ -15,21 +15,15 @@ import {
   TestModuleMetadata,
 } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 import {
+  configureTestBedWithoutReset,
   dispatchMouseEvent,
   wrappedErrorMessage,
-  configureTestBedWithoutReset,
 } from '@terminus/ngx-tools/testing';
 import { TsTableModule } from '@terminus/ui/table';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
-import { TsSortDirective } from './sort.directive';
-import { TsSortModule } from './sort.module';
-import {
-  TsSortDirection,
-  TsSortState,
-} from './sort.directive';
 import {
   getSortDuplicateSortableIdError,
   getSortHeaderMissingIdError,
@@ -37,6 +31,12 @@ import {
   getSortInvalidDirectionError,
 } from './sort-errors';
 import { TsSortHeaderComponent } from './sort-header.component';
+import { TsSortDirective } from './sort.directive';
+import {
+  TsSortDirection,
+  TsSortState,
+} from './sort.directive';
+import { TsSortModule } from './sort.module';
 
 
 /**

--- a/terminus-ui/spacing/src/spacing.module.ts
+++ b/terminus-ui/spacing/src/spacing.module.ts
@@ -1,5 +1,5 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 
 import { TsVerticalSpacingDirective } from './vertical-spacing.directive';
 

--- a/terminus-ui/spacing/src/vertical-spacing.directive.spec.ts
+++ b/terminus-ui/spacing/src/vertical-spacing.directive.spec.ts
@@ -1,7 +1,7 @@
 import { ElementRefMock } from '@terminus/ngx-tools/testing';
 
-import { TsVerticalSpacingDirective } from './vertical-spacing.directive';
 import { TS_SPACING } from './spacing.constant';
+import { TsVerticalSpacingDirective } from './vertical-spacing.directive';
 
 
 describe(`TsVerticalSpacingDirective`, function() {

--- a/terminus-ui/table/src/cell.ts
+++ b/terminus-ui/table/src/cell.ts
@@ -2,19 +2,19 @@
 // directive. So we are disabling the `directive-selector` rule
 // tslint:disable: directive-selector
 import {
-  Directive,
-  ElementRef,
-  Input,
-  Renderer,
-  isDevMode,
-} from '@angular/core';
-import {
   CdkCell,
   CdkCellDef,
   CdkColumnDef,
   CdkHeaderCell,
   CdkHeaderCellDef,
 } from '@angular/cdk/table';
+import {
+  Directive,
+  ElementRef,
+  Input,
+  isDevMode,
+  Renderer,
+} from '@angular/core';
 
 export type TsTableColumnAlignment
   = 'left'

--- a/terminus-ui/table/src/row.ts
+++ b/terminus-ui/table/src/row.ts
@@ -1,16 +1,16 @@
 import {
-  ChangeDetectionStrategy,
-  Component,
-  Directive,
-  ViewEncapsulation,
-} from '@angular/core';
-import {
   CDK_ROW_TEMPLATE,
   CdkHeaderRow,
   CdkHeaderRowDef,
   CdkRow,
   CdkRowDef,
 } from '@angular/cdk/table';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Directive,
+  ViewEncapsulation,
+} from '@angular/core';
 
 
 /**

--- a/terminus-ui/table/src/table.component.spec.ts
+++ b/terminus-ui/table/src/table.component.spec.ts
@@ -1,23 +1,19 @@
 // tslint:disable: no-non-null-assertion component-class-suffix
-import {
-  ComponentFixture,
-  TestBed,
-} from '@angular/core/testing';
+import { DataSource } from '@angular/cdk/collections';
 import {
   Component,
   Provider,
   Type,
   ViewChild,
 } from '@angular/core';
+import {
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { DataSource } from '@angular/cdk/collections';
 import { TsWindowService } from '@terminus/ngx-tools';
 import { TsWindowServiceMock } from '@terminus/ngx-tools/testing';
-import {
-  BehaviorSubject,
-  Observable,
-} from 'rxjs';
 import {
   TsPaginatorComponent,
   TsPaginatorModule,
@@ -27,10 +23,14 @@ import {
   TsSortHeaderComponent,
   TsSortModule,
 } from '@terminus/ui/sort';
+import {
+  BehaviorSubject,
+  Observable,
+} from 'rxjs';
 
 import { TsTableDataSource } from './table-data-source';
-import { TsTableModule } from './table.module';
 import { TsTableComponent } from './table.component';
+import { TsTableModule } from './table.module';
 
 
 

--- a/terminus-ui/table/src/table.component.ts
+++ b/terminus-ui/table/src/table.component.ts
@@ -1,9 +1,9 @@
+import { CdkTable } from '@angular/cdk/table';
 import {
   ChangeDetectionStrategy,
   Component,
   ViewEncapsulation,
 } from '@angular/core';
-import { CdkTable } from '@angular/cdk/table';
 
 
 /**

--- a/terminus-ui/table/src/table.module.ts
+++ b/terminus-ui/table/src/table.module.ts
@@ -1,8 +1,8 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { CdkTableModule } from '@angular/cdk/table';
-import { TsSortModule } from '@terminus/ui/sort';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { TsPaginatorModule } from '@terminus/ui/paginator';
+import { TsSortModule } from '@terminus/ui/sort';
 
 import {
   TsCellDefDirective,

--- a/terminus-ui/toggle/src/toggle.component.ts
+++ b/terminus-ui/toggle/src/toggle.component.ts
@@ -8,8 +8,8 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { MatSlideToggleChange } from '@angular/material/slide-toggle';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { isBoolean } from '@terminus/ngx-tools';
+import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import {
   ControlValueAccessorProviderFactory,
   TsReactiveFormBaseComponent,

--- a/terminus-ui/toggle/src/toggle.module.ts
+++ b/terminus-ui/toggle/src/toggle.module.ts
@@ -1,5 +1,5 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 

--- a/terminus-ui/tooltip/src/tooltip.component.ts
+++ b/terminus-ui/tooltip/src/tooltip.component.ts
@@ -5,8 +5,8 @@ import {
   isDevMode,
   ViewEncapsulation,
 } from '@angular/core';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { isBoolean } from '@terminus/ngx-tools';
+import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 
 
 /**

--- a/terminus-ui/tooltip/src/tooltip.module.ts
+++ b/terminus-ui/tooltip/src/tooltip.module.ts
@@ -1,5 +1,5 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { TsTooltipComponent } from './tooltip.component';

--- a/terminus-ui/validation-messages/src/validation-messages.component.ts
+++ b/terminus-ui/validation-messages/src/validation-messages.component.ts
@@ -7,11 +7,11 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import {
   isBoolean,
   untilComponentDestroyed,
 } from '@terminus/ngx-tools';
+import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 
 import { TsValidationMessagesService } from './validation-messages.service';
 

--- a/terminus-ui/validation-messages/src/validation-messages.module.ts
+++ b/terminus-ui/validation-messages/src/validation-messages.module.ts
@@ -1,10 +1,10 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { TsDatePipe, TsPipesModule } from '@terminus/ui/pipes';
-import { TsValidationMessagesService } from './validation-messages.service';
 import { TsValidationMessagesComponent } from './validation-messages.component';
+import { TsValidationMessagesService } from './validation-messages.service';
 
 export * from './validation-messages.service';
 export * from './validation-messages.component';

--- a/terminus-ui/validators/src/validators/maxDate/maxDate.ts
+++ b/terminus-ui/validators/src/validators/maxDate/maxDate.ts
@@ -3,8 +3,8 @@ import {
   ValidationErrors,
   ValidatorFn,
 } from '@angular/forms';
-import { isValid } from 'date-fns';
 import { isAbstractControl } from '@terminus/ui/utilities';
+import { isValid } from 'date-fns';
 
 
 /**

--- a/terminus-ui/validators/src/validators/minDate/minDate.ts
+++ b/terminus-ui/validators/src/validators/minDate/minDate.ts
@@ -3,8 +3,8 @@ import {
   ValidationErrors,
   ValidatorFn,
 } from '@angular/forms';
-import { isValid } from 'date-fns';
 import { isAbstractControl } from '@terminus/ui/utilities';
+import { isValid } from 'date-fns';
 
 
 /**

--- a/terminus-ui/validators/src/validators/url/url.ts
+++ b/terminus-ui/validators/src/validators/url/url.ts
@@ -1,7 +1,7 @@
 import {
-  ValidatorFn,
   AbstractControl,
   ValidationErrors,
+  ValidatorFn,
 } from '@angular/forms';
 
 import { urlRegex } from '@terminus/ngx-tools/regex';

--- a/tslint.json
+++ b/tslint.json
@@ -121,6 +121,7 @@
       true,
       "ignore-for-loop"
     ],
+    "ordered-imports": true,
     "pipe-impure": true,
     "prefer-const": true,
     "quotemark": [


### PR DESCRIPTION
ISSUES CLOSED: #1404 

NOTE: This touches pretty much every lib file so it will likely cause conflicts if you were already branched off of master. Any conflicts should be fairly easy to fix as the changes are scoped to only file imports.

---

This adds a tslint rule to enforce a) alphabetically sorted imports and b) imports grouped by library. Both of these are 'fixable' rules, so running `yarn run lint` will automatically fix the order (that's what was run to create all the changes in this PR - `tslint.json` was the only manually edited file).

While this doesn't split 3rd party and local imports, it does respect that separation if it already exists.

I _highly_ recommend setting your editor up to run the lint command on save so that you don't need to think about this at all. It will automatically add missed semi-colons, trailing commas, fix spacing issues and more.

VSCode setting for `tslint`: 

```
"editor.codeActionsOnSave": {
    "source.fixAll.tslint": true
}
```

Reference: https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin