### PR TITLE
chore(ValidationMessages): phrasing is aligned

### DIFF
--- a/terminus-ui/validation-messages/src/validation-messages.service.ts
+++ b/terminus-ui/validation-messages/src/validation-messages.service.ts
@@ -44,12 +44,8 @@ export class TsValidationMessagesService {
       // Standard responses:
       required: `Required`,
       requiredTrue: `${validatorName} must be checked.`,
-      // @deprecated target 11.x :  use minLength instead of minlength
-      minlength: `Minimum length ${validatorValue.requiredLength}`,
-      minLength: `Minimum length ${validatorValue.requiredLength}.`,
-      // @deprecated target 11.x : use maxLength insted of maxlength
-      maxlength: `Maximum length ${validatorValue.requiredLength}`,
-      maxLength: `Maximum length ${validatorValue.requiredLength}.`,
+      minLength: `Must be at least ${validatorValue.requiredLength} characters.`,
+      maxLength: `Must be less than ${validatorValue.requiredLength} characters.`,
       // Custom responses:
       creditCard: creditCardMessage,
       email: emailMessage,
@@ -61,15 +57,11 @@ export class TsValidationMessagesService {
       pattern: `Must contain only letters, numbers or spaces`,
       maxDate: '',
       minDate: '',
-      min: `${validatorValue.actual} is less than ${validatorValue.min}.`,
-      greaterThan: `${validatorValue.actual} is not greater than ${validatorValue.greaterThan}`,
-      greaterThanOrEqual: `${validatorValue.actual} is not greater than or equal to ${validatorValue.greaterThanOrEqual}`,
-      // @deprecated target 11.x : use min instead of greaterThanOrEqual
+      min: `${validatorValue.actual} must be greater than ${validatorValue.min}.`,
+      greaterThan: `${validatorValue.actual} must be less than ${validatorValue.greaterThan}`,
       numbers: `Must contain at least ${validatorValue.numbers} numbers`,
-      max: `${validatorValue.actual} is greater than ${validatorValue.max}.`,
-      lessThan: `${validatorValue.actual} is not less than ${validatorValue.lessThan}.`,
-      // @deprecated target 11.x : use max instead of lessThanOrEqual
-      lessThanOrEqual: `${validatorValue.actual} is not less than or equal to ${validatorValue.lessThanOrEqual}.`,
+      max: `${validatorValue.actual} must be less than ${validatorValue.max}.`,
+      lessThan: `${validatorValue.actual} must be less than ${validatorValue.lessThan}.`,
       notUnique: `${validatorValue.actual} has already been selected.`,
       noResults: `No results found.`,
       url: `'${validatorValue.actual}' must be a valid URL.`,

--- a/terminus-ui/validation-messages/src/validation-messages.services.spec.ts
+++ b/terminus-ui/validation-messages/src/validation-messages.services.spec.ts
@@ -18,14 +18,14 @@ describe(`TsValidationMessagesService`, function() {
 
   describe(`getValidatorErrorMessage()`, () => {
 
-    test(`should return a supplied message`, () => {
+    test(`should return a supplied minLength message`, () => {
       const validatorValueMock = {
         requiredLength: 9,
       };
-      const actual = service.getValidatorErrorMessage('minlength', validatorValueMock);
-      const expected = `Minimum length 9`;
+      const actual = service.getValidatorErrorMessage('minLength', validatorValueMock);
+      const expected = `be at least 9`;
 
-      expect(actual).toEqual(expected);
+      expect(actual).toEqual(expect.stringContaining(expected));
     });
 
 
@@ -34,9 +34,9 @@ describe(`TsValidationMessagesService`, function() {
         lowercase: 4,
       };
       const actual = service.getValidatorErrorMessage('lowercase', validatorValueMock);
-      const expected = `Must contain at least 4 lowercase letters`;
+      const expected = `4 lowercase letters`;
 
-      expect(actual).toEqual(expected);
+      expect(actual).toEqual(expect.stringContaining(expected));
     });
 
 
@@ -44,10 +44,10 @@ describe(`TsValidationMessagesService`, function() {
       const validatorValueMock = {
         requiredLength: 12,
       };
-      const actual = service.getValidatorErrorMessage('maxlength', validatorValueMock);
-      const expected = `Maximum length 12`;
+      const actual = service.getValidatorErrorMessage('maxLength', validatorValueMock);
+      const expected = `less than 12`;
 
-      expect(actual).toEqual(expected);
+      expect(actual).toEqual(expect.stringContaining(expected));
     });
 
 
@@ -98,9 +98,9 @@ describe(`TsValidationMessagesService`, function() {
             min: 10,
           };
           const actual = service.getValidatorErrorMessage('min', validatorValueMock);
-          const expected = `5 is less than 10.`;
+          const expected = `must be greater than 10.`;
 
-          expect(actual).toEqual(expected);
+          expect(actual).toEqual(expect.stringContaining(expected));
       });
 
       test(`max should should return max message`, () => {
@@ -109,9 +109,9 @@ describe(`TsValidationMessagesService`, function() {
           max: 10,
         };
         const actual = service.getValidatorErrorMessage('max', validatorValueMock);
-        const expected = `15 is greater than 10.`;
+        const expected = `must be less than 10.`;
 
-        expect(actual).toEqual(expected);
+        expect(actual).toEqual(expect.stringContaining(expected));
       });
 
       test(`requiredTrue should return requiredTrue message`, () => {
@@ -119,9 +119,9 @@ describe(`TsValidationMessagesService`, function() {
           actual: false,
         };
         const actual = service.getValidatorErrorMessage('requiredTrue', validatorValueMock);
-        const expected = `requiredTrue must be checked.`;
+        const expected = `be checked.`;
 
-        expect(actual).toEqual(expected);
+        expect(actual).toEqual(expect.stringContaining(expected));
       });
 
 


### PR DESCRIPTION
- Tests are more lenient on phrasing
- Most messages use "must"
- Removed messages for the validators that were deprecated in v11.

ISSUES CLOSED: #1190