### PR TITLE
fix(CSVEntry): now encapsulating cell content and escaping quotes

### DIFF
--- a/demo/app/components/csv-entry/csv-entry.component.html
+++ b/demo/app/components/csv-entry/csv-entry.component.html
@@ -9,6 +9,7 @@
     ></ts-csv-entry>
   </div>
 
+  <button (click)="generateFile()">Generate file & download</button>
 </ts-card>
 
 

--- a/demo/app/components/csv-entry/csv-entry.component.ts
+++ b/demo/app/components/csv-entry/csv-entry.component.ts
@@ -13,6 +13,8 @@ export class CSVEntryComponent {
     this.validatorsService.url(),
   ];
   results: string | undefined;
+  blob;
+  myFile;
 
   constructor(
     private validatorsService: TsValidatorsService,
@@ -21,6 +23,33 @@ export class CSVEntryComponent {
 
   file(v: Blob) {
     console.log('DEMO: Got file from CSV entry: ', v);
+    this.blob = v;
   }
 
+
+  generateFile() {
+    this.myFile = new File([this.blob], 'testCsv');
+    saveFile(this.blob, 'test');
+  }
+
+
+}
+
+
+// Helper function to generate a file download for testing purposes
+function saveFile(blob: Blob, filename: string) {
+  if (window.navigator.msSaveOrOpenBlob) {
+    window.navigator.msSaveOrOpenBlob(blob, filename);
+  } else {
+    const a = document.createElement('a');
+    document.body.appendChild(a);
+    const url = window.URL.createObjectURL(blob);
+    a.href = url;
+    a.download = filename;
+    a.click();
+    setTimeout(() => {
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    }, 0);
+  }
 }

--- a/terminus-ui/csv-entry/src/csv-entry.component.ts
+++ b/terminus-ui/csv-entry/src/csv-entry.component.ts
@@ -851,12 +851,16 @@ export class TsCSVEntryComponent implements OnInit, OnDestroy {
   private generateBlob(content: TsCSVFormContents): Blob {
     const prefix = 'data:text/csv;charset=utf-8,';
     const headers: string = content.headers.join('\t') + '\r\n';
-    const rows: string = content.records.map((v) => v.columns.join('\t')).join('\r\n') + '\r\n';
+    const rows: string = content.records.map((v) => {
+      // Encapsulate content with quotes and escape any existing quotes
+      return v.columns.map((column) => column ? `"${column.replace(/"/g, '""')}"` : '').join('\t');
+    }).join('\r\n') + '\r\n';
     let joined: string = prefix + headers + rows;
     // istanbul ignore else
     if (this.outputFormat === 'csv') {
       joined = JSON.stringify(joined).replace(/\\t/g, ',');
     }
+
     return new Blob([joined], {type: 'text/csv'});
   }
 


### PR DESCRIPTION
This will enable users to enter cell content containing quotes and commas.

ISSUES CLOSED: #1427

- Add ability in demo to download file
- Add support for double quotes and commas within csv content