### PR TITLE
chore: Update GitHub's built-in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'Needs: planning, Type: bug'
+assignees: benjamincharity
+
+---
+
+#### 1. What is the expected behavior?
+
+
+#### 2. What is the current behavior?
+
+
+#### 3. What are the steps to reproduce?
+
+Providing a reproduction is the *best* way to share your issue.
+
+a) Fork our starter repo: https://github.com/GetTerminus/ui-stackblitz-starter
+b) Replicate your issue.
+c) Add a link to your replication or attach a zip of your project to this issue.
+d) Outline any steps needed to reproduce the issue.
+
+
+#### 4. Which versions of this library, Angular, TypeScript, & browsers are affected?
+
+- UI Library:
+- Angular:
+- TypeScript:
+- Browser(s):
+
+
+#### 5. Is there anything else we should know?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'Type: feature, Needs: planning'
+assignees: benjamincharity
+
+---
+
+### Is your feature request related to a problem? Please describe.
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+
+### Describe the solution you'd like.
+
+A clear and concise description of what you want to happen.
+
+
+### Describe alternatives you've considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+
+### Additional context
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
GitHub wasn't picking up our new issue templates. Apparently there is a different format needed. (our original issue was based off of how Material's looked)

These two templates should be selectable by users and will replace our existing templates if they work.

I'm not sure how they work alongside our existing default template. After Wendy's PR gets merged, I'll merge this and we will see. I will take point on merging them together and cleaning up as needed.

> To be included in the community profile checklist, issue templates must be located in the `.github/ISSUE_TEMPLATE` folder and contain valid `name:` and `about:` YAML front matter.