### PR TITLE
chore(Button): *BREAKING CHANGE* clicked is now emitter name

### DIFF
--- a/demo/app/components/button/button.component.html
+++ b/demo/app/components/button/button.component.html
@@ -36,7 +36,7 @@
   <div [style.textAlign]="layout">
     <ts-button
       [theme]="myTheme"
-      (clickEvent)="run('progress2')"
+      (clicked)="run('progress2')"
       [isDisabled]="disabled"
       [showProgress]="progress2"
       [iconName]="icon"
@@ -102,7 +102,7 @@
     format="hollow"
     [isDisabled]="true"
     [showProgress]="progress2"
-    (clickEvent)="run('progress2')"
+    (clicked)="run('progress2')"
     tsVerticalSpacing
   >I'm disabled AND empty inside :(</ts-button>
 </ts-card>

--- a/demo/app/components/confirmation/confirmation.component.html
+++ b/demo/app/components/confirmation/confirmation.component.html
@@ -19,7 +19,7 @@
     <ts-button
       tsConfirmation
       [showProgress]="progress"
-      (clickEvent)="submit()"
+      (clicked)="submit()"
       (cancelled)="cancel($event)"
       confirmationButtonText="Custom Confirmation Button Text"
       [explanationText]="explanation"
@@ -36,7 +36,7 @@
     <ts-button
       tsConfirmation
       [showProgress]="progress"
-      (clickEvent)="submit()"
+      (clicked)="submit()"
       (cancelled)="cancel($event)"
       confirmationButtonText="Custom Confirmation Button Text"
       [explanationText]="explanation"
@@ -53,7 +53,7 @@
   <ts-button
     tsConfirmation
     [showProgress]="progress"
-    (clickEvent)="submit()"
+    (clicked)="submit()"
     (cancelled)="cancel($event)"
     confirmationButtonText="Custom Confirmation Button Text"
     [explanationText]="explanation"

--- a/demo/app/components/expansion-panel/expansion-panel.component.html
+++ b/demo/app/components/expansion-panel/expansion-panel.component.html
@@ -178,7 +178,7 @@
       And here is my standard panel content.
 
       <ts-expansion-panel-action-row>
-        <ts-button (click)="nextStep()">
+        <ts-button (clicked)="nextStep()">
           Next
         </ts-button>
       </ts-expansion-panel-action-row>
@@ -197,10 +197,10 @@
       And here is my standard panel content.
 
       <ts-expansion-panel-action-row>
-        <ts-button format="hollow" (click)="previousStep()">
+        <ts-button format="hollow" (clicked)="previousStep()">
           Previous
         </ts-button>
-        <ts-button (click)="nextStep()">
+        <ts-button (clicked)="nextStep()">
           Next
         </ts-button>
       </ts-expansion-panel-action-row>
@@ -219,10 +219,10 @@
       And here is my standard panel content.
 
       <ts-expansion-panel-action-row>
-        <ts-button format="hollow" (click)="previousStep()">
+        <ts-button format="hollow" (clicked)="previousStep()">
           Previous
         </ts-button>
-        <ts-button (click)="nextStep()">
+        <ts-button (clicked)="nextStep()">
           End
         </ts-button>
       </ts-expansion-panel-action-row>

--- a/demo/app/components/icon-button/icon-button.component.html
+++ b/demo/app/components/icon-button/icon-button.component.html
@@ -1,7 +1,7 @@
 <ts-card>
   <div fxLayout="row" fxLayoutAlign="start center" tsVerticalSpacing>
     <div>
-      <ts-icon-button (clickEvent)="click('default')">forum</ts-icon-button>
+      <ts-icon-button (clicked)="clickTheme('default')">forum</ts-icon-button>
     </div>
 
     <div>
@@ -13,21 +13,21 @@
   <div tsVerticalSpacing>
     <ts-icon-button
       theme="primary"
-      (clickEvent)="click('primary')"
+      (clicked)="clickTheme('primary')"
     >add_circle</ts-icon-button>
   </div>
 
   <div tsVerticalSpacing>
     <ts-icon-button
       theme="accent"
-      (clickEvent)="click('accent')"
+      (clicked)="clickTheme('accent')"
     >reply_all</ts-icon-button>
   </div>
 
   <div tsVerticalSpacing>
     <ts-icon-button
       theme="warn"
-      (clickEvent)="click('warn')"
+      (clicked)="clickTheme('warn')"
     >delete_forever</ts-icon-button>
   </div>
 </ts-card>

--- a/demo/app/components/icon-button/icon-button.component.ts
+++ b/demo/app/components/icon-button/icon-button.component.ts
@@ -7,7 +7,7 @@ import { Component } from '@angular/core';
 })
 export class IconButtonComponent {
 
-  click(v: string): void {
+  clickTheme(v: string): void {
     console.log(`DEMO: '${v}' icon-button clicked.`);
   }
 

--- a/demo/app/components/menu/menu.component.html
+++ b/demo/app/components/menu/menu.component.html
@@ -65,11 +65,11 @@
   </div>
 
   <ng-template #myTemplate>
-    <ts-button (click)="customItemSelected('yup')">
+    <ts-button (clicked)="customItemSelected('yup')">
       Roger, Roger.
     </ts-button>
 
-    <ts-button (click)="customItemSelected('nope')">
+    <ts-button (clicked)="customItemSelected('nope')">
       Don't call me Shirley.
     </ts-button>
 
@@ -77,7 +77,7 @@
       A tasty link
     </ts-link>
 
-    <ts-button (click)="customItemSelected('nope')">
+    <ts-button (clicked)="customItemSelected('nope')">
       And a final button
     </ts-button>
   </ng-template>

--- a/terminus-ui/button/src/button.component.html
+++ b/terminus-ui/button/src/button.component.html
@@ -10,7 +10,7 @@
   [attr.type]="buttonType"
   [disabled]="shouldBeDisabled"
   tabindex="{{ tabIndex }}"
-  (click)="clicked($event)"
+  (click)="clickedButton($event)"
   #button
 >
   <ts-icon

--- a/terminus-ui/button/src/button.component.spec.ts
+++ b/terminus-ui/button/src/button.component.spec.ts
@@ -18,7 +18,7 @@ import { TsButtonModule } from './button.module';
     [iconName]="iconName"
     [format]="format"
     [theme]="theme"
-    (clickEvent)="clickEvent($event)"
+    (clicked)="clicked($event)"
     collapseDelay="collapseDelay"
   >Click Me!</ts-button>
   `,
@@ -36,7 +36,7 @@ class TestHostComponent implements OnInit, OnDestroy {
   buttonComponent!: TsButtonComponent;
 
   changed = jest.fn();
-  clickEvent = jest.fn();
+  clicked = jest.fn();
   private COLLAPSE_DEFAULT_DELAY = undefined;
   public ngOnInit() { }
   public ngOnDestroy() { }
@@ -65,7 +65,7 @@ describe(`TsButtonComponent`, function() {
         expect(buttonComponent.isDisabled).toEqual(false);
         expect(button.disabled).toEqual(false);
         button.click();
-        expect(component.clickEvent).toHaveBeenCalled();
+        expect(component.clicked).toHaveBeenCalled();
       });
 
       test(`should have button disabled`, () => {
@@ -73,14 +73,14 @@ describe(`TsButtonComponent`, function() {
         fixture.detectChanges();
         expect(buttonComponent.isDisabled).toEqual(true);
         expect(button.disabled).toEqual(true);
-        expect(component.clickEvent).not.toHaveBeenCalled();
+        expect(component.clicked).not.toHaveBeenCalled();
       });
     });
 
     test(`click`, () => {
-      component.buttonComponent.clickEvent.emit = jest.fn();
+      component.buttonComponent.clicked.emit = jest.fn();
       button.click();
-      expect(buttonComponent.clickEvent.emit).toHaveBeenCalled();
+      expect(buttonComponent.clicked.emit).toHaveBeenCalled();
     });
 
     describe(`showProgress`, () => {
@@ -326,27 +326,27 @@ describe(`TsButtonComponent`, function() {
     });
 
 
-    describe(`clicked()`, () => {
+    describe(`clickedButton()`, () => {
       let mouseEvent: MouseEvent;
 
       beforeEach(() => {
-        buttonComponent.clickEvent.emit = jest.fn();
+        buttonComponent.clicked.emit = jest.fn();
         mouseEvent = createMouseEvent('click');
       });
 
 
       test(`should emit the click when interceptClick is false`, () => {
-        buttonComponent.clicked(mouseEvent);
+        buttonComponent.clickedButton(mouseEvent);
 
-        expect(buttonComponent.clickEvent.emit).toHaveBeenCalledWith(mouseEvent);
+        expect(buttonComponent.clicked.emit).toHaveBeenCalledWith(mouseEvent);
       });
 
 
       test(`should not emit the click when interceptClick is true`, () => {
         buttonComponent.interceptClick = true;
-        buttonComponent.clicked(mouseEvent);
+        buttonComponent.clickedButton(mouseEvent);
 
-        expect(buttonComponent.clickEvent.emit).not.toHaveBeenCalledWith();
+        expect(buttonComponent.clicked.emit).not.toHaveBeenCalledWith();
         expect(buttonComponent.originalClickEvent).toEqual(mouseEvent);
       });
 

--- a/terminus-ui/button/src/button.component.ts
+++ b/terminus-ui/button/src/button.component.ts
@@ -75,7 +75,7 @@ export const tsButtonFormatTypesArray = ['filled', 'hollow', 'collapsable'];
  *              [collapsed]="false"
  *              collapseDelay="500"
  *              tabIndex="2"
- *              (clickEvent)="myMethod($event)"
+ *              (clicked)="myMethod($event)"
  * >Click Me!</ts-button>
  *
  * <example-url>https://getterminus.github.io/ui-demos-master/components/button</example-url>
@@ -269,7 +269,7 @@ export class TsButtonComponent implements OnInit, OnDestroy {
    * Pass the click event through to the parent
    */
   @Output()
-  public clickEvent: EventEmitter<MouseEvent> = new EventEmitter;
+  public clicked: EventEmitter<MouseEvent> = new EventEmitter();
 
   /**
    * Provide access to the inner button element
@@ -325,16 +325,16 @@ export class TsButtonComponent implements OnInit, OnDestroy {
 
 
   /**
-   * Do something when clicked
+   * Handle button clicks
    *
    * @param event - The MouseEvent
    */
-  public clicked(event: MouseEvent): void {
+  public clickedButton(event: MouseEvent): void {
     // Allow the click to propagate
     if (!this.interceptClick) {
-      this.clickEvent.emit(event);
+      this.clicked.emit(event);
     } else {
-      // Save the original event but don't emit the clickEvent
+      // Save the original event but don't emit the originalClickEvent
       this.originalClickEvent = event;
     }
   }

--- a/terminus-ui/checkbox/src/checkbox.component.ts
+++ b/terminus-ui/checkbox/src/checkbox.component.ts
@@ -190,13 +190,13 @@ export class TsCheckboxComponent extends TsReactiveFormBaseComponent {
    * Emit an event on input change
    */
   @Output()
-  readonly inputChange: EventEmitter<boolean> = new EventEmitter;
+  readonly inputChange: EventEmitter<boolean> = new EventEmitter();
 
   /**
    * Emit a change when moving from the indeterminate state
    */
   @Output()
-  readonly indeterminateChange: EventEmitter<TsCheckboxChange> = new EventEmitter;
+  readonly indeterminateChange: EventEmitter<TsCheckboxChange> = new EventEmitter();
 
 
   constructor(

--- a/terminus-ui/confirmation/src/confirmation-overlay.component.html
+++ b/terminus-ui/confirmation/src/confirmation-overlay.component.html
@@ -11,14 +11,14 @@
       class="qa-confirmation-cancel"
       theme="warn"
       format="hollow"
-      (clickEvent)="confirm.next(false)"
+      (clicked)="confirm.next(false)"
     >
       {{ cancelButtonTxt }}
     </ts-button>
 
     <ts-button
       class="qa-confirmation-confirm"
-      (clickEvent)="confirm.next(true)"
+      (clicked)="confirm.next(true)"
     >
       {{ confirmationButtonTxt }}
     </ts-button>

--- a/terminus-ui/confirmation/src/confirmation.directive.md
+++ b/terminus-ui/confirmation/src/confirmation.directive.md
@@ -32,7 +32,7 @@ Add the directive to any `ts-button`:
 ```html
 <ts-button
   ts-confirmation
-  (clickEvent)="myContinueFn($event)"
+  (clicked)="myContinueFn($event)"
 >
   Click me!
 </ts-button>
@@ -47,7 +47,7 @@ from the confirmation pop-up.
 ```html
 <ts-button
   ts-confirmation
-  (clickEvent)="myContinueFn($event)"
+  (clicked)="myContinueFn($event)"
   (cancelled)="myCancelEvent($event)"
 >
   Click me!
@@ -62,7 +62,7 @@ Customizes the text in the overlay of the confirmation button; default is "Confi
 ```html
 <ts-button
     tsConfirmation
-    (clickEvent)="submit()"
+    (clicked)="submit()"
     (cancelled)="cancel($event)"
     confirmationButtonText="Custom Confirmation Button Text"
   >
@@ -78,7 +78,7 @@ Customizes the text in the overlay of the cancel button; default is "Cancel".
 ```html
 <ts-button
     tsConfirmation
-    (clickEvent)="submit()"
+    (clicked)="submit()"
     (cancelled)="cancel($event)"
     cancelButtonText="Custom Cancel Button Text"
   >
@@ -94,7 +94,7 @@ Optional text to appear inside of the overlay, generally to use as a warning, fo
 ```html
 <ts-button
     tsConfirmation
-    (clickEvent)="submit()"
+    (clicked)="submit()"
     (cancelled)="cancel($event)"
     explanationText="Optional text within overlay."
   >
@@ -109,7 +109,7 @@ Optional overlayPosition for defining where the overlay will appear relative to 
 ```html
 <ts-button
     tsConfirmation
-    (clickEvent)="submit()"
+    (clicked)="submit()"
     (cancelled)="cancel($event)"
     overlayPosition="before"
   >

--- a/terminus-ui/confirmation/src/confirmation.directive.spec.ts
+++ b/terminus-ui/confirmation/src/confirmation.directive.spec.ts
@@ -48,14 +48,14 @@ class TsButtonComponentMock {
   @Input()
   public showProgress = false;
   @Output()
-  public clickEvent: EventEmitter<MouseEvent> = new EventEmitter;
+  public clicked: EventEmitter<MouseEvent> = new EventEmitter();
 
-  public clicked(event: MouseEvent): void {
+  public clickedButton(event: MouseEvent): void {
     // Allow the click to propagate
     if (!this.interceptClick) {
-      this.clickEvent.emit(event);
+      this.clicked.emit(event);
     } else {
-      // Save the original event but don't emit the clickEvent
+      // Save the original event but don't emit the originalClickEvent
       this.originalClickEvent = event;
     }
   }
@@ -157,7 +157,7 @@ describe(`TsConfirmationDirective`, function() {
   describe(`overlay content`, () => {
 
     test(`should dismiss the overlay and emit event on confirm`, () => {
-      directive['host'].clickEvent.emit = jest.fn();
+      directive['host'].clicked.emit = jest.fn();
       expect(directive['overlayRef']).toBeFalsy();
       button.click();
       expect(directive['overlayRef']).toBeTruthy();
@@ -165,7 +165,7 @@ describe(`TsConfirmationDirective`, function() {
       directive['overlayInstance'].confirm.next(true);
 
       expect(directive['overlayRef']!.hasAttached()).toEqual(false);
-      expect(directive['host'].clickEvent.emit).toHaveBeenCalled();
+      expect(directive['host'].clicked.emit).toHaveBeenCalled();
     });
 
 

--- a/terminus-ui/confirmation/src/confirmation.directive.ts
+++ b/terminus-ui/confirmation/src/confirmation.directive.ts
@@ -230,7 +230,7 @@ export class TsConfirmationDirective implements OnDestroy, OnInit {
     // Subscribe to the continue event
     this.overlayInstance.confirm.subscribe((shouldProceed: boolean) => {
       if (coerceBooleanProperty(shouldProceed)) {
-        this.host.clickEvent.emit(this.host.originalClickEvent);
+        this.host.clicked.emit(this.host.originalClickEvent);
         this.dismissOverlay();
       } else {
         this.dismissOverlay();

--- a/terminus-ui/csv-entry/src/csv-entry.component.html
+++ b/terminus-ui/csv-entry/src/csv-entry.component.html
@@ -135,14 +135,14 @@
         class="qa-csv-entry-reset"
         format="hollow"
         theme="warn"
-        (click)="resetTable()"
+        (clicked)="resetTable()"
       >Reset Table</ts-button>
 
       <ts-button
         id="ts-csv-add-row"
         class="qa-csv-entry-add-row"
         format="hollow"
-        (click)="addRows()"
+        (clicked)="addRows()"
       >Add Row</ts-button>
     </div>
   </div>

--- a/terminus-ui/csv-entry/src/csv-entry.component.spec.ts
+++ b/terminus-ui/csv-entry/src/csv-entry.component.spec.ts
@@ -495,8 +495,8 @@ describe(`TsCSVEntryComponent`, function() {
       fixture.detectChanges();
 
       const addRowButton = fixture.debugElement.query(By.css('#ts-csv-add-row')).nativeElement;
-      dispatchMouseEvent(addRowButton, 'click');
-      dispatchMouseEvent(addRowButton, 'click');
+      dispatchMouseEvent(addRowButton, 'clicked');
+      dispatchMouseEvent(addRowButton, 'clicked');
       fixture.detectChanges();
       const message = fixture.debugElement.query(By.css('.c-csv-entry__message')).nativeElement;
 
@@ -516,14 +516,14 @@ describe(`TsCSVEntryComponent`, function() {
       expect(row2Cell1.value).toEqual(expect.any(String));
 
       const addRowButton = fixture.debugElement.query(By.css('#ts-csv-add-row')).nativeElement;
-      dispatchMouseEvent(addRowButton, 'click');
-      dispatchMouseEvent(addRowButton, 'click');
+      dispatchMouseEvent(addRowButton, 'clicked');
+      dispatchMouseEvent(addRowButton, 'clicked');
       fixture.detectChanges();
       let message = fixture.debugElement.query(By.css('.c-csv-entry__message')).nativeElement;
       expect(message).toBeTruthy();
 
       const resetButton: HTMLInputElement = fixture.debugElement.query(By.css('#ts-csv-reset')).nativeElement;
-      dispatchMouseEvent(resetButton, 'click');
+      dispatchMouseEvent(resetButton, 'clicked');
       fixture.detectChanges();
 
       row2Cell1 = fixture.debugElement.query(By.css('#r_1Xc_0')).nativeElement;

--- a/terminus-ui/expansion-panel/src/expansion-panel.component.md
+++ b/terminus-ui/expansion-panel/src/expansion-panel.component.md
@@ -234,7 +234,7 @@ the `ts-expansion-panel-action-row`.
     And here is my standard panel content.
 
     <ts-expansion-panel-action-row>
-      <ts-button (click)="nextStep()">
+      <ts-button (clicked)="nextStep()">
         Next
       </ts-button>
     </ts-expansion-panel-action-row>
@@ -249,10 +249,10 @@ the `ts-expansion-panel-action-row`.
     And here is my standard panel content.
 
     <ts-expansion-panel-action-row>
-      <ts-button format="hollow" (click)="previousStep()">
+      <ts-button format="hollow" (clicked)="previousStep()">
         Previous
       </ts-button>
-      <ts-button (click)="nextStep()">
+      <ts-button (clicked)="nextStep()">
         Next
       </ts-button>
     </ts-expansion-panel-action-row>
@@ -267,10 +267,10 @@ the `ts-expansion-panel-action-row`.
     And here is my standard panel content.
 
     <ts-expansion-panel-action-row>
-      <ts-button format="hollow" (click)="previousStep()">
+      <ts-button format="hollow" (clicked)="previousStep()">
         Previous
       </ts-button>
-      <ts-button (click)="nextStep()">
+      <ts-button (clicked)="nextStep()">
         End
       </ts-button>
     </ts-expansion-panel-action-row>

--- a/terminus-ui/file-upload/src/file-upload.component.html
+++ b/terminus-ui/file-upload/src/file-upload.component.html
@@ -86,7 +86,7 @@
       [class.c-file-upload__prompt--hidden]="hideButton"
       [theme]="theme"
       [isDisabled]="dragInProgress"
-      (clickEvent)="promptForFiles()"
+      (clicked)="promptForFiles()"
     >
       {{ buttonMessage }}
     </ts-button>

--- a/terminus-ui/icon-button/src/icon-button.component.html
+++ b/terminus-ui/icon-button/src/icon-button.component.html
@@ -4,7 +4,7 @@
   [attr.type]="buttonType"
   [disabled]="isDisabled"
   tabindex="{{ tabIndex }}"
-  (click)="clickEvent.emit($event)"
+  (click)="clicked.emit($event)"
 >
   <ts-icon aria-hidden="true">
     <ng-content></ng-content>

--- a/terminus-ui/icon-button/src/icon-button.component.md
+++ b/terminus-ui/icon-button/src/icon-button.component.md
@@ -13,7 +13,7 @@
 Pass a valid [Material icon][material-icons] name as the content of the button:
 
 ```html
-<ts-icon-button (click)="myMethod()">delete_forever</ts-icon-button>
+<ts-icon-button (clicked)="myMethod()">delete_forever</ts-icon-button>
 ```
 
 
@@ -45,7 +45,7 @@ For accessibility purposes we should set the `actionName` and `buttonType`.
 <ts-icon-button
   actionName="Menu"
   buttonType="button"
-  (click)="myMethod()"
+  (clicked)="myMethod()"
 >bookmark</ts-icon-button>
 ```
 

--- a/terminus-ui/icon-button/src/icon-button.component.spec.ts
+++ b/terminus-ui/icon-button/src/icon-button.component.spec.ts
@@ -14,7 +14,7 @@ import { TsIconButtonModule } from './icon-button.module';
     actionName="Menu"
     buttonType="button"
     isDisabled="false"
-    (clickEvent)="clickEvent($event)"
+    (clicked)="clicked($event)"
   >delete_forever</ts-icon-button>
   `,
 })

--- a/terminus-ui/icon-button/src/icon-button.component.ts
+++ b/terminus-ui/icon-button/src/icon-button.component.ts
@@ -25,7 +25,7 @@ import {
  *              buttonType="button"
  *              [isDisabled]="false"
  *              tabIndex="2"
- *              (clickEvent)="myMethod($event)"
+ *              (clicked)="myMethod($event)"
  * >delete_forever</ts-icon-button>
  *
  * <example-url>https://getterminus.github.io/ui-demos-master/components/icon-button</example-url>
@@ -70,7 +70,7 @@ export class TsIconButtonComponent {
    * Pass the click event through to the parent
    */
   @Output()
-  public clickEvent: EventEmitter<MouseEvent> = new EventEmitter;
+  public clicked: EventEmitter<MouseEvent> = new EventEmitter();
 
 
   /**

--- a/terminus-ui/login-form/src/login-form.component.html
+++ b/terminus-ui/login-form/src/login-form.component.html
@@ -58,7 +58,7 @@
       buttonType="submit"
       [showProgress]="inProgress || isRedirecting"
       [isDisabled]="!loginForm.valid"
-      (clickEvent)="submit.emit(loginForm.value)"
+      (clicked)="submit.emit(loginForm.value)"
       tabindex="-1"
       tabIndex="4"
     >

--- a/terminus-ui/login-form/src/login-form.component.ts
+++ b/terminus-ui/login-form/src/login-form.component.ts
@@ -202,7 +202,7 @@ export class TsLoginFormComponent implements OnChanges {
    * Emit an event on form submission
    */
   @Output()
-  public submit: EventEmitter<TsLoginFormResponse> = new EventEmitter;
+  public submit: EventEmitter<TsLoginFormResponse> = new EventEmitter();
 
 
   /**

--- a/terminus-ui/menu/src/menu.component.md
+++ b/terminus-ui/menu/src/menu.component.md
@@ -17,7 +17,7 @@
 
 <!-- Define a template for the dropdown panel and pass it to `[menuItemsTemplate]` above -->
 <ng-template #myTemplate>
-  <ts-button (click)="customItemSelected('yup')">
+  <ts-button (clicked)="customItemSelected('yup')">
     Roger, Roger.
   </ts-button>
 

--- a/terminus-ui/navigation/src/navigation.component.ts
+++ b/terminus-ui/navigation/src/navigation.component.ts
@@ -254,7 +254,7 @@ export class TsNavigationComponent implements OnInit, AfterViewInit {
    * Emit the click event with the {@link TsNavigationPayload}
    */
   @Output()
-  public action: EventEmitter<TsNavigationPayload> = new EventEmitter;
+  public action: EventEmitter<TsNavigationPayload> = new EventEmitter();
 
   /**
    * Trigger a layout update when the window resizes

--- a/terminus-ui/paginator/src/paginator.component.html
+++ b/terminus-ui/paginator/src/paginator.component.html
@@ -23,7 +23,7 @@
         [theme]="theme"
         [iconName]="firstPageIcon"
         [isDisabled]="isFirstPage(currentPageIndex)"
-        (clickEvent)="changePage(firstPageIndex, currentPageIndex, pagesArray)"
+        (clicked)="changePage(firstPageIndex, currentPageIndex, pagesArray)"
       ></ts-button>
     </ts-tooltip>
 
@@ -34,7 +34,7 @@
         [theme]="theme"
         [iconName]="previousPageIcon"
         [isDisabled]="isFirstPage(currentPageIndex)"
-        (clickEvent)="changePage(currentPageIndex - 1, currentPageIndex, pagesArray)"
+        (clicked)="changePage(currentPageIndex - 1, currentPageIndex, pagesArray)"
       ></ts-button>
     </ts-tooltip>
 
@@ -55,7 +55,7 @@
         [theme]="theme"
         [iconName]="nextPageIcon"
         [isDisabled]="isLastPage(currentPageIndex) || !pagesArray?.length"
-        (clickEvent)="changePage(currentPageIndex + 1, currentPageIndex, pagesArray)"
+        (clicked)="changePage(currentPageIndex + 1, currentPageIndex, pagesArray)"
       ></ts-button>
     </ts-tooltip>
 
@@ -66,7 +66,7 @@
         [theme]="theme"
         [iconName]="lastPageIcon"
         [isDisabled]="isLastPage(currentPageIndex) || !pagesArray?.length"
-        (clickEvent)="changePage(lastPageIndex, currentPageIndex, pagesArray)"
+        (clicked)="changePage(lastPageIndex, currentPageIndex, pagesArray)"
       ></ts-button>
     </ts-tooltip>
   </div>
@@ -87,7 +87,7 @@
 <ng-template #menuItems>
   <ts-button
     *ngFor="let page of pagesArray; trackBy: trackPagesArray"
-    (clickEvent)="currentPageChanged(page)"
+    (clicked)="currentPageChanged(page)"
   >
     {{ page.name }}
   </ts-button>

--- a/terminus-ui/search/src/search.component.html
+++ b/terminus-ui/search/src/search.component.html
@@ -33,7 +33,7 @@
     [showProgress]="isSubmitting"
     [buttonType]="buttonType"
     [actionName]="buttonAction"
-    (clickEvent)="searchForm.valid && !isSubmitting && submitted.emit({query: currentQuery})"
+    (clicked)="searchForm.valid && !isSubmitting && submitted.emit({query: currentQuery})"
   >Search</ts-button>
 
 </form>


### PR DESCRIPTION
:boom: Breaking Change :boom:

Migration notes:
- the clickEvent change emitter name has been changed to `clicked` to align with the past tense naming convention of other change emitters
- this affects `ts-button` and `ts-icon-button`
- to implement, simply change clickEvent to `clicked`:
```typescript
// before:
<ts-button>    
    (clickEvent)="myClick($event)"
  >Click Me!</ts-button>

// after:
<ts-button>    
    (clicked)="myClick($event)"
  >Click Me!</ts-button>
```