### PR TITLE
chore(Card): *BREAKING CHANGE* removed \`disabled\` input

### DIFF
--- a/demo/app/components/card/card.component.html
+++ b/demo/app/components/card/card.component.html
@@ -108,12 +108,12 @@
   <h3 tsCardTitle tsTitleAccentBorder>Card with Title & accent border</h3>
 </ts-card>
 
-<ts-card [disabled]="true" [supportsInteraction]="true" tsVerticalSpacing>
+<ts-card [isDisabled]="true" [supportsInteraction]="true" tsVerticalSpacing>
   Disabled with interactions
 </ts-card>
 
 
-<ts-card [disabled]="true" tsVerticalSpacing>
+<ts-card [isDisabled]="true" tsVerticalSpacing>
   <h3 tsCardTitle tsVerticalSpacing>
     Disabled Card with a very long title foo bar baz
   </h3>
@@ -129,7 +129,7 @@
 
 
 <ts-card
-  [disabled]="false"
+  [isDisabled]="false"
   tsVerticalSpacing
   [utilityMenuTemplate]="myTemplate"
 >
@@ -179,10 +179,10 @@
   </p>
 </ts-card>
 
-<ts-card [flat]="true" tsVerticalSpacing [disabled]="false">
+<ts-card [flat]="true" tsVerticalSpacing [isDisabled]="false">
   <h3 tsVerticalSpacing>Nested card</h3>
   <p>This card is flat and not disabled</p>
-  <ts-card [flat]="false" [disabled]="true">
+  <ts-card [flat]="false" [isDisabled]="true">
     This card is not flat and disabled
   </ts-card>
 </ts-card>

--- a/terminus-ui/card/src/card.component.html
+++ b/terminus-ui/card/src/card.component.html
@@ -4,8 +4,8 @@
     'c-card--interaction': supportsInteraction,
     'c-card--centered': centeredContent,
     'c-card--aspect': aspectRatioPadding,
-    'c-card--disabled': disabled,
-    'c-card--right-spacing': utilityMenuTemplate || disabled,
+    'c-card--disabled': isDisabled,
+    'c-card--right-spacing': utilityMenuTemplate || isDisabled,
     'c-card--flat': flat
   }"
   [style.paddingTop]="aspectRatioPadding"
@@ -14,7 +14,7 @@
   <div
     class="c-card__inner"
     mat-ripple
-    [matRippleDisabled]="!supportsInteraction || disabled"
+    [matRippleDisabled]="!supportsInteraction || isDisabled"
   >
     <ng-content></ng-content>
   </div>
@@ -25,7 +25,7 @@
   ></ng-container>
 
   <ts-icon
-    *ngIf="disabled && !utilityMenuTemplate"
+    *ngIf="isDisabled && !utilityMenuTemplate"
     class="c-card__lock qa-card-lock"
   >lock_outline</ts-icon>
 </div>

--- a/terminus-ui/card/src/card.component.md
+++ b/terminus-ui/card/src/card.component.md
@@ -101,7 +101,7 @@ element which provides the needed styles.
 This will push the opacity of the card contents back and add a lock icon in the top right corner.
 
 ```html
-<ts-card [disabled]="true">
+<ts-card [isDisabled]="true">
   My card
 </ts-card>
 ```

--- a/terminus-ui/card/src/card.component.spec.ts
+++ b/terminus-ui/card/src/card.component.spec.ts
@@ -11,8 +11,7 @@ import { TsCardModule } from './card.module';
 @Component({
   template: `
   <ts-card
-    [isDisabled]="disabled"
-    [disabled]="disabled"
+    [isDisabled]="isDisabled"
     [flat]="flat"
     [supportsInteraction]="supportsInteraction"
     [theme]="theme"
@@ -24,7 +23,7 @@ import { TsCardModule } from './card.module';
 })
 class TestHostComponent {
   border: TsCardBorderOptions | undefined;
-  disabled!: boolean;
+  isDisabled!: boolean;
   flat!: boolean;
   supportsInteraction!: boolean;
   theme: TsStyleThemeTypes | undefined;
@@ -51,19 +50,16 @@ describe(`TsCardComponent`, function() {
 
   describe(`isDisabled`, function() {
     test(`should not disable a card`, () => {
-      expect(cardComponent.disabled).toEqual(false);
-      component.disabled = false;
+      component.isDisabled = false;
       fixture.detectChanges();
       expect(cardComponent.isDisabled).toEqual(false);
-      expect(cardComponent.disabled).toEqual(false);
       expect(card.classList).not.toContain('c-card--disabled');
     });
 
     test(`should disable a card`, () => {
-      component.disabled = true;
+      component.isDisabled = true;
       fixture.detectChanges();
       expect(cardComponent.isDisabled).toEqual(true);
-      expect(cardComponent.disabled).toEqual(true);
       expect(card.classList).toContain('c-card--disabled');
     });
   });

--- a/terminus-ui/card/src/card.component.ts
+++ b/terminus-ui/card/src/card.component.ts
@@ -137,38 +137,7 @@ export class TsCardComponent {
    * Define if the card is disabled
    */
   @Input()
-  public set disabled(value: boolean) {
-    /* istanbul ignore next */
-    console.warn(`TsCardComponent: The "disabled" input will be converted to "isDisabled" to better ` +
-    `align with other components in the next release.`);
-
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCardComponent: "disabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._disabled = coerceBooleanProperty(value);
-  }
-  public get disabled(): boolean {
-    return this._disabled;
-  }
-  public _disabled = false;
-
-  /**
-   * Define if the card is disabled
-   */
-  @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCardComponent: "disabled" value is not a boolean. ` +
-        `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._disabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._disabled;
-  }
+  public isDisabled: boolean = false;
 
   /**
    * Define if the card should not have a drop shadow


### PR DESCRIPTION
💥 BREAKING CHANGE 💥 
Card will have to use isDisabled instead of disabled

Migration notes:
- replace `disabled` with `isDisabled`

```typescript
before
<ts-card [disabled]="true">
  Disabled Card
</ts-card>

after
<ts-card [isDisabled]="true">
  Disabled Card
</ts-card>
```

ISSUES CLOSED: #1267