### PR TITLE
1233 deprecate coerce boolean

### DIFF
--- a/demo/app/components/tooltip/tooltip.component.html
+++ b/demo/app/components/tooltip/tooltip.component.html
@@ -11,8 +11,6 @@
       <option value="after">After</option>
       <option value="above">Above</option>
       <option value="below">Below</option>
-      <option value="left">Left</option>
-      <option value="right">Right</option>
     </select>
   </label>
   <br>

--- a/terminus-ui/autocomplete/src/autocomplete.component.ts
+++ b/terminus-ui/autocomplete/src/autocomplete.component.ts
@@ -23,13 +23,11 @@ import {
 } from '@angular/material/autocomplete';
 import {
   arrayContainsObject,
-  isBoolean,
   isFunction,
   untilComponentDestroyed,
 } from '@terminus/ngx-tools';
 import {
   coerceArray,
-  coerceBooleanProperty,
   coerceNumberProperty,
 } from '@terminus/ngx-tools/coercion';
 import { TS_SPACING } from '@terminus/ui/spacing';
@@ -279,19 +277,8 @@ export class TsAutocompleteComponent<OptionType = {[name: string]: any}> impleme
    * Define if the progress spinner should be active
    */
   @Input()
-  public set showProgress(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsAutocompleteComponent: "showProgress" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
+  public showProgress = false;
 
-    this._showProgress = coerceBooleanProperty(value);
-  }
-  public get showProgress(): boolean {
-    return this._showProgress;
-  }
-  private _showProgress = false;
   /**
    * Define the component theme
    */

--- a/terminus-ui/button/src/button.component.ts
+++ b/terminus-ui/button/src/button.component.ts
@@ -13,11 +13,7 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import {
-  isBoolean,
-  TsWindowService,
-} from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import { TsWindowService } from '@terminus/ngx-tools';
 import {
   TsStyleThemeTypes,
   tsStyleThemeTypesArray,
@@ -141,13 +137,7 @@ export class TsButtonComponent implements OnInit, OnDestroy {
    */
   @Input()
   public set collapsed(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsButtonComponent: "collapsed" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-
-    this.isCollapsed = coerceBooleanProperty(value);
+    this.isCollapsed = value;
 
     // If the value is `false` and a collapse delay is set
     if (!value && this.collapseDelay) {
@@ -205,35 +195,13 @@ export class TsButtonComponent implements OnInit, OnDestroy {
    * Define if the button is disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsButtonComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Define if the progress indicator should show
    */
   @Input()
-  public set showProgress(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsButtonComponent: "showProgress" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._showProgress = coerceBooleanProperty(value);
-  }
-  public get showProgress(): boolean {
-    return this._showProgress;
-  }
-  private _showProgress = false;
+  public showProgress = false;
 
   /**
    * Define the tabindex for the button

--- a/terminus-ui/card/src/card-title.directive.ts
+++ b/terminus-ui/card/src/card-title.directive.ts
@@ -33,6 +33,7 @@ export class TsCardTitleDirective {
       this.tsCardTitle = this.tsCardTitle + ' c-card__title-accent-border';
     }
   }
+
   /**
    * Define the component theme
    */

--- a/terminus-ui/card/src/card.component.ts
+++ b/terminus-ui/card/src/card.component.ts
@@ -3,12 +3,9 @@ import {
   Component,
   ElementRef,
   Input,
-  isDevMode,
   TemplateRef,
   ViewEncapsulation,
 } from '@angular/core';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 
 
@@ -120,41 +117,19 @@ export class TsCardComponent {
    * Define if the card should center child content
    */
   @Input()
-  public set centeredContent(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCardComponent: "centeredContent" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._centeredContent = coerceBooleanProperty(value);
-  }
-  public get centeredContent(): boolean {
-    return this._centeredContent;
-  }
-  private _centeredContent = false;
+  public centeredContent = false;
 
   /**
    * Define if the card is disabled
    */
   @Input()
-  public isDisabled: boolean = false;
+  public isDisabled = false;
 
   /**
    * Define if the card should not have a drop shadow
    */
   @Input()
-  public set flat(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCardComponent: "flat" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._flat = coerceBooleanProperty(value);
-  }
-  public get flat(): boolean {
-    return this._flat;
-  }
-  public _flat: boolean = false;
+  public flat = false;
 
   /**
    * Define an ID for the component
@@ -174,18 +149,7 @@ export class TsCardComponent {
    * NOTE: This only alters style; not functionality
    */
   @Input()
-  public set supportsInteraction(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCardComponent: "supportsInteraction" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._supportsInteraction = coerceBooleanProperty(value);
-  }
-  public get supportsInteraction(): boolean {
-    return this._supportsInteraction;
-  }
-  private _supportsInteraction = false;
+  public supportsInteraction = false;
 
   /**
    * Define the card theme

--- a/terminus-ui/checkbox/src/checkbox.component.ts
+++ b/terminus-ui/checkbox/src/checkbox.component.ts
@@ -4,7 +4,6 @@ import {
   Component,
   EventEmitter,
   Input,
-  isDevMode,
   Output,
   ViewChild,
   ViewEncapsulation,
@@ -13,8 +12,6 @@ import {
   MatCheckbox,
   MatCheckboxChange,
 } from '@angular/material/checkbox';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import {
   ControlValueAccessorProviderFactory,
   TsReactiveFormBaseComponent,
@@ -98,12 +95,7 @@ export class TsCheckboxComponent extends TsReactiveFormBaseComponent {
    */
   @Input()
   public set isChecked(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCheckboxComponent: "isChecked" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isChecked = coerceBooleanProperty(value);
+    this._isChecked = value;
     this.value = this._isChecked;
     this.checkbox.checked = this._isChecked;
     this.changeDetectorRef.detectChanges();
@@ -117,52 +109,19 @@ export class TsCheckboxComponent extends TsReactiveFormBaseComponent {
    * Define if the checkbox is disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCheckboxComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Define if the checkbox should be indeterminate
    */
   @Input()
-  public set isIndeterminate(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCheckboxComponent: "isIndeterminate" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isIndeterminate = coerceBooleanProperty(value);
-  }
-  public get isIndeterminate(): boolean {
-    return this._isIndeterminate;
-  }
-  private _isIndeterminate = false;
+  public isIndeterminate = false;
 
   /**
    * Define if the checkbox is required
    */
   @Input()
-  public set isRequired(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCheckboxComponent: "isRequired" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isRequired = coerceBooleanProperty(value);
-  }
-  public get isRequired(): boolean {
-    return this._isRequired;
-  }
-  private _isRequired = false;
+  public isRequired = false;
 
   /**
    * Toggle the underlying checkbox if the ngModel changes

--- a/terminus-ui/copy/src/copy.component.ts
+++ b/terminus-ui/copy/src/copy.component.ts
@@ -2,16 +2,13 @@ import {
   Component,
   ElementRef,
   Input,
-  isDevMode,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
 import {
-  isBoolean,
   TsDocumentService,
   TsWindowService,
 } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 
 
@@ -79,35 +76,13 @@ export class TsCopyComponent {
    * Define if the initial click should select the contents
    */
   @Input()
-  public set disableInitialSelection(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCopyComponent: "disableInitialSelection" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._disableInitialSelection = coerceBooleanProperty(value);
-  }
-  public get disableInitialSelection(): boolean {
-    return this._disableInitialSelection;
-  }
-  private _disableInitialSelection = false;
+  public disableInitialSelection = false;
 
   /**
    * Define if the copy to clipboard functionality is enabled
    */
   @Input()
-  public set enableQuickCopy(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCopyComponent: "enableQuickCopy" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._enableQuickCopy = coerceBooleanProperty(value);
-  }
-  public get enableQuickCopy(): boolean {
-    return this._enableQuickCopy;
-  }
-  private _enableQuickCopy = false;
+  public enableQuickCopy = false;
 
   /**
    * Define the component theme

--- a/terminus-ui/csv-entry/src/csv-entry.component.ts
+++ b/terminus-ui/csv-entry/src/csv-entry.component.ts
@@ -4,7 +4,6 @@ import {
   Component,
   EventEmitter,
   Input,
-  isDevMode,
   OnDestroy,
   OnInit,
   Output,
@@ -18,7 +17,6 @@ import {
   ValidatorFn,
 } from '@angular/forms';
 import {
-  isBoolean,
   TsDocumentService,
   untilComponentDestroyed,
 } from '@terminus/ngx-tools';
@@ -216,18 +214,7 @@ export class TsCSVEntryComponent implements OnInit, OnDestroy {
    * Allow full-width mode
    */
   @Input()
-  public set fullWidth(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCSVEntryComponent: "fullWidth" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._fullWidth = coerceBooleanProperty(value);
-  }
-  public get fullWidth(): boolean {
-    return this._fullWidth;
-  }
-  private _fullWidth = false;
+  public fullWidth = false;
 
   /**
    * Allow static headers to be set

--- a/terminus-ui/date-range/src/date-range.component.ts
+++ b/terminus-ui/date-range/src/date-range.component.ts
@@ -3,7 +3,6 @@ import {
   Component,
   EventEmitter,
   Input,
-  isDevMode,
   OnDestroy,
   OnInit,
   Output,
@@ -14,11 +13,7 @@ import {
   FormControl,
   FormGroup,
 } from '@angular/forms';
-import {
-  isBoolean,
-  untilComponentDestroyed,
-} from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import { untilComponentDestroyed } from '@terminus/ngx-tools';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 import { BehaviorSubject } from 'rxjs';
 
@@ -170,18 +165,7 @@ export class TsDateRangeComponent implements OnInit, OnDestroy {
    * Define if the range should be disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsDateRangeComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Define the starting view for both datepickers

--- a/terminus-ui/file-upload/src/file-upload.component.ts
+++ b/terminus-ui/file-upload/src/file-upload.component.ts
@@ -22,14 +22,12 @@ import {
   ValidationErrors,
 } from '@angular/forms';
 import {
-  isBoolean,
   isNumber,
   TsDocumentService,
   untilComponentDestroyed,
 } from '@terminus/ngx-tools';
 import {
   coerceArray,
-  coerceBooleanProperty,
   coerceNumberProperty,
 } from '@terminus/ngx-tools/coercion';
 import { ENTER } from '@terminus/ngx-tools/keycodes';
@@ -266,18 +264,7 @@ export class TsFileUploadComponent extends TsReactiveFormBaseComponent implement
    * TODO: This should be removed once UX/Product decide if they want the button.
    */
   @Input()
-  public set hideButton(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsFileUploadComponent: "hideButton" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._hideButton = coerceBooleanProperty(value);
-  }
-  public get hideButton(): boolean {
-    return this._hideButton;
-  }
-  private _hideButton = false;
+  public hideButton = false;
 
   /**
    * Define an ID for the component
@@ -333,18 +320,7 @@ export class TsFileUploadComponent extends TsReactiveFormBaseComponent implement
    * Define if multiple files may be uploaded
    */
   @Input()
-  public set multiple(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsFileUploadComponent: "multiple" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._multiple = coerceBooleanProperty(value);
-  }
-  public get multiple(): boolean {
-    return this._multiple;
-  }
-  private _multiple: boolean = false;
+  public multiple = false;
 
   /**
    * Define the upload progress

--- a/terminus-ui/form-field/src/form-field.component.ts
+++ b/terminus-ui/form-field/src/form-field.component.ts
@@ -8,17 +8,12 @@ import {
   ContentChildren,
   ElementRef,
   Input,
-  isDevMode,
   NgZone,
   QueryList,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import {
-  isBoolean,
-  TsDocumentService,
-} from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import { TsDocumentService } from '@terminus/ngx-tools';
 import { TS_SPACING } from '@terminus/ui/spacing';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 import {
@@ -212,18 +207,7 @@ export class TsFormFieldComponent implements AfterContentInit, AfterContentCheck
    * Define if a required marker should be hidden
    */
   @Input()
-  public set hideRequiredMarker(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsFormFieldComponent: "hideRequiredMarker" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._hideRequiredMarker = coerceBooleanProperty(value);
-  }
-  public get hideRequiredMarker(): boolean {
-    return this._hideRequiredMarker;
-  }
-  private _hideRequiredMarker = false;
+  public hideRequiredMarker = false;
 
   /**
    * Define a hint for the input
@@ -259,13 +243,7 @@ export class TsFormFieldComponent implements AfterContentInit, AfterContentCheck
    * Define if validation messages should be shown immediately or on blur
    */
   @Input()
-  public set validateOnChange(value: boolean) {
-    this._validateOnChange = coerceBooleanProperty(value);
-  }
-  public get validateOnChange(): boolean {
-    return this._validateOnChange;
-  }
-  private _validateOnChange = false;
+  public validateOnChange = false;
 
 
   constructor(

--- a/terminus-ui/icon-button/src/icon-button.component.spec.ts
+++ b/terminus-ui/icon-button/src/icon-button.component.spec.ts
@@ -13,7 +13,7 @@ import { TsIconButtonModule } from './icon-button.module';
   <ts-icon-button
     actionName="Menu"
     buttonType="button"
-    isDisabled="false"
+    [isDisabled]="false"
     (clicked)="clicked($event)"
   >delete_forever</ts-icon-button>
   `,

--- a/terminus-ui/icon/src/icon.component.md
+++ b/terminus-ui/icon/src/icon.component.md
@@ -7,6 +7,7 @@
 
 - [Basic usage](#basic-usage)
 - [Theming](#theming)
+- [Background](#background)
 - [Style with CSS](#style-with-css)
 - [Usage inline with text](#usage-inline-with-text)
 - [Custom Icons](#custom-icons)
@@ -42,6 +43,15 @@ Icons support the same themes as the rest of the components:
 ```
 
 Search for `TsStyleThemeTypes` to see all allowed types.
+
+
+## Background
+
+Icons can be shown white with a colored background (color is determined by theme) by setting `background` to true.
+
+```html
+<ts-icon [background]="true"></ts-icon>
+```
 
 
 ## Style with CSS
@@ -90,4 +100,4 @@ Any icon with a -color suffix will not accept themes. Currently they accept a ba
 | `engage`      | A right-pointing arrow stacked on a left-pointing arrow | Navigation for Engage product     |
 | `lightbulb`   | A lightbulb                                             | Pro-tip box                       |
 | `logo`        | Terminus logo, default is black, but accepts theme      | Logo, negative logo               |
-| `logo-color`  | Terminus logo in correct colors, does not accept theme  | Logo like it is supposed to look  |
+| `logo_color`  | Terminus logo in correct colors, does not accept theme  | Logo like it is supposed to look  |

--- a/terminus-ui/icon/src/icon.component.ts
+++ b/terminus-ui/icon/src/icon.component.ts
@@ -7,7 +7,6 @@ import {
 } from '@angular/core';
 import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 
 import { CSV_ICON } from './custom-icons/csv';
@@ -77,13 +76,7 @@ export class TsIconComponent {
    * NOTE: This will affect layout and style.
    */
   @Input()
-  public set background(value: boolean) {
-    this._background = coerceBooleanProperty(value);
-  }
-  public get background(): boolean {
-    return this._background;
-  }
-  private _background = false;
+  public background = false;
 
   /**
    * Define if the icon should be aligned inline with text

--- a/terminus-ui/input/src/input.component.ts
+++ b/terminus-ui/input/src/input.component.ts
@@ -35,13 +35,11 @@ import {
 import { MatDatepicker } from '@angular/material/datepicker';
 import {
   hasRequiredControl,
-  isBoolean,
   isNumber,
   noop,
   TsDocumentService,
 } from '@terminus/ngx-tools';
 import {
-  coerceBooleanProperty,
   coerceNumberProperty,
 } from '@terminus/ngx-tools/coercion';
 import { TsFormFieldControl } from '@terminus/ui/form-field';
@@ -446,18 +444,7 @@ export class TsInputComponent implements
    * (standard HTML5 property)
    */
   @Input()
-  public set autocapitalize(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "autocapitalize" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._autocapitalize = coerceBooleanProperty(value);
-  }
-  public get autocapitalize(): boolean {
-    return this._autocapitalize;
-  }
-  private _autocapitalize = false;
+  public autocapitalize = false;
 
   /**
    * Define if the input should autocomplete. See {@link TsInputAutocompleteTypes}.
@@ -492,12 +479,7 @@ export class TsInputComponent implements
    */
   @Input()
   public set datepicker(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "datepicker" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._datepicker = coerceBooleanProperty(value);
+    this._datepicker = value;
 
     // When using a datepicker, we need to validate on change so that selecting a date from the calendar
     // istanbul ignore else
@@ -541,35 +523,13 @@ export class TsInputComponent implements
    * Define if the use-case provides it's own {@link TsFormFieldComponent} or if this component should provide it's own.
    */
   @Input()
-  public set hasExternalFormField(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "hasExternalFormField" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._hasExternalFormField = coerceBooleanProperty(value);
-  }
-  public get hasExternalFormField(): boolean {
-    return this._hasExternalFormField;
-  }
-  private _hasExternalFormField = false;
+  public hasExternalFormField = false;
 
   /**
    * Define if a required marker should be included
    */
   @Input()
-  public set hideRequiredMarker(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "hideRequiredMarker" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._hideRequiredMarker = coerceBooleanProperty(value);
-  }
-  public get hideRequiredMarker(): boolean {
-    return this._hideRequiredMarker;
-  }
-  private _hideRequiredMarker = false;
+  public hideRequiredMarker = false;
 
   /**
    * Define a hint for the input
@@ -599,18 +559,7 @@ export class TsInputComponent implements
    * Define if the input should surface the ability to clear it's value
    */
   @Input()
-  public set isClearable(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "isClearable" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isClearable = coerceBooleanProperty(value);
-  }
-  public get isClearable(): boolean {
-    return this._isClearable;
-  }
-  private _isClearable = false;
+  public isClearable = false;
 
   /**
    * Define if the input should be disabled
@@ -618,30 +567,14 @@ export class TsInputComponent implements
    * Implemented as part of {@link TsFormFieldControl}
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Define if the input should be focused
    */
   @Input()
   public set isFocused(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "isFocused" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isFocused = coerceBooleanProperty(value);
+    this._isFocused = value;
 
     if (this._isFocused) {
       this.focus();
@@ -659,12 +592,7 @@ export class TsInputComponent implements
    */
   @Input()
   public set isRequired(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "isRequired" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isRequired = coerceBooleanProperty(value);
+    this._isRequired = value;
   }
   public get isRequired(): boolean {
     const requiredFormControl = (this.formControl && hasRequiredControl(this.formControl));
@@ -678,18 +606,7 @@ export class TsInputComponent implements
    * NOTE: This is not meant to be used with the datepicker or mask enabled.
    */
   @Input()
-  public set isTextarea(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "isTextarea" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isTextarea = coerceBooleanProperty(value);
-  }
-  public get isTextarea(): boolean {
-    return this._isTextarea;
-  }
-  private _isTextarea = false;
+  public isTextarea = false;
 
   /**
    * Define the label
@@ -735,13 +652,8 @@ export class TsInputComponent implements
    */
   @Input()
   public set maskAllowDecimal(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "maskAllowDecimal" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
     const oldValue = this.maskAllowDecimal;
-    this._maskAllowDecimal = coerceBooleanProperty(value);
+    this._maskAllowDecimal = value;
 
     // Re-set the definition if the value was changed
     if (this.mask && this.maskAllowDecimal !== oldValue) {
@@ -757,18 +669,7 @@ export class TsInputComponent implements
    * Define if the value should be sanitized before it is saved to the model
    */
   @Input()
-  public set maskSanitizeValue(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "maskSanitizeValue" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._maskSanitizeValue = coerceBooleanProperty(value);
-  }
-  public get maskSanitizeValue(): boolean {
-    return this._maskSanitizeValue;
-  }
-  private _maskSanitizeValue = true;
+  public maskSanitizeValue = true;
 
   /**
    * Define the maximum date for the datepicker
@@ -825,36 +726,14 @@ export class TsInputComponent implements
    * Define if the input is readOnly
    */
   @Input()
-  public set readOnly(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "readOnly" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._readOnly = coerceBooleanProperty(value);
-  }
-  public get readOnly(): boolean {
-    return this._readOnly;
-  }
-  private _readOnly = false;
+  public readOnly = false;
 
   /**
    * Define if the input should spellcheck
    * (standard HTML5 property)
    */
   @Input()
-  public set spellcheck(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "spellcheck" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._spellcheck = coerceBooleanProperty(value);
-  }
-  public get spellcheck(): boolean {
-    return this._spellcheck;
-  }
-  private _spellcheck: boolean = true;
+  public spellcheck = true;
 
   /**
    * Define the starting calendar view for the datepicker
@@ -942,18 +821,7 @@ export class TsInputComponent implements
    * Define if validation messages should be shown immediately or on blur
    */
   @Input()
-  public set validateOnChange(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "validateOnChange" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._validateOnChange = coerceBooleanProperty(value);
-  }
-  public get validateOnChange(): boolean {
-    return this._validateOnChange;
-  }
-  private _validateOnChange = false;
+  public validateOnChange = false;
 
 
   /**

--- a/terminus-ui/input/testing/src/test-components.ts
+++ b/terminus-ui/input/testing/src/test-components.ts
@@ -64,7 +64,7 @@ export class Autocomplete implements AfterContentInit {
   template: `<ts-input [readOnly]="readOnly"></ts-input>`,
 })
 export class AttrReadonly {
-  readOnly: boolean | undefined = undefined;
+  readOnly = false;
 
   @ViewChild(TsInputComponent)
   inputComponent: TsInputComponent;
@@ -74,7 +74,7 @@ export class AttrReadonly {
   template: `<ts-input [spellcheck]="spellcheck"></ts-input>`,
 })
 export class AttrSpellcheck {
-  spellcheck: boolean | undefined = undefined;
+  spellcheck = false;
 
   @ViewChild(TsInputComponent)
   inputComponent: TsInputComponent;

--- a/terminus-ui/link/src/link.component.spec.ts
+++ b/terminus-ui/link/src/link.component.spec.ts
@@ -69,13 +69,6 @@ describe(`TsLinkComponent`, function() {
       expect(link.children[0].textContent).toContain('open_in_new');
     });
 
-    test(`should throw error if invalid value is passed`, () => {
-      window.console.warn = jest.fn();
-      component.isExternal = 'foo' as any;
-      fixture.detectChanges();
-
-      expect(window.console.warn).toHaveBeenCalled();
-    });
   });
 
   describe(`tabIndex`, () => {

--- a/terminus-ui/link/src/link.component.ts
+++ b/terminus-ui/link/src/link.component.ts
@@ -2,11 +2,8 @@ import {
   ChangeDetectionStrategy,
   Component,
   Input,
-  isDevMode,
   ViewEncapsulation,
 } from '@angular/core';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 
 
 /**
@@ -59,18 +56,7 @@ export class TsLinkComponent {
    * Define if the link is to an external page
    */
   @Input()
-  public set isExternal(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsLinkComponent: "isExternal" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isExternal = coerceBooleanProperty(value);
-  }
-  public get isExternal(): boolean {
-    return this._isExternal;
-  }
-  private _isExternal = false;
+  public isExternal = false;
 
   /**
    * Define the tabindex

--- a/terminus-ui/loading-overlay/src/loading-overlay.directive.ts
+++ b/terminus-ui/loading-overlay/src/loading-overlay.directive.ts
@@ -7,15 +7,10 @@ import {
   HostBinding,
   Injector,
   Input,
-  isDevMode,
   OnDestroy,
   OnInit,
 } from '@angular/core';
-import {
-  isBoolean,
-  TsWindowService,
-} from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import { TsWindowService } from '@terminus/ngx-tools';
 
 import { TsLoadingOverlayComponent } from './loading-overlay.component';
 
@@ -48,12 +43,7 @@ export class TsLoadingOverlayDirective implements OnInit, OnDestroy {
    */
   @Input()
   public set tsLoadingOverlay(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsLoadingOverlayDirective: "tsLoadingOverlay" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    const shouldSet = coerceBooleanProperty(value);
+    const shouldSet = value;
     if (shouldSet) {
       this.bodyPortalHost.attach(this.loadingOverlayPortal);
     } else {

--- a/terminus-ui/login-form/src/login-form.component.ts
+++ b/terminus-ui/login-form/src/login-form.component.ts
@@ -2,7 +2,6 @@ import {
   Component,
   EventEmitter,
   Input,
-  isDevMode,
   OnChanges,
   Output,
   QueryList,
@@ -16,8 +15,6 @@ import {
   FormGroup,
   Validators,
 } from '@angular/forms';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsCheckboxComponent } from '@terminus/ui/checkbox';
 import { TsInputComponent } from '@terminus/ui/input';
 import { TsValidatorsService } from '@terminus/ui/validators';
@@ -145,35 +142,13 @@ export class TsLoginFormComponent implements OnChanges {
    * Define if the form button is showing progress
    */
   @Input()
-  public set inProgress(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsLoginFormComponent: "inProgress" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._inProgress = coerceBooleanProperty(value);
-  }
-  public get inProgress(): boolean {
-    return this._inProgress;
-  }
-  private _inProgress = false;
+  public inProgress = false;
 
   /**
    * Define if the user has successfully logged in and is being redirected
    */
   @Input()
-  public set isRedirecting(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsLoginFormComponent: "isRedirecting" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isRedirecting = coerceBooleanProperty(value);
-  }
-  public get isRedirecting(): boolean {
-    return this._isRedirecting;
-  }
-  private _isRedirecting = false;
+  public isRedirecting = false;
 
   /**
    * Define the login call to action
@@ -185,18 +160,7 @@ export class TsLoginFormComponent implements OnChanges {
    * Allow a consumer to reset the form via an input
    */
   @Input()
-  public set triggerFormReset(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsLoginFormComponent: "triggerFormReset" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._triggerFormReset = coerceBooleanProperty(value);
-  }
-  public get triggerFormReset(): boolean {
-    return this._triggerFormReset;
-  }
-  private _triggerFormReset = false;
+  public triggerFormReset = false;
 
   /**
    * Emit an event on form submission

--- a/terminus-ui/menu/src/menu.component.ts
+++ b/terminus-ui/menu/src/menu.component.ts
@@ -4,15 +4,12 @@ import {
   Component,
   ElementRef,
   Input,
-  isDevMode,
   OnInit,
   TemplateRef,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
 import { MatMenuTrigger } from '@angular/material/menu';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsButtonFormatTypes } from '@terminus/ui/button';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 
@@ -114,35 +111,13 @@ export class TsMenuComponent implements AfterViewInit, OnInit {
    * Define if the menu should be opened by default
    */
   @Input()
-  public set defaultOpened(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsMenuComponent: "defaultOpened" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._defaultOpened = coerceBooleanProperty(value);
-  }
-  public get defaultOpened(): boolean {
-    return this._defaultOpened;
-  }
-  private _defaultOpened = false;
+  public defaultOpened = false;
 
   /**
    * Define if the menu should be disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsMenuComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Allow a custom template for menu items

--- a/terminus-ui/paginator/src/paginator.component.ts
+++ b/terminus-ui/paginator/src/paginator.component.ts
@@ -6,18 +6,13 @@ import {
   ElementRef,
   EventEmitter,
   Input,
-  isDevMode,
   OnChanges,
   Output,
   SimpleChanges,
   TemplateRef,
   ViewEncapsulation,
 } from '@angular/core';
-import { isBoolean } from '@terminus/ngx-tools';
-import {
-  coerceBooleanProperty,
-  coerceNumberProperty,
-} from '@terminus/ngx-tools/coercion';
+import { coerceNumberProperty } from '@terminus/ngx-tools/coercion';
 import { TsSelectChange } from '@terminus/ui/select';
 import { inputHasChanged, TsStyleThemeTypes } from '@terminus/ui/utilities';
 
@@ -186,18 +181,7 @@ export class TsPaginatorComponent implements OnChanges, AfterViewInit {
    * Define if the paging is 0-based or 1-based
    */
   @Input()
-  public set isZeroBased(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsPaginatorComponent: "isZeroBased" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isZeroBased = coerceBooleanProperty(value);
-  }
-  public get isZeroBased(): boolean {
-    return this._isZeroBased;
-  }
-  private _isZeroBased = true;
+  public isZeroBased = true;
 
   /**
    * Define the tooltip message for the first page tooltip
@@ -293,18 +277,7 @@ export class TsPaginatorComponent implements OnChanges, AfterViewInit {
    * Define if the records per page select menu should be visible
    */
   @Input()
-  public set showRecordsPerPageSelector(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsPaginatorComponent: "showRecordsPerPageSelector" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._showRecordsPerPageSelector = coerceBooleanProperty(value);
-  }
-  public get showRecordsPerPageSelector(): boolean {
-    return this._showRecordsPerPageSelector;
-  }
-  private _showRecordsPerPageSelector = true;
+  public showRecordsPerPageSelector = true;
 
   /**
    * Emit a page selected event

--- a/terminus-ui/radio-group/src/radio-group.component.ts
+++ b/terminus-ui/radio-group/src/radio-group.component.ts
@@ -14,11 +14,9 @@ import { MatRadioChange } from '@angular/material/radio';
 import { DomSanitizer } from '@angular/platform-browser';
 import {
   hasRequiredControl,
-  isBoolean,
   isFunction,
   untilComponentDestroyed,
 } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import {
   ControlValueAccessorProviderFactory,
   TsReactiveFormBaseComponent,
@@ -214,35 +212,13 @@ export class TsRadioGroupComponent extends TsReactiveFormBaseComponent implement
    * Define if the radio group is disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsRadioGroupComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Define if the radio group is visual (boxes) or standard (text)
    */
   @Input()
-  public set isVisual(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsRadioGroupComponent: "isVisual" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isVisual = coerceBooleanProperty(value);
-  }
-  public get isVisual(): boolean {
-    return this._isVisual;
-  }
-  private _isVisual = false;
+  public isVisual = false;
 
   /**
    * Define a label for the radio group
@@ -282,18 +258,7 @@ export class TsRadioGroupComponent extends TsReactiveFormBaseComponent implement
    * Define if the visual style should be large or small
    */
   @Input()
-  public set small(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsRadioGroupComponent: "small" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._small = coerceBooleanProperty(value);
-  }
-  public get small(): boolean {
-    return this._small;
-  }
-  private _small = false;
+  public small = false;
 
   /**
    * Define the theme. {@link TsStyleThemeTypes}

--- a/terminus-ui/scrollbars/src/scrollbars.component.ts
+++ b/terminus-ui/scrollbars/src/scrollbars.component.ts
@@ -4,13 +4,10 @@ import {
   EventEmitter,
   forwardRef,
   Input,
-  isDevMode,
   Output,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import {
   Geometry,
   PerfectScrollbarDirective,
@@ -112,18 +109,7 @@ export class TsScrollbarsComponent {
    * Define if the scrollbars are disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsScrollbarsComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Access underlying scrollbar directive

--- a/terminus-ui/search/src/search.component.ts
+++ b/terminus-ui/search/src/search.component.ts
@@ -3,7 +3,6 @@ import {
   Component,
   EventEmitter,
   Input,
-  isDevMode,
   OnInit,
   Output,
   ViewEncapsulation,
@@ -13,11 +12,7 @@ import {
   FormGroup,
   Validators,
 } from '@angular/forms';
-import {
-  debounce,
-  isBoolean,
-} from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import { debounce } from '@terminus/ngx-tools';
 import {
   TsButtonActionTypes,
   TsButtonFunctionTypes,
@@ -136,18 +131,7 @@ export class TsSearchComponent implements OnInit {
    * Define if the input should automatically submit values as typed
    */
   @Input()
-  public set autoSubmit(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSearchComponent: "autoSubmit" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._autoSubmit = coerceBooleanProperty(value);
-  }
-  public get autoSubmit(): boolean {
-    return this._autoSubmit;
-  }
-  private _autoSubmit = false;
+  public autoSubmit = false;
 
   /**
    * Define an initial value for the search input
@@ -171,52 +155,19 @@ export class TsSearchComponent implements OnInit {
    * Define if the search should be disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSearchComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Define if the search input should be focused initially
    */
   @Input()
-  public set isFocused(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSearchComponent: "isFocused" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isFocused = coerceBooleanProperty(value);
-  }
-  public get isFocused(): boolean {
-    return this._isFocused;
-  }
-  private _isFocused = false;
+  public isFocused = false;
 
   /**
    * Define if the search is currently submitting a query
    */
   @Input()
-  public set isSubmitting(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSearchComponent: "isSubmitting" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isSubmitting = coerceBooleanProperty(value);
-  }
-  public get isSubmitting(): boolean {
-    return this._isSubmitting;
-  }
-  private _isSubmitting = false;
+  public isSubmitting = false;
 
   /**
    * Define the theme
@@ -228,18 +179,7 @@ export class TsSearchComponent implements OnInit {
    * Define if the user can clear the search input
    */
   @Input()
-  public set userCanClear(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSearchComponent: "userCanClear" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._userCanClear = coerceBooleanProperty(value);
-  }
-  public get userCanClear(): boolean {
-    return this._userCanClear;
-  }
-  private _userCanClear = true;
+  public userCanClear = true;
 
   /**
    * The event to emit when the form is submitted

--- a/terminus-ui/select/src/autocomplete/autocomplete-panel.component.ts
+++ b/terminus-ui/select/src/autocomplete/autocomplete-panel.component.ts
@@ -13,7 +13,6 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 
 import { TsSelectOptgroupComponent } from './../optgroup/optgroup.component';
 import {
@@ -109,13 +108,7 @@ export class TsAutocompletePanelComponent implements AfterContentInit {
   /**
    * Whether the autocomplete panel is open
    */
-  public set isOpen(value: boolean) {
-    this._isOpen = coerceBooleanProperty(value);
-  }
-  public get isOpen(): boolean {
-    return this._isOpen && this.showPanel;
-  }
-  private _isOpen = false;
+  public isOpen = false;
 
   /**
    * Function that maps an option's control value to its display value in the trigger

--- a/terminus-ui/select/src/optgroup/optgroup.component.ts
+++ b/terminus-ui/select/src/optgroup/optgroup.component.ts
@@ -6,14 +6,11 @@ import {
   ElementRef,
   Inject,
   Input,
-  isDevMode,
   Optional,
   QueryList,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsCheckboxComponent } from '@terminus/ui/checkbox';
 
 import {
@@ -58,7 +55,7 @@ let nextUniqueId = 0;
     role: 'group',
     '[class.ts-optgroup--disabled]': 'isDisabled',
     '[attr.id]': 'id',
-    '[attr.aria-disabled]': 'isDisabled.toString()',
+    '[attr.aria-disabled]': '!!isDisabled',
     '[attr.aria-labelledby]': 'labelId',
   },
   providers: [
@@ -128,18 +125,7 @@ export class TsSelectOptgroupComponent {
    * Define if the group is disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectOptgroupComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Label for the option group

--- a/terminus-ui/select/src/option/option.component.ts
+++ b/terminus-ui/select/src/option/option.component.ts
@@ -21,8 +21,6 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { NgModel } from '@angular/forms';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { ENTER, SPACE } from '@terminus/ngx-tools/keycodes';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 import { Subject } from 'rxjs';
@@ -119,7 +117,7 @@ let nextUniqueId = 0;
     '[class.ts-select-option--template]': 'optionTemplate',
     '[attr.tabindex]': 'tabIndex',
     '[attr.aria-selected]': 'selected.toString()',
-    '[attr.aria-disabled]': 'isDisabled.toString()',
+    '[attr.aria-disabled]': '!!isDisabled',
     '[attr.title]': 'title',
     '[id]': 'id',
     '(click)': 'selectViaInteraction()',
@@ -157,13 +155,7 @@ export class TsSelectOptionComponent implements Highlightable, AfterContentInit,
   /**
    * Define the active state
    */
-  public set active(value: boolean) {
-    this._active = coerceBooleanProperty(value);
-  }
-  public get active(): boolean {
-    return this._active;
-  }
-  private _active = false;
+  public active = false;
 
   /**
    * Whether the wrapping component is in multiple selection mode
@@ -182,13 +174,7 @@ export class TsSelectOptionComponent implements Highlightable, AfterContentInit,
   /**
    * Whether or not the option is currently selected
    */
-  public set selected(value: boolean) {
-    this._selected = coerceBooleanProperty(value);
-  }
-  public get selected(): boolean {
-    return this._selected;
-  }
-  private _selected = false;
+  public selected = false;
 
   /**
    * Returns the correct tabindex for the option depending on the disabled state
@@ -252,12 +238,7 @@ export class TsSelectOptionComponent implements Highlightable, AfterContentInit,
    */
   @Input()
   public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectOptionComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
+    this._isDisabled = value;
   }
   public get isDisabled(): boolean {
     return (this.group && this.group.isDisabled) || this._isDisabled;

--- a/terminus-ui/select/src/select.component.ts
+++ b/terminus-ui/select/src/select.component.ts
@@ -32,7 +32,6 @@ import { MAT_CHECKBOX_CLICK_ACTION } from '@angular/material/checkbox';
 import { MatChipList } from '@angular/material/chips';
 import {
   hasRequiredControl,
-  isBoolean,
   isFunction,
   isString,
   TsDocumentService,
@@ -40,7 +39,6 @@ import {
 } from '@terminus/ngx-tools';
 import {
   coerceArray,
-  coerceBooleanProperty,
   coerceNumberProperty,
 } from '@terminus/ngx-tools/coercion';
 import {
@@ -600,52 +598,19 @@ export class TsSelectComponent implements
    * Define if multiple selections are allowed
    */
   @Input()
-  public set allowMultiple(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "allowMultiple" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._allowMultiple = coerceBooleanProperty(value);
-  }
-  public get allowMultiple(): boolean {
-    return this._allowMultiple;
-  }
-  private _allowMultiple = false;
+  public allowMultiple = false;
 
   /**
    * Define if the select should be in autocomplete mode
    */
   @Input()
-  public set autocomplete(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "autocomplete" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._autocomplete = coerceBooleanProperty(value);
-  }
-  public get autocomplete(): boolean {
-    return this._autocomplete;
-  }
-  private _autocomplete = false;
+  public autocomplete = false;
 
   /**
    * Define if the autocomplete should allow duplicate selections
    */
   @Input()
-  public set autocompleteAllowDuplicateSelections(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "autocompleteAllowDuplicateSelections" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._autocompleteAllowDuplicateSelections = coerceBooleanProperty(value);
-  }
-  public get autocompleteAllowDuplicateSelections(): boolean {
-    return this._autocompleteAllowDuplicateSelections;
-  }
-  private _autocompleteAllowDuplicateSelections = false;
+  public autocompleteAllowDuplicateSelections = false;
 
   /**
    * Define if the autocomplete panel should reopen after a selection is made
@@ -653,18 +618,7 @@ export class TsSelectComponent implements
    * NOTE: Though it is technically 're-opening', it happens fast enough so that it doesn't appear to close at all.
    */
   @Input()
-  public set autocompleteReopenAfterSelection(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "autocompleteReopenAfterSelection" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._autocompleteReopenAfterSelection = coerceBooleanProperty(value);
-  }
-  public get autocompleteReopenAfterSelection(): boolean {
-    return this._autocompleteReopenAfterSelection;
-  }
-  private _autocompleteReopenAfterSelection = false;
+  public autocompleteReopenAfterSelection = false;
 
   /**
    * Define a function to retrieve the UI value for an option
@@ -744,18 +698,7 @@ export class TsSelectComponent implements
    * Define if the required marker should be hidden
    */
   @Input()
-  public set hideRequiredMarker(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "hideRequiredMarker" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._hideRequiredMarker = coerceBooleanProperty(value);
-  }
-  public get hideRequiredMarker(): boolean {
-    return this._hideRequiredMarker;
-  }
-  private _hideRequiredMarker = false;
+  public hideRequiredMarker = false;
 
   /**
    * Define a hint for the input
@@ -785,47 +728,20 @@ export class TsSelectComponent implements
    * Define if the control should be disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Define if the select is filterable
    */
   @Input()
-  public set isFilterable(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "isFilterable" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isFilterable = coerceBooleanProperty(value);
-  }
-  public get isFilterable(): boolean {
-    return this._isFilterable;
-  }
-  private _isFilterable = false;
+  public isFilterable = false;
 
   /**
    * Define if the control is required
    */
   @Input()
   public set isRequired(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "isRequired" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isRequired = coerceBooleanProperty(value);
+    this._isRequired = value;
   }
   public get isRequired(): boolean {
     const ctrl = this.ngControl && this.ngControl.control;
@@ -875,18 +791,7 @@ export class TsSelectComponent implements
    * Define if the input should currently be showing a progress spinner
    */
   @Input()
-  public set showProgress(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "showProgress" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._showProgress = coerceBooleanProperty(value);
-  }
-  public get showProgress(): boolean {
-    return this._showProgress;
-  }
-  private _showProgress = false;
+  public showProgress = false;
 
   /**
    * Function used to sort the values in a select in multiple mode
@@ -920,18 +825,7 @@ export class TsSelectComponent implements
    * Define if validation messages should be shown immediately or on blur
    */
   @Input()
-  public set validateOnChange(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && isDevMode()) {
-      console.warn(`TsSelectComponent: "validateOnChange" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._validateOnChange = coerceBooleanProperty(value);
-  }
-  public get validateOnChange(): boolean {
-    return this._validateOnChange;
-  }
-  private _validateOnChange = false;
+  public validateOnChange = false;
 
   /**
    * Value of the select control

--- a/terminus-ui/sort/src/sort.directive.ts
+++ b/terminus-ui/sort/src/sort.directive.ts
@@ -10,8 +10,6 @@ import {
   Output,
 } from '@angular/core';
 import { CanDisable, mixinDisabled } from '@angular/material/core';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { Subject } from 'rxjs';
 
 import {
@@ -135,17 +133,7 @@ export class TsSortDirective extends _TsSortMixinBase implements CanDisable, OnC
    * May be overriden by the TsSortable's disable clear input.
    */
   @Input('tsSortDisableClear')
-  public set disableClear(value: boolean) {
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSortDirective: "disableClear" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._disableClear = coerceBooleanProperty(value);
-  }
-  public get disableClear() {
-    return this._disableClear;
-  }
-  private _disableClear = false;
+  public disableClear = false;
 
   /**
    * Event emitted when the user changes either the active sort or sort direction

--- a/terminus-ui/toggle/src/toggle.component.ts
+++ b/terminus-ui/toggle/src/toggle.component.ts
@@ -3,13 +3,10 @@ import {
   Component,
   EventEmitter,
   Input,
-  isDevMode,
   Output,
   ViewEncapsulation,
 } from '@angular/core';
 import { MatSlideToggleChange } from '@angular/material/slide-toggle';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import {
   ControlValueAccessorProviderFactory,
   TsReactiveFormBaseComponent,
@@ -66,12 +63,7 @@ export class TsToggleComponent extends TsReactiveFormBaseComponent {
    */
   @Input()
   public set isChecked(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsToggleComponent: "isChecked" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isChecked = coerceBooleanProperty(value);
+    this._isChecked = value;
     this.value = this._isChecked;
   }
   public get isChecked(): boolean {
@@ -83,35 +75,13 @@ export class TsToggleComponent extends TsReactiveFormBaseComponent {
    * Define if the toggle should be disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsToggleComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Define if the toggle is required
    */
   @Input()
-  public set isRequired(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsToggleComponent: "isRequired" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isRequired = coerceBooleanProperty(value);
-  }
-  public get isRequired(): boolean {
-    return this._isRequired;
-  }
-  private _isRequired = false;
+  public isRequired = false;
 
   /**
    * Define the position of the label

--- a/terminus-ui/tooltip/src/tooltip.component.ts
+++ b/terminus-ui/tooltip/src/tooltip.component.ts
@@ -5,8 +5,6 @@ import {
   isDevMode,
   ViewEncapsulation,
 } from '@angular/core';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 
 
 /**
@@ -81,16 +79,5 @@ export class TsTooltipComponent {
    * Define whether there is a dotted underline shown on the text
    */
   @Input()
-  public set hasUnderline(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsTooltipComponent: "hasUnderline" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._hasUnderline = coerceBooleanProperty(value);
-  }
-  public get hasUnderline(): boolean {
-    return this._hasUnderline;
-  }
-  private _hasUnderline = false;
+  public hasUnderline = false;
 }

--- a/terminus-ui/validation-messages/src/validation-messages.component.ts
+++ b/terminus-ui/validation-messages/src/validation-messages.component.ts
@@ -2,16 +2,11 @@ import {
   ChangeDetectorRef,
   Component,
   Input,
-  isDevMode,
   OnDestroy,
   ViewEncapsulation,
 } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import {
-  isBoolean,
-  untilComponentDestroyed,
-} from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import { untilComponentDestroyed } from '@terminus/ngx-tools';
 
 import { TsValidationMessagesService } from './validation-messages.service';
 
@@ -112,35 +107,13 @@ export class TsValidationMessagesComponent implements OnDestroy {
    * Define if validation should occur on blur or immediately
    */
   @Input()
-  public set validateOnChange(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsValidationMessagesComponent: "validateOnChange" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._validateOnChange = coerceBooleanProperty(value);
-  }
-  public get validateOnChange(): boolean {
-    return this._validateOnChange;
-  }
-  private _validateOnChange = false;
+  public validateOnChange = false;
 
   /**
    * Define if the validation should be immediate
    */
   @Input()
-  public set validateImmediately(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsValidationMessagesComponent: "validateImmediately" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._validateImmediately = coerceBooleanProperty(value);
-  }
-  public get validateImmediately(): boolean {
-    return this._validateImmediately;
-  }
-  private _validateImmediately = false;
+  public validateImmediately = false;
 
 
   constructor(


### PR DESCRIPTION

also cleaning up related imports

💥 BREAKING CHANGE 💥 

Migration notes:
boolean values will have to be entered correctly according to angular in the
html([booleanvar]="true")

```html
<!-- before -->
<my-component my-input="true"></my-component>

<!-- after -->
<my-component [my-input]="true"></my-component>
```


ISSUES CLOSED: #1233