### PR TITLE
V12

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ The library of UI components used for Terminus applications.
   - [Constants](#constants)
   - [Style Helpers](#style-helpers)
 - [Installation](#installation)
-- [Global Styles](#global-styles)
+  - [Fonts and Typefaces](#fonts-and-typefaces)
+  - [Global Styles](#global-styles)
 - [SCSS Helpers](#scss-helpers)
 - [Contributing](#contributing)
 - [Contributors](#contributors)
@@ -222,7 +223,17 @@ $ yarn add @amcharts/amcharts4 @amcharts/amcharts4-geodata
 ```
 
 
-## Global Styles
+### Fonts and Typefaces
+
+Add the following links to install the body fonts and icon fonts used by the library:
+
+```html
+  <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+```
+
+
+### Global Styles
 
 To use the global styles, import the CSS file into your stylesheets:
 

--- a/demo/app/components/button/button.component.html
+++ b/demo/app/components/button/button.component.html
@@ -36,7 +36,7 @@
   <div [style.textAlign]="layout">
     <ts-button
       [theme]="myTheme"
-      (clickEvent)="run('progress2')"
+      (clicked)="run('progress2')"
       [isDisabled]="disabled"
       [showProgress]="progress2"
       [iconName]="icon"
@@ -102,7 +102,7 @@
     format="hollow"
     [isDisabled]="true"
     [showProgress]="progress2"
-    (clickEvent)="run('progress2')"
+    (clicked)="run('progress2')"
     tsVerticalSpacing
   >I'm disabled AND empty inside :(</ts-button>
 </ts-card>

--- a/demo/app/components/card/card.component.html
+++ b/demo/app/components/card/card.component.html
@@ -108,12 +108,12 @@
   <h3 tsCardTitle tsTitleAccentBorder>Card with Title & accent border</h3>
 </ts-card>
 
-<ts-card [disabled]="true" [supportsInteraction]="true" tsVerticalSpacing>
+<ts-card [isDisabled]="true" [supportsInteraction]="true" tsVerticalSpacing>
   Disabled with interactions
 </ts-card>
 
 
-<ts-card [disabled]="true" tsVerticalSpacing>
+<ts-card [isDisabled]="true" tsVerticalSpacing>
   <h3 tsCardTitle tsVerticalSpacing>
     Disabled Card with a very long title foo bar baz
   </h3>
@@ -129,7 +129,7 @@
 
 
 <ts-card
-  [disabled]="false"
+  [isDisabled]="false"
   tsVerticalSpacing
   [utilityMenuTemplate]="myTemplate"
 >
@@ -179,10 +179,10 @@
   </p>
 </ts-card>
 
-<ts-card [flat]="true" tsVerticalSpacing [disabled]="false">
+<ts-card [flat]="true" tsVerticalSpacing [isDisabled]="false">
   <h3 tsVerticalSpacing>Nested card</h3>
   <p>This card is flat and not disabled</p>
-  <ts-card [flat]="false" [disabled]="true">
+  <ts-card [flat]="false" [isDisabled]="true">
     This card is not flat and disabled
   </ts-card>
 </ts-card>

--- a/demo/app/components/confirmation/confirmation.component.html
+++ b/demo/app/components/confirmation/confirmation.component.html
@@ -19,7 +19,7 @@
     <ts-button
       tsConfirmation
       [showProgress]="progress"
-      (clickEvent)="submit()"
+      (clicked)="submit()"
       (cancelled)="cancel($event)"
       confirmationButtonText="Custom Confirmation Button Text"
       [explanationText]="explanation"
@@ -36,7 +36,7 @@
     <ts-button
       tsConfirmation
       [showProgress]="progress"
-      (clickEvent)="submit()"
+      (clicked)="submit()"
       (cancelled)="cancel($event)"
       confirmationButtonText="Custom Confirmation Button Text"
       [explanationText]="explanation"
@@ -53,7 +53,7 @@
   <ts-button
     tsConfirmation
     [showProgress]="progress"
-    (clickEvent)="submit()"
+    (clicked)="submit()"
     (cancelled)="cancel($event)"
     confirmationButtonText="Custom Confirmation Button Text"
     [explanationText]="explanation"

--- a/demo/app/components/date-range/date-range.component.html
+++ b/demo/app/components/date-range/date-range.component.html
@@ -19,7 +19,7 @@
 
     <ts-date-range
       [dateFormGroup]="myForm.get('dateRange')"
-      (change)="printRange(myForm.value)"
+      (dateRangeChange)="printRange(myForm.value)"
     ></ts-date-range>
 
   </form>

--- a/demo/app/components/expansion-panel/expansion-panel.component.html
+++ b/demo/app/components/expansion-panel/expansion-panel.component.html
@@ -178,7 +178,7 @@
       And here is my standard panel content.
 
       <ts-expansion-panel-action-row>
-        <ts-button (click)="nextStep()">
+        <ts-button (clicked)="nextStep()">
           Next
         </ts-button>
       </ts-expansion-panel-action-row>
@@ -197,10 +197,10 @@
       And here is my standard panel content.
 
       <ts-expansion-panel-action-row>
-        <ts-button format="hollow" (click)="previousStep()">
+        <ts-button format="hollow" (clicked)="previousStep()">
           Previous
         </ts-button>
-        <ts-button (click)="nextStep()">
+        <ts-button (clicked)="nextStep()">
           Next
         </ts-button>
       </ts-expansion-panel-action-row>
@@ -219,10 +219,10 @@
       And here is my standard panel content.
 
       <ts-expansion-panel-action-row>
-        <ts-button format="hollow" (click)="previousStep()">
+        <ts-button format="hollow" (clicked)="previousStep()">
           Previous
         </ts-button>
-        <ts-button (click)="nextStep()">
+        <ts-button (clicked)="nextStep()">
           End
         </ts-button>
       </ts-expansion-panel-action-row>

--- a/demo/app/components/icon-button/icon-button.component.html
+++ b/demo/app/components/icon-button/icon-button.component.html
@@ -1,7 +1,7 @@
 <ts-card>
   <div fxLayout="row" fxLayoutAlign="start center" tsVerticalSpacing>
     <div>
-      <ts-icon-button (clickEvent)="click('default')">forum</ts-icon-button>
+      <ts-icon-button (clicked)="clickTheme('default')">forum</ts-icon-button>
     </div>
 
     <div>
@@ -13,21 +13,21 @@
   <div tsVerticalSpacing>
     <ts-icon-button
       theme="primary"
-      (clickEvent)="click('primary')"
+      (clicked)="clickTheme('primary')"
     >add_circle</ts-icon-button>
   </div>
 
   <div tsVerticalSpacing>
     <ts-icon-button
       theme="accent"
-      (clickEvent)="click('accent')"
+      (clicked)="clickTheme('accent')"
     >reply_all</ts-icon-button>
   </div>
 
   <div tsVerticalSpacing>
     <ts-icon-button
       theme="warn"
-      (clickEvent)="click('warn')"
+      (clicked)="clickTheme('warn')"
     >delete_forever</ts-icon-button>
   </div>
 </ts-card>

--- a/demo/app/components/icon-button/icon-button.component.ts
+++ b/demo/app/components/icon-button/icon-button.component.ts
@@ -7,7 +7,7 @@ import { Component } from '@angular/core';
 })
 export class IconButtonComponent {
 
-  click(v: string): void {
+  clickTheme(v: string): void {
     console.log(`DEMO: '${v}' icon-button clicked.`);
   }
 

--- a/demo/app/components/menu/menu.component.html
+++ b/demo/app/components/menu/menu.component.html
@@ -65,11 +65,11 @@
   </div>
 
   <ng-template #myTemplate>
-    <ts-button (click)="customItemSelected('yup')">
+    <ts-button (clicked)="customItemSelected('yup')">
       Roger, Roger.
     </ts-button>
 
-    <ts-button (click)="customItemSelected('nope')">
+    <ts-button (clicked)="customItemSelected('nope')">
       Don't call me Shirley.
     </ts-button>
 
@@ -77,7 +77,7 @@
       A tasty link
     </ts-link>
 
-    <ts-button (click)="customItemSelected('nope')">
+    <ts-button (clicked)="customItemSelected('nope')">
       And a final button
     </ts-button>
   </ng-template>

--- a/demo/app/components/tooltip/tooltip.component.html
+++ b/demo/app/components/tooltip/tooltip.component.html
@@ -11,8 +11,6 @@
       <option value="after">After</option>
       <option value="above">Above</option>
       <option value="below">Below</option>
-      <option value="left">Left</option>
-      <option value="right">Right</option>
     </select>
   </label>
   <br>

--- a/demo/index.html
+++ b/demo/index.html
@@ -7,7 +7,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,500,700" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
   "release": {
     "branch": "master",
     "plugins": [
-      ["@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/release-notes-generator",
         {
           "parserOpts": {
             "noteKeywords": [
@@ -172,7 +173,7 @@
     "@angular/platform-browser": "^7.2.2",
     "@angular/platform-browser-dynamic": "^7.2.2",
     "@angular/router": "^7.2.2",
-    "@terminus/ngx-tools": ">=5.0.0",
+    "@terminus/ngx-tools": "^6.3.0",
     "@terminus/ui": "latest",
     "date-fns": "2.0.0-alpha.26",
     "ngx-perfect-scrollbar": "^7.2.0",

--- a/terminus-ui/autocomplete/src/autocomplete.component.ts
+++ b/terminus-ui/autocomplete/src/autocomplete.component.ts
@@ -23,13 +23,11 @@ import {
 } from '@angular/material/autocomplete';
 import {
   arrayContainsObject,
-  isBoolean,
   isFunction,
   untilComponentDestroyed,
 } from '@terminus/ngx-tools';
 import {
   coerceArray,
-  coerceBooleanProperty,
   coerceNumberProperty,
 } from '@terminus/ngx-tools/coercion';
 import { TS_SPACING } from '@terminus/ui/spacing';
@@ -279,19 +277,8 @@ export class TsAutocompleteComponent<OptionType = {[name: string]: any}> impleme
    * Define if the progress spinner should be active
    */
   @Input()
-  public set showProgress(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsAutocompleteComponent: "showProgress" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
+  public showProgress = false;
 
-    this._showProgress = coerceBooleanProperty(value);
-  }
-  public get showProgress(): boolean {
-    return this._showProgress;
-  }
-  private _showProgress = false;
   /**
    * Define the component theme
    */

--- a/terminus-ui/button/src/button.component.html
+++ b/terminus-ui/button/src/button.component.html
@@ -10,7 +10,7 @@
   [attr.type]="buttonType"
   [disabled]="shouldBeDisabled"
   tabindex="{{ tabIndex }}"
-  (click)="clicked($event)"
+  (click)="clickedButton($event)"
   #button
 >
   <ts-icon

--- a/terminus-ui/button/src/button.component.spec.ts
+++ b/terminus-ui/button/src/button.component.spec.ts
@@ -18,7 +18,7 @@ import { TsButtonModule } from './button.module';
     [iconName]="iconName"
     [format]="format"
     [theme]="theme"
-    (clickEvent)="clickEvent($event)"
+    (clicked)="clicked($event)"
     collapseDelay="collapseDelay"
   >Click Me!</ts-button>
   `,
@@ -36,7 +36,7 @@ class TestHostComponent implements OnInit, OnDestroy {
   buttonComponent!: TsButtonComponent;
 
   changed = jest.fn();
-  clickEvent = jest.fn();
+  clicked = jest.fn();
   private COLLAPSE_DEFAULT_DELAY = undefined;
   public ngOnInit() { }
   public ngOnDestroy() { }
@@ -65,7 +65,7 @@ describe(`TsButtonComponent`, function() {
         expect(buttonComponent.isDisabled).toEqual(false);
         expect(button.disabled).toEqual(false);
         button.click();
-        expect(component.clickEvent).toHaveBeenCalled();
+        expect(component.clicked).toHaveBeenCalled();
       });
 
       test(`should have button disabled`, () => {
@@ -73,14 +73,14 @@ describe(`TsButtonComponent`, function() {
         fixture.detectChanges();
         expect(buttonComponent.isDisabled).toEqual(true);
         expect(button.disabled).toEqual(true);
-        expect(component.clickEvent).not.toHaveBeenCalled();
+        expect(component.clicked).not.toHaveBeenCalled();
       });
     });
 
     test(`click`, () => {
-      component.buttonComponent.clickEvent.emit = jest.fn();
+      component.buttonComponent.clicked.emit = jest.fn();
       button.click();
-      expect(buttonComponent.clickEvent.emit).toHaveBeenCalled();
+      expect(buttonComponent.clicked.emit).toHaveBeenCalled();
     });
 
     describe(`showProgress`, () => {
@@ -326,27 +326,27 @@ describe(`TsButtonComponent`, function() {
     });
 
 
-    describe(`clicked()`, () => {
+    describe(`clickedButton()`, () => {
       let mouseEvent: MouseEvent;
 
       beforeEach(() => {
-        buttonComponent.clickEvent.emit = jest.fn();
+        buttonComponent.clicked.emit = jest.fn();
         mouseEvent = createMouseEvent('click');
       });
 
 
       test(`should emit the click when interceptClick is false`, () => {
-        buttonComponent.clicked(mouseEvent);
+        buttonComponent.clickedButton(mouseEvent);
 
-        expect(buttonComponent.clickEvent.emit).toHaveBeenCalledWith(mouseEvent);
+        expect(buttonComponent.clicked.emit).toHaveBeenCalledWith(mouseEvent);
       });
 
 
       test(`should not emit the click when interceptClick is true`, () => {
         buttonComponent.interceptClick = true;
-        buttonComponent.clicked(mouseEvent);
+        buttonComponent.clickedButton(mouseEvent);
 
-        expect(buttonComponent.clickEvent.emit).not.toHaveBeenCalledWith();
+        expect(buttonComponent.clicked.emit).not.toHaveBeenCalledWith();
         expect(buttonComponent.originalClickEvent).toEqual(mouseEvent);
       });
 

--- a/terminus-ui/button/src/button.component.ts
+++ b/terminus-ui/button/src/button.component.ts
@@ -13,11 +13,7 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import {
-  isBoolean,
-  TsWindowService,
-} from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import { TsWindowService } from '@terminus/ngx-tools';
 import {
   TsStyleThemeTypes,
   tsStyleThemeTypesArray,
@@ -141,13 +137,7 @@ export class TsButtonComponent implements OnInit, OnDestroy {
    */
   @Input()
   public set collapsed(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsButtonComponent: "collapsed" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-
-    this.isCollapsed = coerceBooleanProperty(value);
+    this.isCollapsed = value;
 
     // If the value is `false` and a collapse delay is set
     if (!value && this.collapseDelay) {
@@ -205,35 +195,13 @@ export class TsButtonComponent implements OnInit, OnDestroy {
    * Define if the button is disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsButtonComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Define if the progress indicator should show
    */
   @Input()
-  public set showProgress(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsButtonComponent: "showProgress" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._showProgress = coerceBooleanProperty(value);
-  }
-  public get showProgress(): boolean {
-    return this._showProgress;
-  }
-  private _showProgress = false;
+  public showProgress = false;
 
   /**
    * Define the tabindex for the button

--- a/terminus-ui/button/src/button.component.ts
+++ b/terminus-ui/button/src/button.component.ts
@@ -75,7 +75,7 @@ export const tsButtonFormatTypesArray = ['filled', 'hollow', 'collapsable'];
  *              [collapsed]="false"
  *              collapseDelay="500"
  *              tabIndex="2"
- *              (clickEvent)="myMethod($event)"
+ *              (clicked)="myMethod($event)"
  * >Click Me!</ts-button>
  *
  * <example-url>https://getterminus.github.io/ui-demos-master/components/button</example-url>
@@ -269,7 +269,7 @@ export class TsButtonComponent implements OnInit, OnDestroy {
    * Pass the click event through to the parent
    */
   @Output()
-  public clickEvent: EventEmitter<MouseEvent> = new EventEmitter;
+  public clicked: EventEmitter<MouseEvent> = new EventEmitter();
 
   /**
    * Provide access to the inner button element
@@ -325,16 +325,16 @@ export class TsButtonComponent implements OnInit, OnDestroy {
 
 
   /**
-   * Do something when clicked
+   * Handle button clicks
    *
    * @param event - The MouseEvent
    */
-  public clicked(event: MouseEvent): void {
+  public clickedButton(event: MouseEvent): void {
     // Allow the click to propagate
     if (!this.interceptClick) {
-      this.clickEvent.emit(event);
+      this.clicked.emit(event);
     } else {
-      // Save the original event but don't emit the clickEvent
+      // Save the original event but don't emit the originalClickEvent
       this.originalClickEvent = event;
     }
   }

--- a/terminus-ui/card/src/card-title.directive.ts
+++ b/terminus-ui/card/src/card-title.directive.ts
@@ -33,6 +33,7 @@ export class TsCardTitleDirective {
       this.tsCardTitle = this.tsCardTitle + ' c-card__title-accent-border';
     }
   }
+
   /**
    * Define the component theme
    */

--- a/terminus-ui/card/src/card.component.html
+++ b/terminus-ui/card/src/card.component.html
@@ -4,8 +4,8 @@
     'c-card--interaction': supportsInteraction,
     'c-card--centered': centeredContent,
     'c-card--aspect': aspectRatioPadding,
-    'c-card--disabled': disabled,
-    'c-card--right-spacing': utilityMenuTemplate || disabled,
+    'c-card--disabled': isDisabled,
+    'c-card--right-spacing': utilityMenuTemplate || isDisabled,
     'c-card--flat': flat
   }"
   [style.paddingTop]="aspectRatioPadding"
@@ -14,7 +14,7 @@
   <div
     class="c-card__inner"
     mat-ripple
-    [matRippleDisabled]="!supportsInteraction || disabled"
+    [matRippleDisabled]="!supportsInteraction || isDisabled"
   >
     <ng-content></ng-content>
   </div>
@@ -25,7 +25,7 @@
   ></ng-container>
 
   <ts-icon
-    *ngIf="disabled && !utilityMenuTemplate"
+    *ngIf="isDisabled && !utilityMenuTemplate"
     class="c-card__lock qa-card-lock"
   >lock_outline</ts-icon>
 </div>

--- a/terminus-ui/card/src/card.component.md
+++ b/terminus-ui/card/src/card.component.md
@@ -101,7 +101,7 @@ element which provides the needed styles.
 This will push the opacity of the card contents back and add a lock icon in the top right corner.
 
 ```html
-<ts-card [disabled]="true">
+<ts-card [isDisabled]="true">
   My card
 </ts-card>
 ```

--- a/terminus-ui/card/src/card.component.spec.ts
+++ b/terminus-ui/card/src/card.component.spec.ts
@@ -11,8 +11,7 @@ import { TsCardModule } from './card.module';
 @Component({
   template: `
   <ts-card
-    [isDisabled]="disabled"
-    [disabled]="disabled"
+    [isDisabled]="isDisabled"
     [flat]="flat"
     [supportsInteraction]="supportsInteraction"
     [theme]="theme"
@@ -24,7 +23,7 @@ import { TsCardModule } from './card.module';
 })
 class TestHostComponent {
   border: TsCardBorderOptions | undefined;
-  disabled!: boolean;
+  isDisabled!: boolean;
   flat!: boolean;
   supportsInteraction!: boolean;
   theme: TsStyleThemeTypes | undefined;
@@ -51,19 +50,16 @@ describe(`TsCardComponent`, function() {
 
   describe(`isDisabled`, function() {
     test(`should not disable a card`, () => {
-      expect(cardComponent.disabled).toEqual(false);
-      component.disabled = false;
+      component.isDisabled = false;
       fixture.detectChanges();
       expect(cardComponent.isDisabled).toEqual(false);
-      expect(cardComponent.disabled).toEqual(false);
       expect(card.classList).not.toContain('c-card--disabled');
     });
 
     test(`should disable a card`, () => {
-      component.disabled = true;
+      component.isDisabled = true;
       fixture.detectChanges();
       expect(cardComponent.isDisabled).toEqual(true);
-      expect(cardComponent.disabled).toEqual(true);
       expect(card.classList).toContain('c-card--disabled');
     });
   });

--- a/terminus-ui/card/src/card.component.ts
+++ b/terminus-ui/card/src/card.component.ts
@@ -3,12 +3,9 @@ import {
   Component,
   ElementRef,
   Input,
-  isDevMode,
   TemplateRef,
   ViewEncapsulation,
 } from '@angular/core';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 
 
@@ -120,41 +117,19 @@ export class TsCardComponent {
    * Define if the card should center child content
    */
   @Input()
-  public set centeredContent(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCardComponent: "centeredContent" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._centeredContent = coerceBooleanProperty(value);
-  }
-  public get centeredContent(): boolean {
-    return this._centeredContent;
-  }
-  private _centeredContent = false;
+  public centeredContent = false;
 
   /**
    * Define if the card is disabled
    */
   @Input()
-  public isDisabled: boolean = false;
+  public isDisabled = false;
 
   /**
    * Define if the card should not have a drop shadow
    */
   @Input()
-  public set flat(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCardComponent: "flat" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._flat = coerceBooleanProperty(value);
-  }
-  public get flat(): boolean {
-    return this._flat;
-  }
-  public _flat: boolean = false;
+  public flat = false;
 
   /**
    * Define an ID for the component
@@ -174,18 +149,7 @@ export class TsCardComponent {
    * NOTE: This only alters style; not functionality
    */
   @Input()
-  public set supportsInteraction(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCardComponent: "supportsInteraction" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._supportsInteraction = coerceBooleanProperty(value);
-  }
-  public get supportsInteraction(): boolean {
-    return this._supportsInteraction;
-  }
-  private _supportsInteraction = false;
+  public supportsInteraction = false;
 
   /**
    * Define the card theme

--- a/terminus-ui/card/src/card.component.ts
+++ b/terminus-ui/card/src/card.component.ts
@@ -137,38 +137,7 @@ export class TsCardComponent {
    * Define if the card is disabled
    */
   @Input()
-  public set disabled(value: boolean) {
-    /* istanbul ignore next */
-    console.warn(`TsCardComponent: The "disabled" input will be converted to "isDisabled" to better ` +
-    `align with other components in the next release.`);
-
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCardComponent: "disabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._disabled = coerceBooleanProperty(value);
-  }
-  public get disabled(): boolean {
-    return this._disabled;
-  }
-  public _disabled = false;
-
-  /**
-   * Define if the card is disabled
-   */
-  @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCardComponent: "disabled" value is not a boolean. ` +
-        `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._disabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._disabled;
-  }
+  public isDisabled: boolean = false;
 
   /**
    * Define if the card should not have a drop shadow

--- a/terminus-ui/checkbox/src/checkbox.component.ts
+++ b/terminus-ui/checkbox/src/checkbox.component.ts
@@ -190,13 +190,13 @@ export class TsCheckboxComponent extends TsReactiveFormBaseComponent {
    * Emit an event on input change
    */
   @Output()
-  readonly inputChange: EventEmitter<boolean> = new EventEmitter;
+  readonly inputChange: EventEmitter<boolean> = new EventEmitter();
 
   /**
    * Emit a change when moving from the indeterminate state
    */
   @Output()
-  readonly indeterminateChange: EventEmitter<TsCheckboxChange> = new EventEmitter;
+  readonly indeterminateChange: EventEmitter<TsCheckboxChange> = new EventEmitter();
 
 
   constructor(

--- a/terminus-ui/checkbox/src/checkbox.component.ts
+++ b/terminus-ui/checkbox/src/checkbox.component.ts
@@ -4,7 +4,6 @@ import {
   Component,
   EventEmitter,
   Input,
-  isDevMode,
   Output,
   ViewChild,
   ViewEncapsulation,
@@ -13,8 +12,6 @@ import {
   MatCheckbox,
   MatCheckboxChange,
 } from '@angular/material/checkbox';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import {
   ControlValueAccessorProviderFactory,
   TsReactiveFormBaseComponent,
@@ -98,12 +95,7 @@ export class TsCheckboxComponent extends TsReactiveFormBaseComponent {
    */
   @Input()
   public set isChecked(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCheckboxComponent: "isChecked" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isChecked = coerceBooleanProperty(value);
+    this._isChecked = value;
     this.value = this._isChecked;
     this.checkbox.checked = this._isChecked;
     this.changeDetectorRef.detectChanges();
@@ -117,52 +109,19 @@ export class TsCheckboxComponent extends TsReactiveFormBaseComponent {
    * Define if the checkbox is disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCheckboxComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Define if the checkbox should be indeterminate
    */
   @Input()
-  public set isIndeterminate(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCheckboxComponent: "isIndeterminate" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isIndeterminate = coerceBooleanProperty(value);
-  }
-  public get isIndeterminate(): boolean {
-    return this._isIndeterminate;
-  }
-  private _isIndeterminate = false;
+  public isIndeterminate = false;
 
   /**
    * Define if the checkbox is required
    */
   @Input()
-  public set isRequired(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCheckboxComponent: "isRequired" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isRequired = coerceBooleanProperty(value);
-  }
-  public get isRequired(): boolean {
-    return this._isRequired;
-  }
-  private _isRequired = false;
+  public isRequired = false;
 
   /**
    * Toggle the underlying checkbox if the ngModel changes

--- a/terminus-ui/confirmation/src/confirmation-overlay.component.html
+++ b/terminus-ui/confirmation/src/confirmation-overlay.component.html
@@ -11,14 +11,14 @@
       class="qa-confirmation-cancel"
       theme="warn"
       format="hollow"
-      (clickEvent)="confirm.next(false)"
+      (clicked)="confirm.next(false)"
     >
       {{ cancelButtonTxt }}
     </ts-button>
 
     <ts-button
       class="qa-confirmation-confirm"
-      (clickEvent)="confirm.next(true)"
+      (clicked)="confirm.next(true)"
     >
       {{ confirmationButtonTxt }}
     </ts-button>

--- a/terminus-ui/confirmation/src/confirmation.directive.md
+++ b/terminus-ui/confirmation/src/confirmation.directive.md
@@ -32,7 +32,7 @@ Add the directive to any `ts-button`:
 ```html
 <ts-button
   ts-confirmation
-  (clickEvent)="myContinueFn($event)"
+  (clicked)="myContinueFn($event)"
 >
   Click me!
 </ts-button>
@@ -47,7 +47,7 @@ from the confirmation pop-up.
 ```html
 <ts-button
   ts-confirmation
-  (clickEvent)="myContinueFn($event)"
+  (clicked)="myContinueFn($event)"
   (cancelled)="myCancelEvent($event)"
 >
   Click me!
@@ -62,7 +62,7 @@ Customizes the text in the overlay of the confirmation button; default is "Confi
 ```html
 <ts-button
     tsConfirmation
-    (clickEvent)="submit()"
+    (clicked)="submit()"
     (cancelled)="cancel($event)"
     confirmationButtonText="Custom Confirmation Button Text"
   >
@@ -78,7 +78,7 @@ Customizes the text in the overlay of the cancel button; default is "Cancel".
 ```html
 <ts-button
     tsConfirmation
-    (clickEvent)="submit()"
+    (clicked)="submit()"
     (cancelled)="cancel($event)"
     cancelButtonText="Custom Cancel Button Text"
   >
@@ -94,7 +94,7 @@ Optional text to appear inside of the overlay, generally to use as a warning, fo
 ```html
 <ts-button
     tsConfirmation
-    (clickEvent)="submit()"
+    (clicked)="submit()"
     (cancelled)="cancel($event)"
     explanationText="Optional text within overlay."
   >
@@ -109,7 +109,7 @@ Optional overlayPosition for defining where the overlay will appear relative to 
 ```html
 <ts-button
     tsConfirmation
-    (clickEvent)="submit()"
+    (clicked)="submit()"
     (cancelled)="cancel($event)"
     overlayPosition="before"
   >

--- a/terminus-ui/confirmation/src/confirmation.directive.spec.ts
+++ b/terminus-ui/confirmation/src/confirmation.directive.spec.ts
@@ -48,14 +48,14 @@ class TsButtonComponentMock {
   @Input()
   public showProgress = false;
   @Output()
-  public clickEvent: EventEmitter<MouseEvent> = new EventEmitter;
+  public clicked: EventEmitter<MouseEvent> = new EventEmitter();
 
-  public clicked(event: MouseEvent): void {
+  public clickedButton(event: MouseEvent): void {
     // Allow the click to propagate
     if (!this.interceptClick) {
-      this.clickEvent.emit(event);
+      this.clicked.emit(event);
     } else {
-      // Save the original event but don't emit the clickEvent
+      // Save the original event but don't emit the originalClickEvent
       this.originalClickEvent = event;
     }
   }
@@ -157,7 +157,7 @@ describe(`TsConfirmationDirective`, function() {
   describe(`overlay content`, () => {
 
     test(`should dismiss the overlay and emit event on confirm`, () => {
-      directive['host'].clickEvent.emit = jest.fn();
+      directive['host'].clicked.emit = jest.fn();
       expect(directive['overlayRef']).toBeFalsy();
       button.click();
       expect(directive['overlayRef']).toBeTruthy();
@@ -165,7 +165,7 @@ describe(`TsConfirmationDirective`, function() {
       directive['overlayInstance'].confirm.next(true);
 
       expect(directive['overlayRef']!.hasAttached()).toEqual(false);
-      expect(directive['host'].clickEvent.emit).toHaveBeenCalled();
+      expect(directive['host'].clicked.emit).toHaveBeenCalled();
     });
 
 

--- a/terminus-ui/confirmation/src/confirmation.directive.ts
+++ b/terminus-ui/confirmation/src/confirmation.directive.ts
@@ -230,7 +230,7 @@ export class TsConfirmationDirective implements OnDestroy, OnInit {
     // Subscribe to the continue event
     this.overlayInstance.confirm.subscribe((shouldProceed: boolean) => {
       if (coerceBooleanProperty(shouldProceed)) {
-        this.host.clickEvent.emit(this.host.originalClickEvent);
+        this.host.clicked.emit(this.host.originalClickEvent);
         this.dismissOverlay();
       } else {
         this.dismissOverlay();

--- a/terminus-ui/copy/src/copy.component.ts
+++ b/terminus-ui/copy/src/copy.component.ts
@@ -2,16 +2,13 @@ import {
   Component,
   ElementRef,
   Input,
-  isDevMode,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
 import {
-  isBoolean,
   TsDocumentService,
   TsWindowService,
 } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 
 
@@ -79,35 +76,13 @@ export class TsCopyComponent {
    * Define if the initial click should select the contents
    */
   @Input()
-  public set disableInitialSelection(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCopyComponent: "disableInitialSelection" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._disableInitialSelection = coerceBooleanProperty(value);
-  }
-  public get disableInitialSelection(): boolean {
-    return this._disableInitialSelection;
-  }
-  private _disableInitialSelection = false;
+  public disableInitialSelection = false;
 
   /**
    * Define if the copy to clipboard functionality is enabled
    */
   @Input()
-  public set enableQuickCopy(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCopyComponent: "enableQuickCopy" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._enableQuickCopy = coerceBooleanProperty(value);
-  }
-  public get enableQuickCopy(): boolean {
-    return this._enableQuickCopy;
-  }
-  private _enableQuickCopy = false;
+  public enableQuickCopy = false;
 
   /**
    * Define the component theme

--- a/terminus-ui/csv-entry/src/csv-entry.component.html
+++ b/terminus-ui/csv-entry/src/csv-entry.component.html
@@ -135,14 +135,14 @@
         class="qa-csv-entry-reset"
         format="hollow"
         theme="warn"
-        (click)="resetTable()"
+        (clicked)="resetTable()"
       >Reset Table</ts-button>
 
       <ts-button
         id="ts-csv-add-row"
         class="qa-csv-entry-add-row"
         format="hollow"
-        (click)="addRows()"
+        (clicked)="addRows()"
       >Add Row</ts-button>
     </div>
   </div>

--- a/terminus-ui/csv-entry/src/csv-entry.component.scss
+++ b/terminus-ui/csv-entry/src/csv-entry.component.scss
@@ -124,7 +124,7 @@
 
     &--invalid {
       color: color(warn);
-      font-weight: 400;
+      font-weight: $type__weight--base;
     }
   }
 

--- a/terminus-ui/csv-entry/src/csv-entry.component.spec.ts
+++ b/terminus-ui/csv-entry/src/csv-entry.component.spec.ts
@@ -495,8 +495,8 @@ describe(`TsCSVEntryComponent`, function() {
       fixture.detectChanges();
 
       const addRowButton = fixture.debugElement.query(By.css('#ts-csv-add-row')).nativeElement;
-      dispatchMouseEvent(addRowButton, 'click');
-      dispatchMouseEvent(addRowButton, 'click');
+      dispatchMouseEvent(addRowButton, 'clicked');
+      dispatchMouseEvent(addRowButton, 'clicked');
       fixture.detectChanges();
       const message = fixture.debugElement.query(By.css('.c-csv-entry__message')).nativeElement;
 
@@ -516,14 +516,14 @@ describe(`TsCSVEntryComponent`, function() {
       expect(row2Cell1.value).toEqual(expect.any(String));
 
       const addRowButton = fixture.debugElement.query(By.css('#ts-csv-add-row')).nativeElement;
-      dispatchMouseEvent(addRowButton, 'click');
-      dispatchMouseEvent(addRowButton, 'click');
+      dispatchMouseEvent(addRowButton, 'clicked');
+      dispatchMouseEvent(addRowButton, 'clicked');
       fixture.detectChanges();
       let message = fixture.debugElement.query(By.css('.c-csv-entry__message')).nativeElement;
       expect(message).toBeTruthy();
 
       const resetButton: HTMLInputElement = fixture.debugElement.query(By.css('#ts-csv-reset')).nativeElement;
-      dispatchMouseEvent(resetButton, 'click');
+      dispatchMouseEvent(resetButton, 'clicked');
       fixture.detectChanges();
 
       row2Cell1 = fixture.debugElement.query(By.css('#r_1Xc_0')).nativeElement;

--- a/terminus-ui/csv-entry/src/csv-entry.component.ts
+++ b/terminus-ui/csv-entry/src/csv-entry.component.ts
@@ -4,7 +4,6 @@ import {
   Component,
   EventEmitter,
   Input,
-  isDevMode,
   OnDestroy,
   OnInit,
   Output,
@@ -18,7 +17,6 @@ import {
   ValidatorFn,
 } from '@angular/forms';
 import {
-  isBoolean,
   TsDocumentService,
   untilComponentDestroyed,
 } from '@terminus/ngx-tools';
@@ -216,18 +214,7 @@ export class TsCSVEntryComponent implements OnInit, OnDestroy {
    * Allow full-width mode
    */
   @Input()
-  public set fullWidth(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsCSVEntryComponent: "fullWidth" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._fullWidth = coerceBooleanProperty(value);
-  }
-  public get fullWidth(): boolean {
-    return this._fullWidth;
-  }
-  private _fullWidth = false;
+  public fullWidth = false;
 
   /**
    * Allow static headers to be set

--- a/terminus-ui/date-range/src/date-range.component.md
+++ b/terminus-ui/date-range/src/date-range.component.md
@@ -96,13 +96,13 @@ There are three selection events that you can tie into:
 <ts-date-range
   (startSelected)="myMethod($event)"
   (endSelected)="myMethod($event)"
-  (change)="myMethod($event)"
+  (dateRangeChange)="myMethod($event)"
 ></ts-date-range>
 ```
 
 1. `startSelected` is fired when a start date is selected.
 1. `endSelected` is fired when an end date is selected.
-1. `change` is fired when the date range changes.
+1. `dateRangeChange` is fired when the date range changes.
 
 
 ## Date range boundaries

--- a/terminus-ui/date-range/src/date-range.component.spec.ts
+++ b/terminus-ui/date-range/src/date-range.component.spec.ts
@@ -167,18 +167,18 @@ describe(`TsDateRangeComponent`, function() {
       typeInElement('3-4-2019', startInputInstance.inputElement.nativeElement);
       fixture.detectChanges();
       expect(fixture.componentInstance.startSelected).toHaveBeenCalledWith(new Date('3-4-2019'));
-      expect(fixture.componentInstance.change).toHaveBeenCalledWith({start: new Date('3-4-2019'), end: null});
+      expect(fixture.componentInstance.dateRangeChange).toHaveBeenCalledWith({start: new Date('3-4-2019'), end: null});
 
       typeInElement('3-8-2019', endInputInstance.inputElement.nativeElement);
       fixture.detectChanges();
       expect(fixture.componentInstance.endSelected).toHaveBeenCalledWith(new Date('3-8-2019'));
-      expect(fixture.componentInstance.change).toHaveBeenCalledWith({start: new Date('3-4-2019'), end: new Date('3-8-2019')});
+      expect(fixture.componentInstance.dateRangeChange).toHaveBeenCalledWith({start: new Date('3-4-2019'), end: new Date('3-8-2019')});
 
       typeInElement('', startInputInstance.inputElement.nativeElement);
       fixture.detectChanges();
       startInputInstance.inputElement.nativeElement.blur();
       fixture.detectChanges();
-      const changeMock = fixture.componentInstance.change.mock;
+      const changeMock = fixture.componentInstance.dateRangeChange.mock;
       // FIXME: Once https://github.com/GetTerminus/terminus-ui/issues/1361 is complete we should adjust this
       // test to verify that the changeMock was called exactly 3 times.
       expect(changeMock.calls[changeMock.calls.length - 1][0]).toEqual({start: null, end: new Date('3-8-2019')});

--- a/terminus-ui/date-range/src/date-range.component.ts
+++ b/terminus-ui/date-range/src/date-range.component.ts
@@ -3,7 +3,6 @@ import {
   Component,
   EventEmitter,
   Input,
-  isDevMode,
   OnDestroy,
   OnInit,
   Output,
@@ -14,11 +13,7 @@ import {
   FormControl,
   FormGroup,
 } from '@angular/forms';
-import {
-  isBoolean,
-  untilComponentDestroyed,
-} from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import { untilComponentDestroyed } from '@terminus/ngx-tools';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 import { BehaviorSubject } from 'rxjs';
 
@@ -170,18 +165,7 @@ export class TsDateRangeComponent implements OnInit, OnDestroy {
    * Define if the range should be disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsDateRangeComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Define the starting view for both datepickers

--- a/terminus-ui/date-range/src/date-range.component.ts
+++ b/terminus-ui/date-range/src/date-range.component.ts
@@ -25,22 +25,17 @@ import { BehaviorSubject } from 'rxjs';
 
 /**
  * Define the structure of the date range object used by {@link TsDateRangeComponent}
- *
- * TODO: In the process of deprecating the `null` portion of this interface. It should be using
- * `undefined` instead.
- *
- * Deprecation target: 10.0.0
  */
 export interface TsDateRange {
   /**
    * The start date of the range
    */
-  start: Date | undefined | null;
+  start: Date | undefined;
 
   /**
    * The end date of the range
    */
-  end: Date | undefined | null;
+  end: Date | undefined;
 }
 
 

--- a/terminus-ui/date-range/src/date-range.component.ts
+++ b/terminus-ui/date-range/src/date-range.component.ts
@@ -62,7 +62,7 @@ export interface TsDateRange {
  *              startMaxDate="{{ new Date(2017, 4, 30) }}"
  *              startMinDate="{{ new Date(2017, 4, 1) }}"
  *              theme="primary"
- *              (change)="myMethod($event)"
+ *              (dateRangeChange)="myMethod($event)"
  *              (endSelected)="myMethod($event)"
  *              (startSelected)="myMethod($event)"
  * ></ts-date-range>
@@ -216,7 +216,7 @@ export class TsDateRangeComponent implements OnInit, OnDestroy {
    * Event emitted anytime the range is changed
    */
   @Output()
-  public change: EventEmitter<TsDateRange> = new EventEmitter();
+  public dateRangeChange: EventEmitter<TsDateRange> = new EventEmitter();
 
   /**
    * Output the end date when selected
@@ -342,7 +342,7 @@ export class TsDateRangeComponent implements OnInit, OnDestroy {
       }
 
       this.startSelected.emit(date);
-      this.change.emit(this.dateRange);
+      this.dateRangeChange.emit(this.dateRange);
     } else {
       // If no startDate was selected, reset to the original endMinDate
       this.endMinDate$.next(this.endMinDate);
@@ -367,7 +367,7 @@ export class TsDateRangeComponent implements OnInit, OnDestroy {
       }
 
       this.endSelected.emit(date);
-      this.change.emit(this.dateRange);
+      this.dateRangeChange.emit(this.dateRange);
     } else {
       // If no endDate was selected, reset to the original startMaxDate
       this.startMaxDate$.next(this.startMaxDate);
@@ -393,7 +393,7 @@ export class TsDateRangeComponent implements OnInit, OnDestroy {
       ctrl.setValue(value);
       ctrl.markAsTouched();
       ctrl.updateValueAndValidity();
-      this.change.emit(this.dateRange);
+      this.dateRangeChange.emit(this.dateRange);
     }
   }
 
@@ -416,7 +416,7 @@ export class TsDateRangeComponent implements OnInit, OnDestroy {
       ctrl.setValue(value);
       ctrl.markAsTouched();
       ctrl.updateValueAndValidity();
-      this.change.emit(this.dateRange);
+      this.dateRangeChange.emit(this.dateRange);
     }
   }
 

--- a/terminus-ui/date-range/testing/src/test-components.ts
+++ b/terminus-ui/date-range/testing/src/test-components.ts
@@ -56,7 +56,7 @@ export class SeededDates {
   <form [formGroup]="dateGroup" novalidate>
     <ts-date-range
       [dateFormGroup]="dateGroup"
-      (change)="change($event)"
+      (dateRangeChange)="dateRangeChange($event)"
       (endSelected)="endSelected($event)"
       (startSelected)="startSelected($event)"
     ></ts-date-range>
@@ -65,7 +65,7 @@ export class SeededDates {
 })
 export class Emitters {
   dateGroup = createDateRangeGroup();
-  change = jest.fn();
+  dateRangeChange = jest.fn();
   endSelected = jest.fn();
   startSelected = jest.fn();
 

--- a/terminus-ui/expansion-panel/src/expansion-panel.component.md
+++ b/terminus-ui/expansion-panel/src/expansion-panel.component.md
@@ -234,7 +234,7 @@ the `ts-expansion-panel-action-row`.
     And here is my standard panel content.
 
     <ts-expansion-panel-action-row>
-      <ts-button (click)="nextStep()">
+      <ts-button (clicked)="nextStep()">
         Next
       </ts-button>
     </ts-expansion-panel-action-row>
@@ -249,10 +249,10 @@ the `ts-expansion-panel-action-row`.
     And here is my standard panel content.
 
     <ts-expansion-panel-action-row>
-      <ts-button format="hollow" (click)="previousStep()">
+      <ts-button format="hollow" (clicked)="previousStep()">
         Previous
       </ts-button>
-      <ts-button (click)="nextStep()">
+      <ts-button (clicked)="nextStep()">
         Next
       </ts-button>
     </ts-expansion-panel-action-row>
@@ -267,10 +267,10 @@ the `ts-expansion-panel-action-row`.
     And here is my standard panel content.
 
     <ts-expansion-panel-action-row>
-      <ts-button format="hollow" (click)="previousStep()">
+      <ts-button format="hollow" (clicked)="previousStep()">
         Previous
       </ts-button>
-      <ts-button (click)="nextStep()">
+      <ts-button (clicked)="nextStep()">
         End
       </ts-button>
     </ts-expansion-panel-action-row>

--- a/terminus-ui/file-upload/src/file-upload.component.html
+++ b/terminus-ui/file-upload/src/file-upload.component.html
@@ -86,7 +86,7 @@
       [class.c-file-upload__prompt--hidden]="hideButton"
       [theme]="theme"
       [isDisabled]="dragInProgress"
-      (clickEvent)="promptForFiles()"
+      (clicked)="promptForFiles()"
     >
       {{ buttonMessage }}
     </ts-button>

--- a/terminus-ui/file-upload/src/file-upload.component.ts
+++ b/terminus-ui/file-upload/src/file-upload.component.ts
@@ -22,14 +22,12 @@ import {
   ValidationErrors,
 } from '@angular/forms';
 import {
-  isBoolean,
   isNumber,
   TsDocumentService,
   untilComponentDestroyed,
 } from '@terminus/ngx-tools';
 import {
   coerceArray,
-  coerceBooleanProperty,
   coerceNumberProperty,
 } from '@terminus/ngx-tools/coercion';
 import { ENTER } from '@terminus/ngx-tools/keycodes';
@@ -266,18 +264,7 @@ export class TsFileUploadComponent extends TsReactiveFormBaseComponent implement
    * TODO: This should be removed once UX/Product decide if they want the button.
    */
   @Input()
-  public set hideButton(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsFileUploadComponent: "hideButton" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._hideButton = coerceBooleanProperty(value);
-  }
-  public get hideButton(): boolean {
-    return this._hideButton;
-  }
-  private _hideButton = false;
+  public hideButton = false;
 
   /**
    * Define an ID for the component
@@ -333,18 +320,7 @@ export class TsFileUploadComponent extends TsReactiveFormBaseComponent implement
    * Define if multiple files may be uploaded
    */
   @Input()
-  public set multiple(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsFileUploadComponent: "multiple" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._multiple = coerceBooleanProperty(value);
-  }
-  public get multiple(): boolean {
-    return this._multiple;
-  }
-  private _multiple: boolean = false;
+  public multiple = false;
 
   /**
    * Define the upload progress

--- a/terminus-ui/form-field/src/form-field.component.ts
+++ b/terminus-ui/form-field/src/form-field.component.ts
@@ -8,17 +8,12 @@ import {
   ContentChildren,
   ElementRef,
   Input,
-  isDevMode,
   NgZone,
   QueryList,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import {
-  isBoolean,
-  TsDocumentService,
-} from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import { TsDocumentService } from '@terminus/ngx-tools';
 import { TS_SPACING } from '@terminus/ui/spacing';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 import {
@@ -212,18 +207,7 @@ export class TsFormFieldComponent implements AfterContentInit, AfterContentCheck
    * Define if a required marker should be hidden
    */
   @Input()
-  public set hideRequiredMarker(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsFormFieldComponent: "hideRequiredMarker" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._hideRequiredMarker = coerceBooleanProperty(value);
-  }
-  public get hideRequiredMarker(): boolean {
-    return this._hideRequiredMarker;
-  }
-  private _hideRequiredMarker = false;
+  public hideRequiredMarker = false;
 
   /**
    * Define a hint for the input
@@ -259,13 +243,7 @@ export class TsFormFieldComponent implements AfterContentInit, AfterContentCheck
    * Define if validation messages should be shown immediately or on blur
    */
   @Input()
-  public set validateOnChange(value: boolean) {
-    this._validateOnChange = coerceBooleanProperty(value);
-  }
-  public get validateOnChange(): boolean {
-    return this._validateOnChange;
-  }
-  private _validateOnChange = false;
+  public validateOnChange = false;
 
 
   constructor(

--- a/terminus-ui/icon-button/src/icon-button.component.html
+++ b/terminus-ui/icon-button/src/icon-button.component.html
@@ -4,7 +4,7 @@
   [attr.type]="buttonType"
   [disabled]="isDisabled"
   tabindex="{{ tabIndex }}"
-  (click)="clickEvent.emit($event)"
+  (click)="clicked.emit($event)"
 >
   <ts-icon aria-hidden="true">
     <ng-content></ng-content>

--- a/terminus-ui/icon-button/src/icon-button.component.md
+++ b/terminus-ui/icon-button/src/icon-button.component.md
@@ -13,7 +13,7 @@
 Pass a valid [Material icon][material-icons] name as the content of the button:
 
 ```html
-<ts-icon-button (click)="myMethod()">delete_forever</ts-icon-button>
+<ts-icon-button (clicked)="myMethod()">delete_forever</ts-icon-button>
 ```
 
 
@@ -45,7 +45,7 @@ For accessibility purposes we should set the `actionName` and `buttonType`.
 <ts-icon-button
   actionName="Menu"
   buttonType="button"
-  (click)="myMethod()"
+  (clicked)="myMethod()"
 >bookmark</ts-icon-button>
 ```
 

--- a/terminus-ui/icon-button/src/icon-button.component.spec.ts
+++ b/terminus-ui/icon-button/src/icon-button.component.spec.ts
@@ -13,7 +13,7 @@ import { TsIconButtonModule } from './icon-button.module';
   <ts-icon-button
     actionName="Menu"
     buttonType="button"
-    isDisabled="false"
+    [isDisabled]="false"
     (clicked)="clicked($event)"
   >delete_forever</ts-icon-button>
   `,

--- a/terminus-ui/icon-button/src/icon-button.component.spec.ts
+++ b/terminus-ui/icon-button/src/icon-button.component.spec.ts
@@ -14,7 +14,7 @@ import { TsIconButtonModule } from './icon-button.module';
     actionName="Menu"
     buttonType="button"
     isDisabled="false"
-    (clickEvent)="clickEvent($event)"
+    (clicked)="clicked($event)"
   >delete_forever</ts-icon-button>
   `,
 })

--- a/terminus-ui/icon-button/src/icon-button.component.ts
+++ b/terminus-ui/icon-button/src/icon-button.component.ts
@@ -25,7 +25,7 @@ import {
  *              buttonType="button"
  *              [isDisabled]="false"
  *              tabIndex="2"
- *              (clickEvent)="myMethod($event)"
+ *              (clicked)="myMethod($event)"
  * >delete_forever</ts-icon-button>
  *
  * <example-url>https://getterminus.github.io/ui-demos-master/components/icon-button</example-url>
@@ -70,7 +70,7 @@ export class TsIconButtonComponent {
    * Pass the click event through to the parent
    */
   @Output()
-  public clickEvent: EventEmitter<MouseEvent> = new EventEmitter;
+  public clicked: EventEmitter<MouseEvent> = new EventEmitter();
 
 
   /**

--- a/terminus-ui/icon/src/icon.component.md
+++ b/terminus-ui/icon/src/icon.component.md
@@ -7,6 +7,7 @@
 
 - [Basic usage](#basic-usage)
 - [Theming](#theming)
+- [Background](#background)
 - [Style with CSS](#style-with-css)
 - [Usage inline with text](#usage-inline-with-text)
 - [Custom Icons](#custom-icons)
@@ -42,6 +43,15 @@ Icons support the same themes as the rest of the components:
 ```
 
 Search for `TsStyleThemeTypes` to see all allowed types.
+
+
+## Background
+
+Icons can be shown white with a colored background (color is determined by theme) by setting `background` to true.
+
+```html
+<ts-icon [background]="true"></ts-icon>
+```
 
 
 ## Style with CSS
@@ -90,4 +100,4 @@ Any icon with a -color suffix will not accept themes. Currently they accept a ba
 | `engage`      | A right-pointing arrow stacked on a left-pointing arrow | Navigation for Engage product     |
 | `lightbulb`   | A lightbulb                                             | Pro-tip box                       |
 | `logo`        | Terminus logo, default is black, but accepts theme      | Logo, negative logo               |
-| `logo-color`  | Terminus logo in correct colors, does not accept theme  | Logo like it is supposed to look  |
+| `logo_color`  | Terminus logo in correct colors, does not accept theme  | Logo like it is supposed to look  |

--- a/terminus-ui/icon/src/icon.component.ts
+++ b/terminus-ui/icon/src/icon.component.ts
@@ -7,7 +7,6 @@ import {
 } from '@angular/core';
 import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 
 import { CSV_ICON } from './custom-icons/csv';
@@ -77,13 +76,7 @@ export class TsIconComponent {
    * NOTE: This will affect layout and style.
    */
   @Input()
-  public set background(value: boolean) {
-    this._background = coerceBooleanProperty(value);
-  }
-  public get background(): boolean {
-    return this._background;
-  }
-  private _background = false;
+  public background = false;
 
   /**
    * Define if the icon should be aligned inline with text

--- a/terminus-ui/input/src/input.component.scss
+++ b/terminus-ui/input/src/input.component.scss
@@ -156,5 +156,5 @@
 }
 
 .cdk-overlay-container {
-  z-index: z(panel-overlay);
+  z-index: z(attached-panel-overlay);
 }

--- a/terminus-ui/input/src/input.component.ts
+++ b/terminus-ui/input/src/input.component.ts
@@ -35,13 +35,11 @@ import {
 import { MatDatepicker } from '@angular/material/datepicker';
 import {
   hasRequiredControl,
-  isBoolean,
   isNumber,
   noop,
   TsDocumentService,
 } from '@terminus/ngx-tools';
 import {
-  coerceBooleanProperty,
   coerceNumberProperty,
 } from '@terminus/ngx-tools/coercion';
 import { TsFormFieldControl } from '@terminus/ui/form-field';
@@ -446,18 +444,7 @@ export class TsInputComponent implements
    * (standard HTML5 property)
    */
   @Input()
-  public set autocapitalize(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "autocapitalize" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._autocapitalize = coerceBooleanProperty(value);
-  }
-  public get autocapitalize(): boolean {
-    return this._autocapitalize;
-  }
-  private _autocapitalize = false;
+  public autocapitalize = false;
 
   /**
    * Define if the input should autocomplete. See {@link TsInputAutocompleteTypes}.
@@ -492,12 +479,7 @@ export class TsInputComponent implements
    */
   @Input()
   public set datepicker(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "datepicker" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._datepicker = coerceBooleanProperty(value);
+    this._datepicker = value;
 
     // When using a datepicker, we need to validate on change so that selecting a date from the calendar
     // istanbul ignore else
@@ -541,35 +523,13 @@ export class TsInputComponent implements
    * Define if the use-case provides it's own {@link TsFormFieldComponent} or if this component should provide it's own.
    */
   @Input()
-  public set hasExternalFormField(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "hasExternalFormField" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._hasExternalFormField = coerceBooleanProperty(value);
-  }
-  public get hasExternalFormField(): boolean {
-    return this._hasExternalFormField;
-  }
-  private _hasExternalFormField = false;
+  public hasExternalFormField = false;
 
   /**
    * Define if a required marker should be included
    */
   @Input()
-  public set hideRequiredMarker(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "hideRequiredMarker" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._hideRequiredMarker = coerceBooleanProperty(value);
-  }
-  public get hideRequiredMarker(): boolean {
-    return this._hideRequiredMarker;
-  }
-  private _hideRequiredMarker = false;
+  public hideRequiredMarker = false;
 
   /**
    * Define a hint for the input
@@ -599,18 +559,7 @@ export class TsInputComponent implements
    * Define if the input should surface the ability to clear it's value
    */
   @Input()
-  public set isClearable(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "isClearable" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isClearable = coerceBooleanProperty(value);
-  }
-  public get isClearable(): boolean {
-    return this._isClearable;
-  }
-  private _isClearable = false;
+  public isClearable = false;
 
   /**
    * Define if the input should be disabled
@@ -618,30 +567,14 @@ export class TsInputComponent implements
    * Implemented as part of {@link TsFormFieldControl}
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Define if the input should be focused
    */
   @Input()
   public set isFocused(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "isFocused" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isFocused = coerceBooleanProperty(value);
+    this._isFocused = value;
 
     if (this._isFocused) {
       this.focus();
@@ -659,12 +592,7 @@ export class TsInputComponent implements
    */
   @Input()
   public set isRequired(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "isRequired" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isRequired = coerceBooleanProperty(value);
+    this._isRequired = value;
   }
   public get isRequired(): boolean {
     const requiredFormControl = (this.formControl && hasRequiredControl(this.formControl));
@@ -678,18 +606,7 @@ export class TsInputComponent implements
    * NOTE: This is not meant to be used with the datepicker or mask enabled.
    */
   @Input()
-  public set isTextarea(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "isTextarea" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isTextarea = coerceBooleanProperty(value);
-  }
-  public get isTextarea(): boolean {
-    return this._isTextarea;
-  }
-  private _isTextarea = false;
+  public isTextarea = false;
 
   /**
    * Define the label
@@ -735,13 +652,8 @@ export class TsInputComponent implements
    */
   @Input()
   public set maskAllowDecimal(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "maskAllowDecimal" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
     const oldValue = this.maskAllowDecimal;
-    this._maskAllowDecimal = coerceBooleanProperty(value);
+    this._maskAllowDecimal = value;
 
     // Re-set the definition if the value was changed
     if (this.mask && this.maskAllowDecimal !== oldValue) {
@@ -757,18 +669,7 @@ export class TsInputComponent implements
    * Define if the value should be sanitized before it is saved to the model
    */
   @Input()
-  public set maskSanitizeValue(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "maskSanitizeValue" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._maskSanitizeValue = coerceBooleanProperty(value);
-  }
-  public get maskSanitizeValue(): boolean {
-    return this._maskSanitizeValue;
-  }
-  private _maskSanitizeValue = true;
+  public maskSanitizeValue = true;
 
   /**
    * Define the maximum date for the datepicker
@@ -825,36 +726,14 @@ export class TsInputComponent implements
    * Define if the input is readOnly
    */
   @Input()
-  public set readOnly(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "readOnly" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._readOnly = coerceBooleanProperty(value);
-  }
-  public get readOnly(): boolean {
-    return this._readOnly;
-  }
-  private _readOnly = false;
+  public readOnly = false;
 
   /**
    * Define if the input should spellcheck
    * (standard HTML5 property)
    */
   @Input()
-  public set spellcheck(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "spellcheck" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._spellcheck = coerceBooleanProperty(value);
-  }
-  public get spellcheck(): boolean {
-    return this._spellcheck;
-  }
-  private _spellcheck: boolean = true;
+  public spellcheck = true;
 
   /**
    * Define the starting calendar view for the datepicker
@@ -942,18 +821,7 @@ export class TsInputComponent implements
    * Define if validation messages should be shown immediately or on blur
    */
   @Input()
-  public set validateOnChange(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsInputComponent: "validateOnChange" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._validateOnChange = coerceBooleanProperty(value);
-  }
-  public get validateOnChange(): boolean {
-    return this._validateOnChange;
-  }
-  private _validateOnChange = false;
+  public validateOnChange = false;
 
 
   /**

--- a/terminus-ui/input/testing/src/test-components.ts
+++ b/terminus-ui/input/testing/src/test-components.ts
@@ -64,7 +64,7 @@ export class Autocomplete implements AfterContentInit {
   template: `<ts-input [readOnly]="readOnly"></ts-input>`,
 })
 export class AttrReadonly {
-  readOnly: boolean | undefined = undefined;
+  readOnly = false;
 
   @ViewChild(TsInputComponent)
   inputComponent: TsInputComponent;
@@ -74,7 +74,7 @@ export class AttrReadonly {
   template: `<ts-input [spellcheck]="spellcheck"></ts-input>`,
 })
 export class AttrSpellcheck {
-  spellcheck: boolean | undefined = undefined;
+  spellcheck = false;
 
   @ViewChild(TsInputComponent)
   inputComponent: TsInputComponent;

--- a/terminus-ui/link/src/link.component.scss
+++ b/terminus-ui/link/src/link.component.scss
@@ -107,7 +107,7 @@
   .mat-menu-content & {
     color: color(pure, dark);
     display: block;
-    font-weight: 300;
+    font-weight: $type__weight--base;
     padding: spacing(small, 1) spacing();
     text-decoration: none;
     transition: background 400ms $g-material-background-easing;

--- a/terminus-ui/link/src/link.component.spec.ts
+++ b/terminus-ui/link/src/link.component.spec.ts
@@ -69,13 +69,6 @@ describe(`TsLinkComponent`, function() {
       expect(link.children[0].textContent).toContain('open_in_new');
     });
 
-    test(`should throw error if invalid value is passed`, () => {
-      window.console.warn = jest.fn();
-      component.isExternal = 'foo' as any;
-      fixture.detectChanges();
-
-      expect(window.console.warn).toHaveBeenCalled();
-    });
   });
 
   describe(`tabIndex`, () => {

--- a/terminus-ui/link/src/link.component.ts
+++ b/terminus-ui/link/src/link.component.ts
@@ -2,11 +2,8 @@ import {
   ChangeDetectionStrategy,
   Component,
   Input,
-  isDevMode,
   ViewEncapsulation,
 } from '@angular/core';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 
 
 /**
@@ -59,18 +56,7 @@ export class TsLinkComponent {
    * Define if the link is to an external page
    */
   @Input()
-  public set isExternal(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsLinkComponent: "isExternal" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isExternal = coerceBooleanProperty(value);
-  }
-  public get isExternal(): boolean {
-    return this._isExternal;
-  }
-  private _isExternal = false;
+  public isExternal = false;
 
   /**
    * Define the tabindex

--- a/terminus-ui/loading-overlay/src/loading-overlay.component.scss
+++ b/terminus-ui/loading-overlay/src/loading-overlay.component.scss
@@ -57,7 +57,7 @@ $duration: 1.4s;
     right: 0;
     top: 0;
     will-change: opacity;
-    z-index: z(panel-overlay);
+    z-index: z(attached-panel-overlay);
   }
 }
 

--- a/terminus-ui/loading-overlay/src/loading-overlay.directive.ts
+++ b/terminus-ui/loading-overlay/src/loading-overlay.directive.ts
@@ -7,15 +7,10 @@ import {
   HostBinding,
   Injector,
   Input,
-  isDevMode,
   OnDestroy,
   OnInit,
 } from '@angular/core';
-import {
-  isBoolean,
-  TsWindowService,
-} from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import { TsWindowService } from '@terminus/ngx-tools';
 
 import { TsLoadingOverlayComponent } from './loading-overlay.component';
 
@@ -48,12 +43,7 @@ export class TsLoadingOverlayDirective implements OnInit, OnDestroy {
    */
   @Input()
   public set tsLoadingOverlay(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsLoadingOverlayDirective: "tsLoadingOverlay" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    const shouldSet = coerceBooleanProperty(value);
+    const shouldSet = value;
     if (shouldSet) {
       this.bodyPortalHost.attach(this.loadingOverlayPortal);
     } else {

--- a/terminus-ui/login-form/src/login-form.component.html
+++ b/terminus-ui/login-form/src/login-form.component.html
@@ -58,7 +58,7 @@
       buttonType="submit"
       [showProgress]="inProgress || isRedirecting"
       [isDisabled]="!loginForm.valid"
-      (clickEvent)="submit.emit(loginForm.value)"
+      (clicked)="submit.emit(loginForm.value)"
       tabindex="-1"
       tabIndex="4"
     >

--- a/terminus-ui/login-form/src/login-form.component.ts
+++ b/terminus-ui/login-form/src/login-form.component.ts
@@ -202,7 +202,7 @@ export class TsLoginFormComponent implements OnChanges {
    * Emit an event on form submission
    */
   @Output()
-  public submit: EventEmitter<TsLoginFormResponse> = new EventEmitter;
+  public submit: EventEmitter<TsLoginFormResponse> = new EventEmitter();
 
 
   /**

--- a/terminus-ui/login-form/src/login-form.component.ts
+++ b/terminus-ui/login-form/src/login-form.component.ts
@@ -2,7 +2,6 @@ import {
   Component,
   EventEmitter,
   Input,
-  isDevMode,
   OnChanges,
   Output,
   QueryList,
@@ -16,8 +15,6 @@ import {
   FormGroup,
   Validators,
 } from '@angular/forms';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsCheckboxComponent } from '@terminus/ui/checkbox';
 import { TsInputComponent } from '@terminus/ui/input';
 import { TsValidatorsService } from '@terminus/ui/validators';
@@ -145,35 +142,13 @@ export class TsLoginFormComponent implements OnChanges {
    * Define if the form button is showing progress
    */
   @Input()
-  public set inProgress(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsLoginFormComponent: "inProgress" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._inProgress = coerceBooleanProperty(value);
-  }
-  public get inProgress(): boolean {
-    return this._inProgress;
-  }
-  private _inProgress = false;
+  public inProgress = false;
 
   /**
    * Define if the user has successfully logged in and is being redirected
    */
   @Input()
-  public set isRedirecting(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsLoginFormComponent: "isRedirecting" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isRedirecting = coerceBooleanProperty(value);
-  }
-  public get isRedirecting(): boolean {
-    return this._isRedirecting;
-  }
-  private _isRedirecting = false;
+  public isRedirecting = false;
 
   /**
    * Define the login call to action
@@ -185,18 +160,7 @@ export class TsLoginFormComponent implements OnChanges {
    * Allow a consumer to reset the form via an input
    */
   @Input()
-  public set triggerFormReset(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsLoginFormComponent: "triggerFormReset" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._triggerFormReset = coerceBooleanProperty(value);
-  }
-  public get triggerFormReset(): boolean {
-    return this._triggerFormReset;
-  }
-  private _triggerFormReset = false;
+  public triggerFormReset = false;
 
   /**
    * Emit an event on form submission

--- a/terminus-ui/menu/src/menu.component.md
+++ b/terminus-ui/menu/src/menu.component.md
@@ -17,7 +17,7 @@
 
 <!-- Define a template for the dropdown panel and pass it to `[menuItemsTemplate]` above -->
 <ng-template #myTemplate>
-  <ts-button (click)="customItemSelected('yup')">
+  <ts-button (clicked)="customItemSelected('yup')">
     Roger, Roger.
   </ts-button>
 

--- a/terminus-ui/menu/src/menu.component.ts
+++ b/terminus-ui/menu/src/menu.component.ts
@@ -4,15 +4,12 @@ import {
   Component,
   ElementRef,
   Input,
-  isDevMode,
   OnInit,
   TemplateRef,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
 import { MatMenuTrigger } from '@angular/material/menu';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsButtonFormatTypes } from '@terminus/ui/button';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 
@@ -114,35 +111,13 @@ export class TsMenuComponent implements AfterViewInit, OnInit {
    * Define if the menu should be opened by default
    */
   @Input()
-  public set defaultOpened(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsMenuComponent: "defaultOpened" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._defaultOpened = coerceBooleanProperty(value);
-  }
-  public get defaultOpened(): boolean {
-    return this._defaultOpened;
-  }
-  private _defaultOpened = false;
+  public defaultOpened = false;
 
   /**
    * Define if the menu should be disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsMenuComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Allow a custom template for menu items

--- a/terminus-ui/navigation/src/navigation.component.scss
+++ b/terminus-ui/navigation/src/navigation.component.scss
@@ -120,7 +120,7 @@
 
     // <span> wrapper for welcome message
     &-welcome {
-      font-weight: 300;
+      font-weight: $type__weight--base;
     }
 
     // <ts-icon>

--- a/terminus-ui/navigation/src/navigation.component.ts
+++ b/terminus-ui/navigation/src/navigation.component.ts
@@ -254,7 +254,7 @@ export class TsNavigationComponent implements OnInit, AfterViewInit {
    * Emit the click event with the {@link TsNavigationPayload}
    */
   @Output()
-  public action: EventEmitter<TsNavigationPayload> = new EventEmitter;
+  public action: EventEmitter<TsNavigationPayload> = new EventEmitter();
 
   /**
    * Trigger a layout update when the window resizes

--- a/terminus-ui/paginator/src/paginator.component.html
+++ b/terminus-ui/paginator/src/paginator.component.html
@@ -23,7 +23,7 @@
         [theme]="theme"
         [iconName]="firstPageIcon"
         [isDisabled]="isFirstPage(currentPageIndex)"
-        (clickEvent)="changePage(firstPageIndex, currentPageIndex, pagesArray)"
+        (clicked)="changePage(firstPageIndex, currentPageIndex, pagesArray)"
       ></ts-button>
     </ts-tooltip>
 
@@ -34,7 +34,7 @@
         [theme]="theme"
         [iconName]="previousPageIcon"
         [isDisabled]="isFirstPage(currentPageIndex)"
-        (clickEvent)="changePage(currentPageIndex - 1, currentPageIndex, pagesArray)"
+        (clicked)="changePage(currentPageIndex - 1, currentPageIndex, pagesArray)"
       ></ts-button>
     </ts-tooltip>
 
@@ -55,7 +55,7 @@
         [theme]="theme"
         [iconName]="nextPageIcon"
         [isDisabled]="isLastPage(currentPageIndex) || !pagesArray?.length"
-        (clickEvent)="changePage(currentPageIndex + 1, currentPageIndex, pagesArray)"
+        (clicked)="changePage(currentPageIndex + 1, currentPageIndex, pagesArray)"
       ></ts-button>
     </ts-tooltip>
 
@@ -66,7 +66,7 @@
         [theme]="theme"
         [iconName]="lastPageIcon"
         [isDisabled]="isLastPage(currentPageIndex) || !pagesArray?.length"
-        (clickEvent)="changePage(lastPageIndex, currentPageIndex, pagesArray)"
+        (clicked)="changePage(lastPageIndex, currentPageIndex, pagesArray)"
       ></ts-button>
     </ts-tooltip>
   </div>
@@ -87,7 +87,7 @@
 <ng-template #menuItems>
   <ts-button
     *ngFor="let page of pagesArray; trackBy: trackPagesArray"
-    (clickEvent)="currentPageChanged(page)"
+    (clicked)="currentPageChanged(page)"
   >
     {{ page.name }}
   </ts-button>

--- a/terminus-ui/paginator/src/paginator.component.ts
+++ b/terminus-ui/paginator/src/paginator.component.ts
@@ -6,18 +6,13 @@ import {
   ElementRef,
   EventEmitter,
   Input,
-  isDevMode,
   OnChanges,
   Output,
   SimpleChanges,
   TemplateRef,
   ViewEncapsulation,
 } from '@angular/core';
-import { isBoolean } from '@terminus/ngx-tools';
-import {
-  coerceBooleanProperty,
-  coerceNumberProperty,
-} from '@terminus/ngx-tools/coercion';
+import { coerceNumberProperty } from '@terminus/ngx-tools/coercion';
 import { TsSelectChange } from '@terminus/ui/select';
 import { inputHasChanged, TsStyleThemeTypes } from '@terminus/ui/utilities';
 
@@ -186,18 +181,7 @@ export class TsPaginatorComponent implements OnChanges, AfterViewInit {
    * Define if the paging is 0-based or 1-based
    */
   @Input()
-  public set isZeroBased(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsPaginatorComponent: "isZeroBased" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isZeroBased = coerceBooleanProperty(value);
-  }
-  public get isZeroBased(): boolean {
-    return this._isZeroBased;
-  }
-  private _isZeroBased = true;
+  public isZeroBased = true;
 
   /**
    * Define the tooltip message for the first page tooltip
@@ -293,18 +277,7 @@ export class TsPaginatorComponent implements OnChanges, AfterViewInit {
    * Define if the records per page select menu should be visible
    */
   @Input()
-  public set showRecordsPerPageSelector(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsPaginatorComponent: "showRecordsPerPageSelector" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._showRecordsPerPageSelector = coerceBooleanProperty(value);
-  }
-  public get showRecordsPerPageSelector(): boolean {
-    return this._showRecordsPerPageSelector;
-  }
-  private _showRecordsPerPageSelector = true;
+  public showRecordsPerPageSelector = true;
 
   /**
    * Emit a page selected event

--- a/terminus-ui/radio-group/src/radio-group.component.ts
+++ b/terminus-ui/radio-group/src/radio-group.component.ts
@@ -14,11 +14,9 @@ import { MatRadioChange } from '@angular/material/radio';
 import { DomSanitizer } from '@angular/platform-browser';
 import {
   hasRequiredControl,
-  isBoolean,
   isFunction,
   untilComponentDestroyed,
 } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import {
   ControlValueAccessorProviderFactory,
   TsReactiveFormBaseComponent,
@@ -214,35 +212,13 @@ export class TsRadioGroupComponent extends TsReactiveFormBaseComponent implement
    * Define if the radio group is disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsRadioGroupComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Define if the radio group is visual (boxes) or standard (text)
    */
   @Input()
-  public set isVisual(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsRadioGroupComponent: "isVisual" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isVisual = coerceBooleanProperty(value);
-  }
-  public get isVisual(): boolean {
-    return this._isVisual;
-  }
-  private _isVisual = false;
+  public isVisual = false;
 
   /**
    * Define a label for the radio group
@@ -282,18 +258,7 @@ export class TsRadioGroupComponent extends TsReactiveFormBaseComponent implement
    * Define if the visual style should be large or small
    */
   @Input()
-  public set small(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsRadioGroupComponent: "small" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._small = coerceBooleanProperty(value);
-  }
-  public get small(): boolean {
-    return this._small;
-  }
-  private _small = false;
+  public small = false;
 
   /**
    * Define the theme. {@link TsStyleThemeTypes}

--- a/terminus-ui/scrollbars/src/scrollbars.component.ts
+++ b/terminus-ui/scrollbars/src/scrollbars.component.ts
@@ -4,13 +4,10 @@ import {
   EventEmitter,
   forwardRef,
   Input,
-  isDevMode,
   Output,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import {
   Geometry,
   PerfectScrollbarDirective,
@@ -112,18 +109,7 @@ export class TsScrollbarsComponent {
    * Define if the scrollbars are disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsScrollbarsComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Access underlying scrollbar directive

--- a/terminus-ui/scss/docs/z-index.md
+++ b/terminus-ui/scss/docs/z-index.md
@@ -18,9 +18,9 @@ of `z-index` values while at the same time guaranteeing that no two `z-index` va
   z-index: z(tooltip);
 }
 
-// Use the 'overlay' z-index value
+// Use the 'global-overlay' z-index value
 .bar {
-  z-index: z(overlay);
+  z-index: z(global-overlay);
 }
 ```
 
@@ -28,10 +28,11 @@ of `z-index` values while at the same time guaranteeing that no two `z-index` va
 
 (values are computed in ascending order - highest values at the top)
 
-- `overlay`,
+- `global-overlay`,
+- `global-header`,
 - `tooltip`,
-- `header`,
-- `menu`,
+- `attached-panel-overlay`,
+- `panel-header`,
 - `menu-trigger`,
 
 More `z-index` values will be added as needed.

--- a/terminus-ui/scss/helpers/_triangle.scss
+++ b/terminus-ui/scss/helpers/_triangle.scss
@@ -22,7 +22,7 @@
   height: 0;
   position: absolute;
   width: 0;
-  z-index: z('tooltip');
+  z-index: z(tooltip);
 
   @if not index(top right bottom left, $direction) {
     @error 'Direction must be either `top`, `right`, `bottom` or `left`.';

--- a/terminus-ui/scss/helpers/_typography.scss
+++ b/terminus-ui/scss/helpers/_typography.scss
@@ -44,7 +44,7 @@ $type__size--base: 16px !default;
  * @nuclide
  * @section Typography
  */
-$type__weight--base: 300 !default;
+$type__weight--base: 400 !default;
 
 /**
  * The available typography formats
@@ -146,7 +146,7 @@ $typography-body-levels: (
 
     @if $level == 4 {
       font-size: 112px;
-      font-weight: 300;
+      font-weight: 400;
       letter-spacing: -.01em;
       line-height: 112px;
     }
@@ -189,7 +189,7 @@ $typography-body-levels: (
     }
 
     @if $level == 1 {
-      font-weight: 300;
+      font-weight: 400;
 
       // TODO: overwrite in files rather than this nested chain (too specific) https://github.com/GetTerminus/terminus-ui/issues/1152
       // Don't apply custom line-height to buttons
@@ -227,7 +227,7 @@ $typography-body-levels: (
   @if $format == 'hint' {
     color: color(utility);
     font-size: 75%;
-    font-weight: 300;
+    font-weight: 400;
     letter-spacing: .01em;
     line-height: 1.5;
   }

--- a/terminus-ui/scss/helpers/_z-index.scss
+++ b/terminus-ui/scss/helpers/_z-index.scss
@@ -7,12 +7,11 @@
  * @section Config
  */
 $z-layers: (
-  'overlay',
+  'global-overlay',
+  'global-header',
   'tooltip',
-  'header',
-  'panel-overlay',
+  'attached-panel-overlay',
   'panel-header',
-  'menu',
   'menu-trigger',
 );
 
@@ -25,7 +24,7 @@ $z-layers: (
  *  The name of the item that should have an associated z-index
  * @example
  *  z(tooltip);
- *  z(menu);
+ *  z(attached-panel-overlay);
  */
 @function z($name) {
   @if index($z-layers, $name) {

--- a/terminus-ui/search/src/search.component.html
+++ b/terminus-ui/search/src/search.component.html
@@ -33,7 +33,7 @@
     [showProgress]="isSubmitting"
     [buttonType]="buttonType"
     [actionName]="buttonAction"
-    (clickEvent)="searchForm.valid && !isSubmitting && submitted.emit({query: currentQuery})"
+    (clicked)="searchForm.valid && !isSubmitting && submitted.emit({query: currentQuery})"
   >Search</ts-button>
 
 </form>

--- a/terminus-ui/search/src/search.component.ts
+++ b/terminus-ui/search/src/search.component.ts
@@ -3,7 +3,6 @@ import {
   Component,
   EventEmitter,
   Input,
-  isDevMode,
   OnInit,
   Output,
   ViewEncapsulation,
@@ -13,11 +12,7 @@ import {
   FormGroup,
   Validators,
 } from '@angular/forms';
-import {
-  debounce,
-  isBoolean,
-} from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import { debounce } from '@terminus/ngx-tools';
 import {
   TsButtonActionTypes,
   TsButtonFunctionTypes,
@@ -136,18 +131,7 @@ export class TsSearchComponent implements OnInit {
    * Define if the input should automatically submit values as typed
    */
   @Input()
-  public set autoSubmit(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSearchComponent: "autoSubmit" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._autoSubmit = coerceBooleanProperty(value);
-  }
-  public get autoSubmit(): boolean {
-    return this._autoSubmit;
-  }
-  private _autoSubmit = false;
+  public autoSubmit = false;
 
   /**
    * Define an initial value for the search input
@@ -171,52 +155,19 @@ export class TsSearchComponent implements OnInit {
    * Define if the search should be disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSearchComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Define if the search input should be focused initially
    */
   @Input()
-  public set isFocused(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSearchComponent: "isFocused" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isFocused = coerceBooleanProperty(value);
-  }
-  public get isFocused(): boolean {
-    return this._isFocused;
-  }
-  private _isFocused = false;
+  public isFocused = false;
 
   /**
    * Define if the search is currently submitting a query
    */
   @Input()
-  public set isSubmitting(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSearchComponent: "isSubmitting" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isSubmitting = coerceBooleanProperty(value);
-  }
-  public get isSubmitting(): boolean {
-    return this._isSubmitting;
-  }
-  private _isSubmitting = false;
+  public isSubmitting = false;
 
   /**
    * Define the theme
@@ -228,18 +179,7 @@ export class TsSearchComponent implements OnInit {
    * Define if the user can clear the search input
    */
   @Input()
-  public set userCanClear(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSearchComponent: "userCanClear" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._userCanClear = coerceBooleanProperty(value);
-  }
-  public get userCanClear(): boolean {
-    return this._userCanClear;
-  }
-  private _userCanClear = true;
+  public userCanClear = true;
 
   /**
    * The event to emit when the form is submitted

--- a/terminus-ui/select/src/autocomplete/autocomplete-panel.component.ts
+++ b/terminus-ui/select/src/autocomplete/autocomplete-panel.component.ts
@@ -13,7 +13,6 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 
 import { TsSelectOptgroupComponent } from './../optgroup/optgroup.component';
 import {
@@ -109,13 +108,7 @@ export class TsAutocompletePanelComponent implements AfterContentInit {
   /**
    * Whether the autocomplete panel is open
    */
-  public set isOpen(value: boolean) {
-    this._isOpen = coerceBooleanProperty(value);
-  }
-  public get isOpen(): boolean {
-    return this._isOpen && this.showPanel;
-  }
-  private _isOpen = false;
+  public isOpen = false;
 
   /**
    * Function that maps an option's control value to its display value in the trigger

--- a/terminus-ui/select/src/optgroup/optgroup.component.ts
+++ b/terminus-ui/select/src/optgroup/optgroup.component.ts
@@ -6,14 +6,11 @@ import {
   ElementRef,
   Inject,
   Input,
-  isDevMode,
   Optional,
   QueryList,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { TsCheckboxComponent } from '@terminus/ui/checkbox';
 
 import {
@@ -58,7 +55,7 @@ let nextUniqueId = 0;
     role: 'group',
     '[class.ts-optgroup--disabled]': 'isDisabled',
     '[attr.id]': 'id',
-    '[attr.aria-disabled]': 'isDisabled.toString()',
+    '[attr.aria-disabled]': '!!isDisabled',
     '[attr.aria-labelledby]': 'labelId',
   },
   providers: [
@@ -128,18 +125,7 @@ export class TsSelectOptgroupComponent {
    * Define if the group is disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectOptgroupComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Label for the option group

--- a/terminus-ui/select/src/option/option.component.scss
+++ b/terminus-ui/select/src/option/option.component.scss
@@ -53,7 +53,7 @@ $ts-select-item-height: 3em !default;
 .ts-select-panel {
   @include elevation-element(menu);
   background: color(pure);
-  z-index: z(menu);
+  z-index: z(attached-panel-overlay);
 
   .ts-optgroup-label,
   .ts-select-option:not(.ts-select-option--template) {

--- a/terminus-ui/select/src/option/option.component.ts
+++ b/terminus-ui/select/src/option/option.component.ts
@@ -21,8 +21,6 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { NgModel } from '@angular/forms';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { ENTER, SPACE } from '@terminus/ngx-tools/keycodes';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 import { Subject } from 'rxjs';
@@ -119,7 +117,7 @@ let nextUniqueId = 0;
     '[class.ts-select-option--template]': 'optionTemplate',
     '[attr.tabindex]': 'tabIndex',
     '[attr.aria-selected]': 'selected.toString()',
-    '[attr.aria-disabled]': 'isDisabled.toString()',
+    '[attr.aria-disabled]': '!!isDisabled',
     '[attr.title]': 'title',
     '[id]': 'id',
     '(click)': 'selectViaInteraction()',
@@ -157,13 +155,7 @@ export class TsSelectOptionComponent implements Highlightable, AfterContentInit,
   /**
    * Define the active state
    */
-  public set active(value: boolean) {
-    this._active = coerceBooleanProperty(value);
-  }
-  public get active(): boolean {
-    return this._active;
-  }
-  private _active = false;
+  public active = false;
 
   /**
    * Whether the wrapping component is in multiple selection mode
@@ -182,13 +174,7 @@ export class TsSelectOptionComponent implements Highlightable, AfterContentInit,
   /**
    * Whether or not the option is currently selected
    */
-  public set selected(value: boolean) {
-    this._selected = coerceBooleanProperty(value);
-  }
-  public get selected(): boolean {
-    return this._selected;
-  }
-  private _selected = false;
+  public selected = false;
 
   /**
    * Returns the correct tabindex for the option depending on the disabled state
@@ -252,12 +238,7 @@ export class TsSelectOptionComponent implements Highlightable, AfterContentInit,
    */
   @Input()
   public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectOptionComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
+    this._isDisabled = value;
   }
   public get isDisabled(): boolean {
     return (this.group && this.group.isDisabled) || this._isDisabled;

--- a/terminus-ui/select/src/select.component.ts
+++ b/terminus-ui/select/src/select.component.ts
@@ -32,7 +32,6 @@ import { MAT_CHECKBOX_CLICK_ACTION } from '@angular/material/checkbox';
 import { MatChipList } from '@angular/material/chips';
 import {
   hasRequiredControl,
-  isBoolean,
   isFunction,
   isString,
   TsDocumentService,
@@ -40,7 +39,6 @@ import {
 } from '@terminus/ngx-tools';
 import {
   coerceArray,
-  coerceBooleanProperty,
   coerceNumberProperty,
 } from '@terminus/ngx-tools/coercion';
 import {
@@ -600,52 +598,19 @@ export class TsSelectComponent implements
    * Define if multiple selections are allowed
    */
   @Input()
-  public set allowMultiple(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "allowMultiple" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._allowMultiple = coerceBooleanProperty(value);
-  }
-  public get allowMultiple(): boolean {
-    return this._allowMultiple;
-  }
-  private _allowMultiple = false;
+  public allowMultiple = false;
 
   /**
    * Define if the select should be in autocomplete mode
    */
   @Input()
-  public set autocomplete(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "autocomplete" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._autocomplete = coerceBooleanProperty(value);
-  }
-  public get autocomplete(): boolean {
-    return this._autocomplete;
-  }
-  private _autocomplete = false;
+  public autocomplete = false;
 
   /**
    * Define if the autocomplete should allow duplicate selections
    */
   @Input()
-  public set autocompleteAllowDuplicateSelections(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "autocompleteAllowDuplicateSelections" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._autocompleteAllowDuplicateSelections = coerceBooleanProperty(value);
-  }
-  public get autocompleteAllowDuplicateSelections(): boolean {
-    return this._autocompleteAllowDuplicateSelections;
-  }
-  private _autocompleteAllowDuplicateSelections = false;
+  public autocompleteAllowDuplicateSelections = false;
 
   /**
    * Define if the autocomplete panel should reopen after a selection is made
@@ -653,18 +618,7 @@ export class TsSelectComponent implements
    * NOTE: Though it is technically 're-opening', it happens fast enough so that it doesn't appear to close at all.
    */
   @Input()
-  public set autocompleteReopenAfterSelection(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "autocompleteReopenAfterSelection" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._autocompleteReopenAfterSelection = coerceBooleanProperty(value);
-  }
-  public get autocompleteReopenAfterSelection(): boolean {
-    return this._autocompleteReopenAfterSelection;
-  }
-  private _autocompleteReopenAfterSelection = false;
+  public autocompleteReopenAfterSelection = false;
 
   /**
    * Define a function to retrieve the UI value for an option
@@ -744,18 +698,7 @@ export class TsSelectComponent implements
    * Define if the required marker should be hidden
    */
   @Input()
-  public set hideRequiredMarker(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "hideRequiredMarker" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._hideRequiredMarker = coerceBooleanProperty(value);
-  }
-  public get hideRequiredMarker(): boolean {
-    return this._hideRequiredMarker;
-  }
-  private _hideRequiredMarker = false;
+  public hideRequiredMarker = false;
 
   /**
    * Define a hint for the input
@@ -785,47 +728,20 @@ export class TsSelectComponent implements
    * Define if the control should be disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Define if the select is filterable
    */
   @Input()
-  public set isFilterable(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "isFilterable" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isFilterable = coerceBooleanProperty(value);
-  }
-  public get isFilterable(): boolean {
-    return this._isFilterable;
-  }
-  private _isFilterable = false;
+  public isFilterable = false;
 
   /**
    * Define if the control is required
    */
   @Input()
   public set isRequired(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "isRequired" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isRequired = coerceBooleanProperty(value);
+    this._isRequired = value;
   }
   public get isRequired(): boolean {
     const ctrl = this.ngControl && this.ngControl.control;
@@ -875,18 +791,7 @@ export class TsSelectComponent implements
    * Define if the input should currently be showing a progress spinner
    */
   @Input()
-  public set showProgress(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSelectComponent: "showProgress" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._showProgress = coerceBooleanProperty(value);
-  }
-  public get showProgress(): boolean {
-    return this._showProgress;
-  }
-  private _showProgress = false;
+  public showProgress = false;
 
   /**
    * Function used to sort the values in a select in multiple mode
@@ -920,18 +825,7 @@ export class TsSelectComponent implements
    * Define if validation messages should be shown immediately or on blur
    */
   @Input()
-  public set validateOnChange(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && isDevMode()) {
-      console.warn(`TsSelectComponent: "validateOnChange" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._validateOnChange = coerceBooleanProperty(value);
-  }
-  public get validateOnChange(): boolean {
-    return this._validateOnChange;
-  }
-  private _validateOnChange = false;
+  public validateOnChange = false;
 
   /**
    * Value of the select control

--- a/terminus-ui/sort/src/sort.directive.ts
+++ b/terminus-ui/sort/src/sort.directive.ts
@@ -10,8 +10,6 @@ import {
   Output,
 } from '@angular/core';
 import { CanDisable, mixinDisabled } from '@angular/material/core';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { Subject } from 'rxjs';
 
 import {
@@ -135,17 +133,7 @@ export class TsSortDirective extends _TsSortMixinBase implements CanDisable, OnC
    * May be overriden by the TsSortable's disable clear input.
    */
   @Input('tsSortDisableClear')
-  public set disableClear(value: boolean) {
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsSortDirective: "disableClear" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._disableClear = coerceBooleanProperty(value);
-  }
-  public get disableClear() {
-    return this._disableClear;
-  }
-  private _disableClear = false;
+  public disableClear = false;
 
   /**
    * Event emitted when the user changes either the active sort or sort direction

--- a/terminus-ui/toggle/src/toggle.component.ts
+++ b/terminus-ui/toggle/src/toggle.component.ts
@@ -3,13 +3,10 @@ import {
   Component,
   EventEmitter,
   Input,
-  isDevMode,
   Output,
   ViewEncapsulation,
 } from '@angular/core';
 import { MatSlideToggleChange } from '@angular/material/slide-toggle';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import {
   ControlValueAccessorProviderFactory,
   TsReactiveFormBaseComponent,
@@ -66,12 +63,7 @@ export class TsToggleComponent extends TsReactiveFormBaseComponent {
    */
   @Input()
   public set isChecked(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsToggleComponent: "isChecked" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isChecked = coerceBooleanProperty(value);
+    this._isChecked = value;
     this.value = this._isChecked;
   }
   public get isChecked(): boolean {
@@ -83,35 +75,13 @@ export class TsToggleComponent extends TsReactiveFormBaseComponent {
    * Define if the toggle should be disabled
    */
   @Input()
-  public set isDisabled(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsToggleComponent: "isDisabled" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isDisabled = coerceBooleanProperty(value);
-  }
-  public get isDisabled(): boolean {
-    return this._isDisabled;
-  }
-  private _isDisabled = false;
+  public isDisabled = false;
 
   /**
    * Define if the toggle is required
    */
   @Input()
-  public set isRequired(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsToggleComponent: "isRequired" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._isRequired = coerceBooleanProperty(value);
-  }
-  public get isRequired(): boolean {
-    return this._isRequired;
-  }
-  private _isRequired = false;
+  public isRequired = false;
 
   /**
    * Define the position of the label

--- a/terminus-ui/tooltip/src/tooltip.component.ts
+++ b/terminus-ui/tooltip/src/tooltip.component.ts
@@ -5,8 +5,6 @@ import {
   isDevMode,
   ViewEncapsulation,
 } from '@angular/core';
-import { isBoolean } from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 
 
 /**
@@ -81,16 +79,5 @@ export class TsTooltipComponent {
    * Define whether there is a dotted underline shown on the text
    */
   @Input()
-  public set hasUnderline(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsTooltipComponent: "hasUnderline" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._hasUnderline = coerceBooleanProperty(value);
-  }
-  public get hasUnderline(): boolean {
-    return this._hasUnderline;
-  }
-  private _hasUnderline = false;
+  public hasUnderline = false;
 }

--- a/terminus-ui/validation-messages/src/validation-messages.component.scss
+++ b/terminus-ui/validation-messages/src/validation-messages.component.scss
@@ -16,7 +16,7 @@
   .c-validation-message {
     @include typography('caption');
     color: color(warn);
-    z-index: z('tooltip');
+    z-index: z(tooltip);
   }
 }
 

--- a/terminus-ui/validation-messages/src/validation-messages.component.ts
+++ b/terminus-ui/validation-messages/src/validation-messages.component.ts
@@ -2,16 +2,11 @@ import {
   ChangeDetectorRef,
   Component,
   Input,
-  isDevMode,
   OnDestroy,
   ViewEncapsulation,
 } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import {
-  isBoolean,
-  untilComponentDestroyed,
-} from '@terminus/ngx-tools';
-import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
+import { untilComponentDestroyed } from '@terminus/ngx-tools';
 
 import { TsValidationMessagesService } from './validation-messages.service';
 
@@ -112,35 +107,13 @@ export class TsValidationMessagesComponent implements OnDestroy {
    * Define if validation should occur on blur or immediately
    */
   @Input()
-  public set validateOnChange(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsValidationMessagesComponent: "validateOnChange" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._validateOnChange = coerceBooleanProperty(value);
-  }
-  public get validateOnChange(): boolean {
-    return this._validateOnChange;
-  }
-  private _validateOnChange = false;
+  public validateOnChange = false;
 
   /**
    * Define if the validation should be immediate
    */
   @Input()
-  public set validateImmediately(value: boolean) {
-    /* istanbul ignore if */
-    if (!isBoolean(value) && value && isDevMode()) {
-      console.warn(`TsValidationMessagesComponent: "validateImmediately" value is not a boolean. ` +
-      `String values of 'true' and 'false' will no longer be coerced to a true boolean with the next release.`);
-    }
-    this._validateImmediately = coerceBooleanProperty(value);
-  }
-  public get validateImmediately(): boolean {
-    return this._validateImmediately;
-  }
-  private _validateImmediately = false;
+  public validateImmediately = false;
 
 
   constructor(

--- a/yarn.lock
+++ b/yarn.lock
@@ -780,10 +780,10 @@
     into-stream "^4.0.0"
     lodash "^4.17.4"
 
-"@terminus/ngx-tools@>=5.0.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@terminus/ngx-tools/-/ngx-tools-6.1.0.tgz#34f4935879904c7630118bb2df131eecd12e79da"
-  integrity sha512-bW8ch5/n7PpSkj//00SBmbW+iJi78uTEYM67oFd4J6+enqK8CKZWe43w5f+GKhl7k0hzVyllfJ53x+7SS77rHw==
+"@terminus/ngx-tools@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@terminus/ngx-tools/-/ngx-tools-6.3.0.tgz#146b7cdadbc21bdd8d3cef6ff9c6d1b89fc98f22"
+  integrity sha512-4V4zC/Ctg5GPzb+gUdpUJf3yx+C4j2EAFDFaEaBNUGgoTSIynbVSqFgJAQOz3iVgqAvXNi/FpiJbsDs+kdNafA==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
BREAKING CHANGE:

1. All: No components coercing boolean `@Input`s
1. Card: `disabled` `@Input` no longer exists
1. DateRange: `change` emitter renamed to `dateRangeChange`
1. DateRange: `TsDateRange` interface no longer supports `null`
1. Typography: Base font weight changed to `400`
1. Button: `clickEvent` event emitter is now named `clicked`
1. Z-index: Naming and order updates


## Migration Notes

### Boolean coercion

Boolean values can no longer be passed in as strings:

```html
<!-- before -->
<my-component my-input="true"></my-component>

<!-- after -->
<my-component [my-input]="true"></my-component>
```

> ⚠️ NOTE: This effects _all_ components

### Card

Updated input name to align with existing library conventions:

```html
<!-- before -->
<ts-card [disabled]="true"></ts-card>

<!-- after -->
<ts-card [isDisabled]="true"></ts-card>
```

### DateRange

The `change` event emitter is duplicated by Angular so it has been renamed:

```html
<!-- before -->
<ts-date-range (change)="myDateRange($event)"></ts-date-range>

<!-- after -->
<ts-date-range (dateRangeChange)="myDateRange($event)"></ts-date-range>
```

The `TsDateRange` interface no longer supports `null`:

```typescript
// before
export interface TsDateRange {
  start: Date | undefined | null;
  end: Date | undefined | null;
}

// after
export interface TsDateRange {
  start: Date | undefined;
  end: Date | undefined;
}
```

### Base font weight

To solve a few readability issues, our base font weight has been increased to match the Material spec:

```html
<!-- before -->
<link href="https://fonts.googleapis.com/css?family=Roboto:300,500,700" rel="stylesheet">

<!-- after -->
<link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">
```

### Button & Icon Button

Updated event emitter name to align with existing library conventions:

```html
<!-- before -->
<ts-button (clickEvent)="myFunction($event)"></ts-button>
<ts-icon-button (clickEvent)="myFunction($event)"></ts-icon-button>

<!-- after -->
<ts-button (clicked)="myFunction($event)"></ts-button>
<ts-icon-button (clicked)="myFunction($event)"></ts-icon-button>
```

### Z-Index

Naming needed clarification and the order needed to be updated:

Update the following z-index values:

| before             | after                      |
| -------------- | ----------------------- |
| header            | global-header                 |
| overlay            | global-overlay                |
| panel-overlay | attached-panel-overlay |
| menu               | attached-panel-overlay |

> NOTE: `tooltip` will now be at a lower z-index than `global-header`
