### PR TITLE
fix(LoadingOverlay): fix for portal already loaded error

### DIFF
--- a/terminus-ui/loading-overlay/src/loading-overlay.directive.ts
+++ b/terminus-ui/loading-overlay/src/loading-overlay.directive.ts
@@ -43,7 +43,8 @@ export class TsLoadingOverlayDirective implements OnInit, OnDestroy {
    */
   @Input()
   public set tsLoadingOverlay(value: boolean) {
-    const shouldSet = value;
+    const shouldSet = value && (this.bodyPortalHost && !this.bodyPortalHost.hasAttached());
+
     if (shouldSet) {
       this.bodyPortalHost.attach(this.loadingOverlayPortal);
     } else {


### PR DESCRIPTION
When using the async pipe and a nested value the portal could be reinitialized without first tearing down the portal

ISSUES CLOSED: #1455