### PR TITLE
1480 directive test coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,6 +22,7 @@ module.exports = {
   clearMocks: true,
   collectCoverageFrom: [
     'terminus-ui/**/!(index|public-api|*.module|*.interface|*.constant|*.mock|*.d).ts',
+    'terminus-ui/**/*.directive.ts',
     '!terminus-ui/**/testing/**',
   ],
   moduleFileExtensions: [

--- a/terminus-ui/confirmation/src/confirmation.directive.spec.ts
+++ b/terminus-ui/confirmation/src/confirmation.directive.spec.ts
@@ -8,19 +8,21 @@ import {
   ViewChild,
 } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
+import { KEYS } from '@terminus/ngx-tools/keycodes';
 import {
   createComponent,
+  dispatchKeyboardEvent,
   expectNativeEl,
 } from '@terminus/ngx-tools/testing';
-import { TsButtonModule } from '@terminus/ui';
+import { TsButtonModule } from '@terminus/ui/button';
 
 import { TsConfirmationDirective } from './confirmation.directive';
 import { TsConfirmationModule } from './confirmation.module';
 
 
-/** *****************************************
+/**
  * TestHostComponent
- *******************************************/
+ */
 @Component({
   template: `
     <ts-button
@@ -79,18 +81,31 @@ describe(`TsConfirmationDirective`, function() {
   });
 
 
-  describe(`ESCAPE key`, () => {
+  describe(`dismissing the overlay`, () => {
 
-    test(`should dismiss the overlay`, () => {
+    test(`should dismiss the overlay by clicking the backdrop`, () => {
       expect(directive['overlayRef']).toBeFalsy();
       button.click();
       expect(directive['overlayRef']).toBeTruthy();
 
-      directive['overlayRef']['_backdropClick'].next(new Event('click'));
+      directive['overlayRef']!['_backdropClick'].next(new Event('click'));
       fixture.detectChanges();
 
       expect(directive['overlayRef']!.hasAttached()).toEqual(false);
     });
+
+
+    test(`should dismiss the overlay by using the escape key`, function() {
+      expect(directive['overlayRef']).toBeFalsy();
+      button.click();
+      expect(directive['overlayRef']).toBeTruthy();
+
+      dispatchKeyboardEvent(button, 'keydown', KEYS.ESCAPE);
+      fixture.detectChanges();
+
+      expect(directive['overlayRef']!.hasAttached()).toEqual(false);
+    });
+
 
   });
 
@@ -190,7 +205,9 @@ describe(`TsConfirmationDirective`, function() {
 
   });
 
+
   describe(`Positioning`, () => {
+
     test(`should default to 'below'`, () => {
       jest.useFakeTimers();
       button.click();
@@ -200,6 +217,7 @@ describe(`TsConfirmationDirective`, function() {
       expect(directive['overlayPosition']).toEqual('below');
       expect(document.querySelector('.ts-confirmation-overlay__panel-below')).not.toBeNull();
     });
+
 
     test(`should accept 'above' position type and set class`, () => {
       jest.useFakeTimers();
@@ -211,6 +229,7 @@ describe(`TsConfirmationDirective`, function() {
       expect(document.querySelector('.ts-confirmation-overlay__panel-above')).not.toBeNull();
     });
 
+
     test(`should accept 'below' position type and set class`, () => {
       jest.useFakeTimers();
       directive.overlayPosition = 'below';
@@ -220,6 +239,7 @@ describe(`TsConfirmationDirective`, function() {
 
       expect(document.querySelector('.ts-confirmation-overlay__panel-below')).not.toBeNull();
     });
+
 
     test(`should accept 'before' position type and set class`, () => {
       jest.useFakeTimers();
@@ -231,6 +251,7 @@ describe(`TsConfirmationDirective`, function() {
       expect(document.querySelector('.ts-confirmation-overlay__panel-before')).not.toBeNull();
     });
 
+
     test(`should accept 'after' position type and set class`, () => {
       jest.useFakeTimers();
       directive.overlayPosition = 'after';
@@ -240,6 +261,7 @@ describe(`TsConfirmationDirective`, function() {
 
       expect(document.querySelector('.ts-confirmation-overlay__panel-after')).not.toBeNull();
     });
+
 
     test(`should throw error if invalid position is set`, () => {
       jest.useFakeTimers();
@@ -251,7 +273,17 @@ describe(`TsConfirmationDirective`, function() {
 
       expect(window.console.warn).toHaveBeenCalled();
     });
+
+  });
+
+
+  describe(`generateOverlayConfig`, function() {
+
+    test(`should use default value`, function() {
+      const result = directive['generateOverlayConfig']();
+      expect(result.panelClass).toContain('ts-confirmation-overlay__panel-below');
+    });
+
   });
 
 });
-

--- a/terminus-ui/navigation/src/navigation.component.spec.ts
+++ b/terminus-ui/navigation/src/navigation.component.spec.ts
@@ -276,4 +276,14 @@ describe(`TsNavigationComponent`, function() {
 
   });
 
+
+  describe(`trackByFn`, function() {
+
+    test(`should return the index passed to it`, function() {
+      expect(component.trackByFn(3)).toEqual(3);
+      expect(component.trackByFn(6)).toEqual(6);
+    });
+
+  });
+
 });

--- a/tooling/jest-setup.ts
+++ b/tooling/jest-setup.ts
@@ -1,4 +1,4 @@
 import 'jest-preset-angular';
-import './jest-global-mocks';
 import 'jest-zone-patch';
+import './jest-global-mocks';
 


### PR DESCRIPTION
- Coverage now reporting on directives
  - Not entirely sure why the change was needed. The overall glob _should_ have been matching directives also. But since it wasn't I added an explicit inclusion.
- Add a couple tests to catch missed lines and paths