### PR TITLE
fix(Demo): correct over-zealous find and replace for 'master'

### DIFF
--- a/tooling/ci/demos-deploy.sh
+++ b/tooling/ci/demos-deploy.sh
@@ -37,7 +37,7 @@ if [[ " ${releaseBranches[@]} " =~ " ${CIRCLE_BRANCH} " ]]; then
   git commit -m "Update via CircleCI: ${CIRCLE_BRANCH}"
 
   # Push quietly to prevent showing the token in log
-  git push -q https://${GH_TOKEN}@github.com/GetTerminus/ui-demos-${CIRCLE_BRANCH}.git release
+  git push -q https://${GH_TOKEN}@github.com/GetTerminus/ui-demos-${CIRCLE_BRANCH}.git master
 else
   echo "Branch '${CIRCLE_BRANCH}' is not a release branch. Skipping demo release."
   echo "Valid release branches:  ${releaseBranches[*]}"


### PR DESCRIPTION
This branch reference should not have been changed along with the others. The demo repos are still using master as a base