### PR TITLE
fix(Packages): use correct versions for internal package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Install the library and required dependencies:
 $ yarn add @terminus/ui @terminus/ngx-tools
 
 # Peer dependencies that will need to be installed (needed by UI and tools libraries):
-$ yarn add @angular/flex-layout@6.0.0-beta.18 date-fns@2.0.0-alpha.16 @ngrx/effects @ngrx/store hammerjs
+$ yarn add @angular/cdk @angular/material @angular/flex-layout@6.0.0-beta.26 date-fns@2.0.0-alpha.26 @ngrx/effects @ngrx/store hammerjs
 
 # Optional dependencies (needed if using the TsChartComponent):
 $ yarn add @amcharts/amcharts4 @amcharts/amcharts4-geodata

--- a/terminus-ui/package.json
+++ b/terminus-ui/package.json
@@ -45,13 +45,13 @@
     "yarn": ">= 1.0.0"
   },
   "dependencies": {
-    "@angular/cdk": "^7.3.0",
-    "ngx-perfect-scrollbar": "^7.2.0",
+    "ngx-perfect-scrollbar": "^8.0.0",
     "text-mask-addons": "^3.8.0",
     "text-mask-core": "^5.1.2"
   },
   "peerDependencies": {
     "@angular/animations": "^8.0.1",
+    "@angular/cdk": "^8.0.1",
     "@angular/core": "^8.0.1",
     "@angular/flex-layout": "8.0.0-beta.26",
     "@angular/forms": "^8.0.1",
@@ -86,7 +86,6 @@
       "comments": "none"
     },
     "whitelistedNonPeerDependencies": [
-      "@angular/cdk",
       "ngx-perfect-scrollbar",
       "text-mask-addons",
       "text-mask-core"


### PR DESCRIPTION
- update incorrect package versions - Closes #1596
- update installation docs - Closes #1597 
- move the CDK to peer dependency - Closes #1598

### Injection Issue

This seems to be caused by multiple versions of the CDK existing. Despite the Engage pinned version (`8.0.1`) matching the library requirement (`^8.0.1`) it still installed two versions of the CDK: `8.0.1` and `8.0.2`.

NOTE: This is only a partial fix for the injection issue. Engage will need a tweak once this is released:

1. Install the latest version of the library that contains this fix (should be `14.0.6`)
1. Change the pinned version of Material and CDK to `8.0.2`. ⚠️ Note: this issue could occur again when versions change - we highly suggest matching the version range of the library: `^8.0.1` or at the very least `~8.0.1`
1. Verify that only a single version of the CDK exists in Engage `yarn.lock`