### PR TITLE
fix(Input): correct alignment between prefix icon and input content

### DIFF
--- a/demo/app/components/input/input.component.html
+++ b/demo/app/components/input/input.component.html
@@ -128,7 +128,7 @@
       [formControl]="myForm.get('email')"
       [label]="label2"
       [isClearable]="clearable"
-      [prefixIcon]="icon"
+      [prefixIcon]="'alternate_email'"
       [validateOnChange]="true"
       [hint]="'Email input with validation'"
       name="email"

--- a/terminus-ui/form-field/src/form-field.component.scss
+++ b/terminus-ui/form-field/src/form-field.component.scss
@@ -265,7 +265,7 @@ $outline-appearance-label-offset: -.25em;
   .ts-form-field__suffix {
     flex: none;
     position: relative;
-    top: $form-field-outline-label-overlap;
+    top: $form-field-outline-label-overlap - .1;
     white-space: nowrap;
   }
 


### PR DESCRIPTION
ISSUES CLOSED: #1588

Not a huge change, but aligning to the baseline looked much worse.

Previous:
<img width="126" alt="Screen Shot 2019-07-17 at 8 03 39 AM" src="https://user-images.githubusercontent.com/270193/61374536-9d442780-a86a-11e9-9c7a-57dbaa66a300.png">


With this PRs adjustments:
<img width="152" alt="Screen Shot 2019-07-17 at 8 03 45 AM" src="https://user-images.githubusercontent.com/270193/61374542-9fa68180-a86a-11e9-8249-dcc640676859.png">
