### PR TITLE
Hotfix radio layout

### DIFF
--- a/terminus-ui/radio-group/src/radio-group.component.scss
+++ b/terminus-ui/radio-group/src/radio-group.component.scss
@@ -67,6 +67,7 @@
  */
 
 .c-radio--visual {
+  $radius: 3px;
   &.c-radio--small {
     .c-radio__control {
       height: 7rem;
@@ -90,6 +91,7 @@
   .c-radio__control {
     @include elevation-element(raised-button);
     @include responsive-ratio(1, 1);
+    border-radius: $radius;
     overflow: hidden;
     padding: spacing(default);
     position: relative;
@@ -100,7 +102,7 @@
     @include take-space;
     align-items: center;
     border: 1px solid color(utility, light);
-    border-radius: 3px;
+    border-radius: $radius;
     padding: spacing(default);
     transition: border-color 200ms ease-in;
 

--- a/terminus-ui/radio-group/src/radio-group.component.scss
+++ b/terminus-ui/radio-group/src/radio-group.component.scss
@@ -68,10 +68,17 @@
 
 .c-radio--visual {
   $radius: 3px;
+
   &.c-radio--small {
     .c-radio__control {
+      float: left;
       height: 7rem;
+      margin-bottom: spacing(small);
       width: 13.75rem;
+
+      &:not(:last-child) {
+        margin-right: spacing(small);
+      }
     }
   }
 
@@ -80,11 +87,13 @@
     all: unset;
   }
 
-  // <div> wrapper for all options
-  .c-radio__options {
-    display: grid;
-    grid-gap: spacing(small);
-    grid-template-columns: repeat(auto-fill, minmax(12em, 1fr));
+  &:not(.c-radio--small) {
+    // <div> wrapper for all options
+    .c-radio__options {
+      display: grid;
+      grid-gap: spacing(small);
+      grid-template-columns: repeat(auto-fill, minmax(12em, 1fr));
+    }
   }
 
   // <label> container for a single option


### PR DESCRIPTION
After the last radio group commit, the CSS grid layout began acting odd by overlapping at certain sizes:

![Screen Shot 2019-08-06 at 6 33 24 AM](https://user-images.githubusercontent.com/270193/62534208-8e6fe580-b816-11e9-93ef-8cfde8a4690a.png)

The PR:

- Changes small layout to float rather than grid (grid is still used for the large layout)
- Fix issue where corners were bleeding past the rounded container corner (unrelated to the small layout)