### PR TITLE
feat(Tooltip): styles match our palette

### DIFF
--- a/demo/app/components/tooltip/tooltip.component.ts
+++ b/demo/app/components/tooltip/tooltip.component.ts
@@ -7,7 +7,7 @@ import { TsTooltipPositionTypes } from '@terminus/ui/tooltip';
   templateUrl: './tooltip.component.html',
 })
 export class TooltipComponent {
-  myTooltip = 'Here is my content';
+  myTooltip = 'Here is my content.';
   myPosition: TsTooltipPositionTypes = 'below';
   showUnderline = true;
 }

--- a/terminus-ui/tooltip/src/tooltip.component.scss
+++ b/terminus-ui/tooltip/src/tooltip.component.scss
@@ -1,5 +1,8 @@
+@import './../../scss/helpers/color';
 @import './../../scss/helpers/cursors';
 @import './../../scss/helpers/reset';
+@import './../../scss/helpers/shadows';
+@import './../../scss/helpers/typography';
 
 
 //
@@ -17,4 +20,14 @@
   border-bottom: .1em dotted;
   border-color: inherit;
   cursor: cursor(help);
+}
+
+// Override material styles
+.mat-tooltip-panel {
+  .mat-tooltip {
+    @include typography(caption);
+    @include elevation-element(snackbar);
+    background-color: color(pure);
+    color: color(pure, dark);
+  }
 }


### PR DESCRIPTION
ISSUES CLOSED: #1635

- Update tooltip styles to match our palette

<img width="204" alt="Screen Shot 2019-08-14 at 7 55 51 AM" src="https://user-images.githubusercontent.com/270193/63020150-4c285300-be6b-11e9-88fa-85d1d9c714d5.png">
