### PR TITLE
Feature(Autocomplete): show template value as chip

### DIFF
--- a/demo/app/components/autocomplete/autocomplete.component.html
+++ b/demo/app/components/autocomplete/autocomplete.component.html
@@ -7,7 +7,7 @@
     fxLayoutGap="1rem"
   >
     <h3 tsCardTitle tsVerticalSpacing="small--1">
-      Autocomplete
+      Autocomplete w/ Multiple
     </h3>
 
     <ts-autocomplete
@@ -24,7 +24,7 @@
     >
 
       <ts-option
-        [value]="state.name"
+        [value]="state"
         [option]="state"
         *ngFor="let state of filteredStates | async"
       >
@@ -35,6 +35,46 @@
 
     <div>
       FormControl value: {{ stateCtrl.value | json }}
+    </div>
+  </form>
+</ts-card>
+
+<ts-card tsVerticalSpacing fxFlex>
+  <form
+    novalidate
+    fxLayout="column"
+    fxLayout.gt-sm="row"
+    fxLayoutGap="1rem"
+  >
+    <h3 tsCardTitle tsVerticalSpacing="small--1">
+      Autocomplete w/ Single
+    </h3>
+
+    <ts-autocomplete
+      label="Autocomplete Example"
+      hint="Begin typing to select.."
+      [formControl]="singleStateCtrl"
+      [allowMultiple]="false"
+      [allowDuplicateSelections]="true"
+      [reopenAfterSelection]="false"
+      [showProgress]="fakeAsync"
+      (queryChange)="queryHasChanged($event)"
+      (duplicateSelection)="duplicate($event)"
+      tsVerticalSpacing
+    >
+
+      <ts-option
+        [value]="state"
+        [option]="state"
+        *ngFor="let state of filteredStates | async"
+      >
+        {{ state.name }}
+      </ts-option>
+
+    </ts-autocomplete>
+
+    <div>
+      FormControl value: {{ singleStateCtrl.value | json }}
     </div>
   </form>
 </ts-card>

--- a/demo/app/components/autocomplete/autocomplete.component.ts
+++ b/demo/app/components/autocomplete/autocomplete.component.ts
@@ -1,10 +1,8 @@
 import {
-  ChangeDetectorRef,
   Component,
   OnInit,
 } from '@angular/core';
 import {
-  FormBuilder,
   FormControl,
   Validators,
 } from '@angular/forms';
@@ -27,9 +25,6 @@ export interface State {
 })
 export class AutocompleteComponent implements OnInit {
 
-  stateCtrl = new FormControl(null, [Validators.required]);
-
-  filteredStates!: Observable<State[]>;
   states: State[] = [
     {
       name: 'Arkansas',
@@ -116,10 +111,12 @@ export class AutocompleteComponent implements OnInit {
       population: '24.112M',
     },
   ];
+  filteredStates!: Observable<State[]>;
   myQuery$: BehaviorSubject<string> = new BehaviorSubject('');
   fakeAsync = false;
 
-  comparator: ((f1: any, f2: any) => boolean) | null = this.compareByValue;
+  stateCtrl = new FormControl([this.states[4]], [Validators.required]);
+  singleStateCtrl = new FormControl(null, [Validators.required]);
 
   constructor() {
     this.filteredStates = this.myQuery$
@@ -135,32 +132,9 @@ export class AutocompleteComponent implements OnInit {
   ngOnInit() {
   }
 
-
   private filterStates(value: string): State[] {
     const filterValue = value.toLowerCase();
-    const r = this.states.filter(state => state.name.toLowerCase().indexOf(filterValue) === 0);
-    return r;
-  }
-
-  myFormatUIFn = (v: any): string => v.name;
-
-  compareByValue(f1: any, f2: any) {
-    return f1 && f2 && f1.text === f2.text;
-  }
-  compareByReference(f1: any, f2: any) {
-    return f1 === f2;
-  }
-
-  panelChange(e: boolean): void {
-    console.log(`DEMO: Panel ${e ? 'opened' : 'closed'}`);
-  }
-
-  isSelected(v) {
-    console.log('DEMO: optionSelected: ', v);
-  }
-
-  isDeselected(v) {
-    console.log('DEMO: optionDeselected: ', v);
+    return this.states.filter(state => state.name.toLowerCase().indexOf(filterValue) === 0);
   }
 
   log(v: any): void {

--- a/terminus-ui/autocomplete/src/autocomplete.component.html
+++ b/terminus-ui/autocomplete/src/autocomplete.component.html
@@ -17,13 +17,13 @@
     <ng-container *ngIf="allowMultiple">
       <mat-chip-list #chipList="matChipList">
         <mat-chip
-          *ngFor="let option of autocompleteFormControl.value; trackBy: trackByFn"
+          *ngFor="let option of autocompleteSelections; trackBy: trackByFn"
           class="qa-autocomplete-chip"
           [removable]="true"
           (removed)="autocompleteDeselectItem(option)"
         >
           <span class="ts-autocomplete-chip-value">
-            {{ option }}
+            {{ option.viewValue }}
           </span>
 
           <ts-icon matChipRemove>

--- a/terminus-ui/autocomplete/src/autocomplete.component.spec.ts
+++ b/terminus-ui/autocomplete/src/autocomplete.component.spec.ts
@@ -33,11 +33,7 @@ import {
 import { TsOptionModule } from '@terminus/ui/option';
 import { getValidationMessageElement } from '@terminus/ui/validation-messages/testing';
 
-import {
-  TsAutocompleteModule,
-  TsAutocompletePanelComponent,
-  TsAutocompletePanelSelectedEvent,
-} from './autocomplete.module';
+import { TsAutocompleteModule } from './autocomplete.module';
 
 function createComponent<T>(component: Type<T>): ComponentFixture<T> {
   const moduleImports = [
@@ -299,31 +295,20 @@ describe(`TsAutocompleteComponent`, function() {
     expect(fixture.componentInstance.change).toHaveBeenCalledTimes(1);
   });
 
-  test(`should throw an error if non string type passed in the component`, function() {
-    const fixture = createComponent<testComponents.PassingInObjectValue>(testComponents.PassingInObjectValue);
-    fixture.detectChanges();
-    expect(() => getAutocompleteInstance(fixture).autocompleteSelectItem(
-      new TsAutocompletePanelSelectedEvent(
-        {} as TsAutocompletePanelComponent,
-        getOptionInstance(fixture, 0, 1)
-      )
-    )).toThrowError(`The value passing into autocomplete has to be string type`);
-  });
-
-
   describe(`duplicate selections`, function() {
 
     // NOTE: Even though we are simulating a typed query, the list of states is not actually changing.
     test(`should not be allowed by default but should emit an event`, fakeAsync(function() {
       const fixture = createComponent<testComponents.SeededAutocomplete>(testComponents.SeededAutocomplete);
       fixture.detectChanges();
-      fixture.componentInstance.duplicate = jest.fn();
+      const component = fixture.componentInstance;
+      component.duplicate = jest.fn();
 
       let chips = getAllChipInstances(fixture);
       expect(chips.length).toEqual(1);
 
       const input = getAutocompleteInput(fixture);
-      typeInElement('fl', input);
+      typeInElement(fixture.componentInstance.states[3].name.substring(0, 3), input);
       tick(1000);
       fixture.detectChanges();
 
@@ -352,7 +337,8 @@ describe(`TsAutocompleteComponent`, function() {
         expect(chips.length).toEqual(1);
 
         const input = getAutocompleteInput(fixture);
-        typeInElement('fl', input);
+        const states = fixture.componentInstance.states;
+        typeInElement(states[4].name.substring(0, 2), input);
         tick(1000);
         fixture.detectChanges();
 
@@ -364,10 +350,14 @@ describe(`TsAutocompleteComponent`, function() {
 
         // Verify the selection DID work
         chips = getAllChipInstances(fixture);
-        expect(chips.length).toEqual(2);
-        expect(getAutocompleteInstance(fixture).autocompleteSelections).toEqual(['Florida', 'Florida']);
+        expect(chips.length).toEqual(1);
+        const autocomplete = getAutocompleteInstance(fixture);
+        const option = autocomplete.options.find(o => o.value === states[4]);
+        expect(autocomplete.autocompleteSelections).toEqual([option]);
+        expect(autocomplete.autocompleteFormControl.value.length).toEqual(2);
+        expect(autocomplete.autocompleteFormControl.value).toEqual([states[4], states[4]]);
 
-        expect.assertions(3);
+        expect.assertions(5);
       }));
 
     });
@@ -388,7 +378,8 @@ describe(`TsAutocompleteComponent`, function() {
         const instance = getAutocompleteInstance(fixture);
         const input = getAutocompleteInput(fixture);
 
-        typeInElement('fl', input);
+        const states = fixture.componentInstance.states;
+        typeInElement(states[4].name.substring(0, 2), input);
         tick(1000);
         fixture.detectChanges();
 
@@ -397,7 +388,7 @@ describe(`TsAutocompleteComponent`, function() {
         tick(1000);
         fixture.detectChanges();
 
-        expect(instance.autocompleteFormControl.value).toEqual(['Arkansas']);
+        expect(instance.autocompleteFormControl.value).toEqual([states[0]]);
       }));
 
     });
@@ -409,11 +400,13 @@ describe(`TsAutocompleteComponent`, function() {
       fixture.detectChanges();
 
       const input = getAutocompleteInput(fixture);
-      typeInElement('fl', input);
+      const states = fixture.componentInstance.states;
+      const name = states[3].name.substring(0, 2);
+      typeInElement(name, input);
       tick(1000);
       fixture.detectChanges();
 
-      expect(input.value).toEqual('fl');
+      expect(input.value).toEqual(name);
 
       const opt = getOptionElement(fixture, 0, 4);
       opt.click();
@@ -423,32 +416,41 @@ describe(`TsAutocompleteComponent`, function() {
       expect(input.value).toEqual('');
     }));
 
+    test(`should complain and moan if you set a form control that isn't an array`, () => {
+      const fixture = createComponent(testComponents.SeededNonArrayAutocomplete);
+      expect(() => fixture.detectChanges()).toThrowError('form control values must be an array of values');
+    });
 
     test(`should seed the autocomplete model(s) after timeout when using ngModel`, fakeAsync(function() {
       const fixture = createComponent(testComponents.SeededNgModelAutocomplete);
       fixture.detectChanges();
 
+      const states = fixture.componentInstance.states;
+
       tick(1000);
       fixture.detectChanges();
 
       const instance = getAutocompleteInstance(fixture);
-      expect(instance.autocompleteFormControl.value).toEqual(['Florida']);
-      expect(instance.autocompleteSelections).toEqual(['Florida']);
+      expect(instance.autocompleteFormControl.value).toEqual([states[4]]);
+      expect(instance.autocompleteSelections.length).toEqual(1);
+      expect(instance.autocompleteSelections[0]).toEqual(instance.options.find(opt => opt.value === states[4]));
     }));
 
     test(`should allow a value seeded by a FormControl`, fakeAsync(function() {
       const fixture = createComponent(testComponents.AutocompleteAllowMultipleNoReopen);
       fixture.detectChanges();
 
+      const states = fixture.componentInstance.states;
       const input = getAutocompleteInput(fixture);
-      typeInElement('al', input);
+      const name = states[4].name.substring(0, 2);
+      typeInElement(name, input);
       tick(1000);
       fixture.detectChanges();
       const opt = getOptionElement(fixture, 0, 2);
       opt.click();
       tick(1000);
       fixture.detectChanges();
-      expect(getAutocompleteInstance(fixture).autocompleteFormControl.value).toEqual(['Alaska']);
+      expect(getAutocompleteInstance(fixture).autocompleteFormControl.value).toEqual([states[2]]);
     }));
 
     test(`should close the panel if open when getting a blur event that isn't from a selection`, function() {

--- a/terminus-ui/autocomplete/testing/src/test-components.ts
+++ b/terminus-ui/autocomplete/testing/src/test-components.ts
@@ -8,7 +8,6 @@ import {
   FormControl,
   FormsModule,
   ReactiveFormsModule,
-  Validator,
   Validators,
 } from '@angular/forms';
 import { TsAutocompleteModule } from '@terminus/ui/autocomplete';
@@ -21,7 +20,7 @@ interface State {
   disabled?: boolean;
 }
 
-const STATES: State[] = [
+export const STATES: State[] = [
   {
     name: 'Arkansas',
     population: '2.978M',
@@ -167,7 +166,7 @@ const STATES_GROUPED: GroupedStates[] = [
     >
       <ts-option
         *ngFor="let option of states"
-        [value]="option.slug"
+        [value]="option"
         [option]="option"
         [isDisabled]="option?.disabled"
       >
@@ -198,7 +197,7 @@ export class Autocomplete {
     >
       <ts-option
         *ngFor="let option of states"
-        [value]="option.slug"
+        [value]="option"
         [option]="option"
       >
         {{ option.foo }}
@@ -222,7 +221,7 @@ export class AutocompleteRequired {
     >
       <ts-option
         *ngFor="let option of states"
-        [value]="option.name"
+        [value]="option"
         [option]="option"
         [isDisabled]="option?.disabled"
       >
@@ -234,8 +233,8 @@ export class AutocompleteRequired {
   `,
 })
 export class SeededAutocomplete {
-  public myCtrl = new FormControl(['Florida']);
   public states: State[] = STATES.slice();
+  public myCtrl = new FormControl([STATES[4]]);
   public allowMultiple = true;
   public allowDuplicates = false;
   public keepOpen = false;
@@ -266,8 +265,8 @@ export class SeededAutocomplete {
   `,
 })
 export class PassingInObjectValue {
-  public myCtrl = new FormControl([{name: 'Florida'}]);
   public states: State[] = STATES.slice();
+  public myCtrl = new FormControl([STATES[4]]);
   public allowMultiple = false;
   public allowDuplicates = false;
   public keepOpen = false;
@@ -283,7 +282,7 @@ export class PassingInObjectValue {
     >
       <ts-option
         *ngFor="let option of states"
-        [value]="option.name"
+        [value]="option"
         [option]="option"
         [isDisabled]="option?.disabled"
       >
@@ -295,8 +294,29 @@ export class PassingInObjectValue {
   `,
 })
 export class SeededNgModelAutocomplete {
-  public myModel = ['Florida'];
+  public myModel = [STATES[4]];
   public states: State[] = STATES.slice();
+}
+
+@Component({
+  template: `
+    <ts-autocomplete [formControl]="meow">
+      <ts-option
+        *ngFor="let option of states"
+        [value]="option"
+        [option]="option"
+        [isDisabled]="option?.disabled"
+      >
+        <span tsOptionDisplay>
+          {{ option.name }}
+        </span>
+      </ts-option>
+    </ts-autocomplete>
+  `,
+})
+export class SeededNonArrayAutocomplete {
+  public states: State[] = STATES.slice();
+  public meow = new FormControl(this.states[0]);
 }
 
 @Component({
@@ -308,7 +328,7 @@ export class SeededNgModelAutocomplete {
     >
       <ts-option
         *ngFor="let option of states"
-        [value]="option.name"
+        [value]="option"
         [option]="option"
         [isDisabled]="option?.disabled"
       >
@@ -333,7 +353,7 @@ export class AutocompleteAllowMultipleNoReopen {
       (opened)="wasOpened($event)"
     >
       <ts-option
-        [value]="option.name"
+        [value]="option"
         [option]="option"
         [isDisabled]="option?.disabled"
         *ngFor="let option of options"
@@ -356,7 +376,7 @@ export class Disabled {
       [allowMultiple]="true"
     >
       <ts-option
-        [value]="option.name"
+        [value]="option"
         [option]="option"
         [isDisabled]="option?.disabled"
         *ngFor="let option of options"
@@ -365,7 +385,7 @@ export class Disabled {
   `,
 })
 export class SelectOptionChange {
-  public myCtrl = new FormControl(['Texas', 'Florida']);
+  public myCtrl = new FormControl([STATES[3], STATES[4]]);
   public options: State[] = STATES.slice(0, 10);
 
   public updateOptions() {
@@ -439,7 +459,7 @@ export class CustomCompareFn {
   template: `
     <ts-autocomplete [formControl]="myCtrl">
       <ts-option
-        [value]="option.name"
+        [value]="option"
         [option]="option"
         [isDisabled]="option?.disabled"
         *ngFor="let option of items"
@@ -448,7 +468,7 @@ export class CustomCompareFn {
   `,
 })
 export class DeferOptionSelectionStream {
-  public myCtrl = new FormControl('Florida');
+  public myCtrl = new FormControl([STATES[4]]);
   public items: any[] = [];
 
   public updateOptions() {
@@ -463,7 +483,7 @@ export class DeferOptionSelectionStream {
       (queryChange)="change($event)"
     >
       <ts-option
-        [value]="option.name"
+        [value]="option"
         [option]="option"
         [isDisabled]="option?.disabled"
         *ngFor="let option of options"
@@ -472,7 +492,7 @@ export class DeferOptionSelectionStream {
   `,
 })
 export class Debounce {
-  public myCtrl = new FormControl(['Florida', 'Texas']);
+  public myCtrl = new FormControl([STATES[3], STATES[4]]);
   public options = STATES.slice();
   public change = v => { };
 }
@@ -485,7 +505,7 @@ export class Debounce {
       (queryChange)="change($event)"
     >
       <ts-option
-        [value]="option.name"
+        [value]="option"
         [option]="option"
         [isDisabled]="option?.disabled"
         *ngFor="let option of options"
@@ -494,7 +514,7 @@ export class Debounce {
   `,
 })
 export class CustomDebounce {
-  public myCtrl = new FormControl(['Florida', 'Texas']);
+  public myCtrl = new FormControl([STATES[3], STATES[4]]);
   public options = STATES.slice();
   public change = v => { };
 }
@@ -508,7 +528,7 @@ export class CustomDebounce {
       (queryChange)="change($event)"
     >
       <ts-option
-        [value]="option.name"
+        [value]="option"
         [option]="option"
         [isDisabled]="option?.disabled"
         *ngFor="let option of options"
@@ -517,7 +537,7 @@ export class CustomDebounce {
   `,
 })
 export class CustomCharacterCount {
-  public myCtrl = new FormControl(['Florida', 'Texas']);
+  public myCtrl = new FormControl([STATES[3], STATES[4]]);
   public options = STATES.slice();
   public customCount: number | undefined;
   public change = v => { };
@@ -531,7 +551,7 @@ export class CustomCharacterCount {
       [isRequired]="true"
     >
       <ts-option
-        [value]="option.name"
+        [value]="option"
         [option]="option"
         [isDisabled]="option?.disabled"
         *ngFor="let option of options"
@@ -552,7 +572,7 @@ export class HideRequired {
       [hint]="myHint"
     >
       <ts-option
-        [value]="option.name"
+        [value]="option"
         [option]="option"
         [isDisabled]="option?.disabled"
         *ngFor="let option of options"
@@ -573,7 +593,7 @@ export class Hint {
       [id]="myId"
     >
       <ts-option
-        [value]="option.name"
+        [value]="option"
         [option]="option"
         [isDisabled]="option?.disabled"
         *ngFor="let option of options"
@@ -594,7 +614,7 @@ export class Id {
       [label]="myLabel"
     >
       <ts-option
-        [value]="option.name"
+        [value]="option"
         [option]="option"
         [isDisabled]="option?.disabled"
         *ngFor="let option of options"
@@ -616,7 +636,7 @@ export class Label {
       [validateOnChange]="validateOnChange"
     >
       <ts-option
-        [value]="option.name"
+        [value]="option"
         [option]="option"
         [isDisabled]="option?.disabled"
         *ngFor="let option of options"
@@ -634,7 +654,7 @@ export class ValidateOnChange {
   template: `
     <ts-autocomplete [formControl]="myCtrl">
       <ts-option
-        [value]="option.value"
+        [value]="option"
         [option]="option"
         *ngFor="let option of items"
       >{{ option.viewValue }}</ts-option>
@@ -642,7 +662,6 @@ export class ValidateOnChange {
   `,
 })
 export class NullSelection {
-  public myCtrl = new FormControl('bar');
   public items = [
     {
       value: 'foo',
@@ -657,13 +676,14 @@ export class NullSelection {
       viewValue: 'bar view',
     },
   ];
+  public myCtrl = new FormControl(this.items[2]);
 }
 
 @Component({
   template: `
     <ts-autocomplete [formControl]="myCtrl">
       <ts-option
-        [value]="state.name"
+        [value]="state"
         *ngFor="let state of items"
       >
         <ng-template let-option>
@@ -685,7 +705,7 @@ export class OptionError {
   template: `
     <ts-autocomplete [formControl]="myCtrl">
       <ts-option
-        [value]="state.name"
+        [value]="state"
         [option]="state"
         [id]="state.name"
         *ngFor="let state of items"
@@ -712,7 +732,7 @@ export class OptionId {
       >
         <ts-option
           *ngFor="let option of group.children"
-          [value]="option.name"
+          [value]="option"
           [option]="option"
         >
           {{ option.name }}
@@ -736,7 +756,7 @@ export class OptgroupIDs {
       >
         <ts-option
           *ngFor="let option of group.children"
-          [value]="option.name"
+          [value]="option"
           [option]="option"
         >
           {{ option.name }}
@@ -746,7 +766,7 @@ export class OptgroupIDs {
   `,
 })
 export class OptgroupBadIDs {
-  public myCtrl = new FormControl('Florida');
+  public myCtrl = new FormControl([STATES[4]]);
   public groups = STATES_GROUPED.slice();
 }
 
@@ -782,6 +802,7 @@ export class OptgroupBadIDs {
     OptionError,
     OptionId,
     SeededAutocomplete,
+    SeededNonArrayAutocomplete,
     PassingInObjectValue,
     SeededNgModelAutocomplete,
     SelectOptionChange,


### PR DESCRIPTION
Shows the options template value as the chip instead of the `[value]` of the option. Also, allows the use of any type of object to be used as the `[value]` instead of just strings