### PR TITLE
feat(Copy): Support for minimal and icon modes

### DIFF
--- a/demo/app/components/copy/copy.component.html
+++ b/demo/app/components/copy/copy.component.html
@@ -7,10 +7,30 @@
     Enable quick copy:
     <input type="checkbox" [(ngModel)]="canCopy">
   </label>
+  <br>
+
+  <label>
+    Format:
+    <select [(ngModel)]="format">
+      <option selected="selected" value="standard">Standard</option>
+      <option value="minimal">Minimal</option>
+      <option value="icon">Icon</option>
+    </select>
+  </label>
+  <br>
+
+  <label>
+    Theme:
+    <select [(ngModel)]="theme">
+      <option value="{{ theme }}" *ngFor="let theme of themes">{{ theme | titlecase }}</option>
+    </select>
+  </label>
 </ts-card>
 
-<ts-card style="width: 22rem;">
+<ts-card style="max-width: 22rem;">
   <ts-copy
     [enableQuickCopy]="canCopy"
+    [format]="format"
+    [theme]="theme"
   >{{ fakeUrl }}</ts-copy>
 </ts-card>

--- a/demo/app/components/copy/copy.component.ts
+++ b/demo/app/components/copy/copy.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 
 
 @Component({
@@ -6,8 +7,10 @@ import { Component } from '@angular/core';
   templateUrl: './copy.component.html',
 })
 export class CopyComponent {
-  // tslint:disable: max-line-length
-  fakeUrl = 'https://github.com/foo/bar/baz/bing/bang/boom/foo/bar/baz/bing/bang/boom/foo/bar/baz/bing/bang/boom/foo/bar/baz/bing/bang/boom/foo/bar/baz/bing/bang/boom/foo/bar/baz/bing/bang/boom';
-  // tslint:enable: max-line-length
-  canCopy = false;
+  // eslint-disable-next-line max-len
+  public fakeUrl = 'https://github.com/foo/bar/baz/bing/bang/boom/foo/bar/baz/bing/bang/boom/foo/bar/baz/bing/bang/boom/foo/bar/baz/bing/bang/boom/foo/bar/baz/bing/bang/boom/foo/bar/baz/bing/bang/boom';
+  public canCopy = true;
+  public format = 'standard';
+  public theme: TsStyleThemeTypes = 'primary';
+  public themes: TsStyleThemeTypes[] = ['primary', 'accent', 'warn'];
 }

--- a/terminus-ui/autocomplete/src/autocomplete.component.md
+++ b/terminus-ui/autocomplete/src/autocomplete.component.md
@@ -10,6 +10,7 @@
 - [Keep Panel Open After Selection](#keep-panel-open-after-selection)
 - [Debouncing](#debouncing)
 - [Minimum Characters](#minimum-characters)
+- [Formatting options](#formatting-options)
 - [Test Helpers](#test-helpers)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->

--- a/terminus-ui/copy/src/copy.component.html
+++ b/terminus-ui/copy/src/copy.component.html
@@ -1,30 +1,32 @@
 <div
   class="c-copy qa-copy"
   fxLayout="row"
-  tabindex="1"
+  tabindex="0"
   (click)="selectText(content, hasSelected, disableInitialSelection)"
   (blur)="resetSelection()"
 >
-  <div
-    #content
-    class="c-copy__content qa-copy-content"
-    fxFlex="auto"
-    title="{{ textContent }}"
-  >
-    <ng-content></ng-content>
-  </div>
-
-  <ts-tooltip tooltipValue="Copy to clipboard" *ngIf="enableQuickCopy">
     <div
-      class="c-copy__icon qa-copy-icon"
-      (click)="copyToClipboard(textContent)"
-      mat-ripple
-      [matRippleColor]="rippleColor"
-      fxFlex="noshrink"
+      #content
+      class="c-copy__content qa-copy-content"
+      fxFlex="auto"
     >
-      <ts-icon matSuffix>
-        {{ icon }}
-      </ts-icon>
+      <ts-tooltip [tooltipValue]="textContent">
+        <ng-content></ng-content>
+      </ts-tooltip>
     </div>
-  </ts-tooltip>
+
+  <div class="c-copy__tooltip">
+    <ts-tooltip tooltipValue="Copy to clipboard" *ngIf="enableQuickCopy">
+      <div
+        class="c-copy__icon qa-copy-icon"
+        (click)="copyToClipboard(textContent)"
+        mat-ripple
+        [matRippleColor]="rippleColor"
+      >
+        <ts-icon matSuffix fxFlex>
+          {{ icon }}
+        </ts-icon>
+      </div>
+    </ts-tooltip>
+  </div>
 </div>

--- a/terminus-ui/copy/src/copy.component.scss
+++ b/terminus-ui/copy/src/copy.component.scss
@@ -2,11 +2,26 @@
 @import './../../scss/helpers/cursors';
 @import './../../scss/helpers/reset';
 @import './../../scss/helpers/typography';
+@import './../../scss/helpers/scrollbars';
 
 
 $margin__vertical: .2em;
 $margin__horizontal: $margin__vertical * 2;
 $radius: 3px;
+/*
+ * TODO: We are manually adjusting the ripple in multiple places now. We should abstract this out.
+ * https://github.com/GetTerminus/terminus-ui/issues/1653
+*/
+$ripple-opacity: .4;
+$black: color(pure, dark);
+$primary: darken(color(primary), 10%);
+$accent: darken(color(accent), 10%);
+$warn: darken(color(warn), 10%);
+$ripple-black: rgba($black, $ripple-opacity);
+$ripple-primary: rgba($primary, $ripple-opacity);
+$ripple-accent: rgba($accent, $ripple-opacity);
+$ripple-warn: rgba($warn, $ripple-opacity);
+$icon-padding: .25em .3em .25em .4em;
 
 //
 // @component
@@ -21,13 +36,59 @@ $radius: 3px;
   // Top level styles should be nested here
   .c-copy {
     @include typography;
+    color: color(utility, dark);
+    position: relative;
+  }
+
+  //
+  // Theme support
+  //
+  &--primary {
+    // These are the default styles
+
+    .mat-ripple-element {
+      // NOTE: Important needed to override inline Material styles
+      // stylelint-disable-next-line declaration-no-important
+      background-color: $ripple-primary !important;
+    }
+  }
+
+  &--accent {
+    .c-copy {
+      .c-copy__icon {
+        background-color: color(accent);
+      }
+    }
+
+    .mat-ripple-element {
+      // NOTE: Important needed to override inline Material styles
+      // stylelint-disable-next-line declaration-no-important
+      background-color: $ripple-accent !important;
+    }
+  }
+
+  &--warn {
+    .c-copy {
+      .c-copy__icon {
+        background-color: color(warn);
+      }
+    }
+
+    .mat-ripple-element {
+      // NOTE: Important needed to override inline Material styles
+      // stylelint-disable-next-line declaration-no-important
+      background-color: $ripple-warn !important;
+    }
+  }
+
+  //
+  // Format support
+  //
+  &--standard {
     background-color: color(utility, xlight);
     border: 1px solid color(utility, light);
     border-radius: $radius;
-    color: color(utility, dark);
-    padding: $margin__vertical $margin__horizontal;
     transition: border-color 200ms ease-in-out 50ms;
-    will-change: border-color;
 
     // Adding tabindex to the element allows focus, but we don't need the visual indicator
     &:focus {
@@ -37,22 +98,43 @@ $radius: 3px;
     }
   }
 
-  //
-  // Theme support
-  //
-  &[theme='primary'] {
-    // These are the default styles
-  }
+  &--minimal {
+    .c-copy__content {
+      line-height: 24px;
+      padding: $icon-padding;
+    }
 
-  &[theme='accent'] {
-    .c-copy__icon {
-      background-color: color(accent);
+    .c-copy {
+      .c-copy__tooltip {
+        $offset-for-border-minimal: 3px;
+        bottom: $offset-for-border-minimal;
+        top: $offset-for-border-minimal;
+      }
     }
   }
 
-  &[theme='warn'] {
-    .c-copy__icon {
-      background-color: color(warn);
+  &--icon {
+    display: inline-block;
+
+    .c-copy__content {
+      // Match the width of the icon
+      width: 35px;
+    }
+
+    .c-copy {
+      .c-copy__tooltip {
+        opacity: 1;
+        pointer-events: auto;
+      }
+    }
+  }
+
+  &:focus,
+  &:hover {
+    .c-copy__tooltip {
+      opacity: 1;
+      pointer-events: auto;
+      transition-delay: 70ms;
     }
   }
 }
@@ -60,35 +142,71 @@ $radius: 3px;
 .c-copy {
   // <div> Container for text content
   .c-copy__content {
-    // Match the line height of the copy icon
-    line-height: 24px;
-    overflow-x: scroll;
+    $icon-width: 35px;
+    @include hidden-scrollbars;
+    align-items: center;
+    justify-content: center;
+    line-height: 32px;
+    min-width: $icon-width;
+    overflow: hidden;
     white-space: nowrap;
+
+    .ts-tooltip {
+      display: block;
+      max-width: 100%;
+    }
+
+    .c-tooltip {
+      display: block;
+      overflow: hidden;
+      padding: $margin__vertical 0 $margin__vertical $margin__horizontal;
+      text-overflow: ellipsis;
+    }
+  }
+
+  .c-copy__tooltip {
+    $offset-for-border-standard: -1px;
+    bottom: $offset-for-border-standard;
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    right: $offset-for-border-standard;
+    top: $offset-for-border-standard;
+    transition: opacity 200ms ease-out;
+
+    .ts-tooltip {
+      height: 100%;
+    }
+
+    .ts-icon {
+      align-items: center;
+      display: flex;
+    }
   }
 
   // <div> The container for the icon
   .c-copy__icon {
     $vertical-margin: calc(#{-$margin__vertical} - 1px);
     $horizontal-margin: calc(#{-$margin__horizontal} - 1px);
-    $icon-margin: $vertical-margin $horizontal-margin $vertical-margin 0;
-    $icon-padding: .25em .2em .2em .5em;
 
     @include cursor(pointer);
     background-color: color(primary);
-    border-radius: 0 $radius $radius 0;
+    border-radius: $radius;
+    bottom: 0;
     color: color(pure);
-    margin: $icon-margin;
+    height: 100%;
     padding: $icon-padding;
-    // Set up for mat-ripple
-    position: relative;
     transition: background-color 200ms ease-in;
-    // Double the width of the 24px icon
-    width: 38px;
-    will-change: background-color;
   }
 
   // Adjust icon alignment
   .mat-icon {
     vertical-align: bottom;
+  }
+
+  .ts-copy--standard & {
+    .c-copy__icon {
+      border-radius: 0 $radius $radius 0;
+    }
   }
 }

--- a/terminus-ui/copy/src/copy.component.spec.ts
+++ b/terminus-ui/copy/src/copy.component.spec.ts
@@ -4,6 +4,7 @@ import {
 } from '@terminus/ngx-tools/browser/testing';
 import { ElementRefMock } from '@terminus/ngx-tools/testing';
 import { noop } from '@terminus/ngx-tools/utilities';
+import { TsUILibraryError } from '@terminus/ui/utilities';
 
 import { TsCopyComponent } from './copy.component';
 
@@ -20,36 +21,38 @@ describe(`TsCopyComponent`, function() {
   });
 
 
-  it(`should exist`, () => {
+  test(`should exist`, () => {
     expect(component).toBeTruthy();
   });
 
   describe(`disableInitialSelection`, () => {
+
     test(`should set and retrieve`, () => {
       component.disableInitialSelection = true;
       expect(component.disableInitialSelection).toEqual(true);
     });
+
   });
 
   describe(`enableQuickCopy`, () => {
+
     test(`should set and retrieve`, () => {
       component.enableQuickCopy = true;
       expect(component.enableQuickCopy).toEqual(true);
     });
+
   });
 
   describe(`get textContent()`, () => {
 
-    it(`should return the content if accessible`, () => {
+    test(`should return the content if accessible`, () => {
       component.content.nativeElement.innerText = 'foo';
-
       expect(component.textContent).toEqual('foo');
     });
 
 
-    it(`should return an empty string if the content is not accessible`, () => {
+    test(`should return an empty string if the content is not accessible`, () => {
       component.content.nativeElement.innerText = null;
-
       expect(component.textContent).toEqual('');
     });
 
@@ -58,17 +61,17 @@ describe(`TsCopyComponent`, function() {
 
   describe(`selectText()`, () => {
 
-    it(`should return false if disabled`, () => {
+    test(`should return false if disabled`, () => {
       expect(component.selectText(component.content, false, true)).toEqual(false);
     });
 
 
-    it(`should return if already selected`, () => {
+    test(`should return if already selected`, () => {
       expect(component.selectText(component.content, true, false)).toEqual(false);
     });
 
 
-    it(`should select the text within the passed in element`, () => {
+    test(`should select the text within the passed in element`, () => {
       component['window'].getSelection = jest.fn().mockReturnValue({
         removeAllRanges: noop,
         addRange: noop,
@@ -87,7 +90,7 @@ describe(`TsCopyComponent`, function() {
 
   describe(`resetSelection()`, () => {
 
-    it(`should set the flag to false`, () => {
+    test(`should set the flag to false`, () => {
       component.hasSelected = true;
 
       expect(component.hasSelected).toEqual(true);
@@ -117,7 +120,7 @@ describe(`TsCopyComponent`, function() {
     });
 
 
-    it(`should set the text to the clipboard`, () => {
+    test(`should set the text to the clipboard`, () => {
       component['document'].body.appendChild = jest.fn();
       component['document'].execCommand = jest.fn();
       component.copyToClipboard('foo');
@@ -129,15 +132,34 @@ describe(`TsCopyComponent`, function() {
     });
 
 
-    it(`should fall back to a prompt if execCommand fails`, () => {
+    test(`should fall back to a prompt if execCommand fails`, () => {
       component['document'].execCommand = () => {
         throw new Error('fake error');
       };
       component['window'].prompt = jest.fn();
-
       component.copyToClipboard('foo');
 
       expect(component['window'].prompt).toHaveBeenCalled();
+    });
+
+  });
+
+
+  describe(`format`, () => {
+
+    test(`should set a default format and allow custom`, () => {
+      expect(component.format).toEqual('standard');
+      component.format = 'minimal';
+      expect(component.format).toEqual('minimal');
+    });
+
+
+    test(`should throw an error if consumer ues icon mode without quick copy enabled`, () => {
+      component.enableQuickCopy = false;
+      const actual = () => {
+        component.format = 'icon';
+      };
+      expect(actual).toThrowError(Error);
     });
 
   });

--- a/terminus-ui/scss/helpers/_scrollbars.scss
+++ b/terminus-ui/scss/helpers/_scrollbars.scss
@@ -40,3 +40,32 @@ $defaultColor: #{color(pure)};
     background-color: $color;
   }
 }
+
+
+@mixin hidden-scrollbars() {
+  &::-webkit-scrollbar {
+    -webkit-appearance: none;
+
+    &:vertical {
+      width: 0;
+    }
+
+    &:horizontal {
+      height: 0;
+    }
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-color: transparent;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+    border-color: transparent;
+  }
+
+  &::-webkit-scrollbar-corner {
+    background-color: transparent;
+  }
+}

--- a/terminus-ui/tooltip/src/tooltip.component.scss
+++ b/terminus-ui/tooltip/src/tooltip.component.scss
@@ -29,5 +29,7 @@
     @include elevation-element(snackbar);
     background-color: color(pure);
     color: color(pure, dark);
+    overflow-wrap: break-word;
+    white-space: normal;
   }
 }

--- a/terminus-ui/utilities/src/error/ui-error.spec.ts
+++ b/terminus-ui/utilities/src/error/ui-error.spec.ts
@@ -1,0 +1,18 @@
+import {TsUILibraryError} from './ui-error';
+
+
+describe(`TsUILibraryError`, () => {
+  let error: TsUILibraryError;
+
+  beforeEach(() => {
+    error = new TsUILibraryError('Foo bar baz');
+  });
+
+  test(`should return our error`, () => {
+    expect(error.name).toEqual('TsUILibraryError');
+    expect(error.message).toEqual('Foo bar baz');
+    expect(error.stack).toEqual(expect.stringContaining('Error: Foo bar baz'));
+    expect(error.stack).toEqual(expect.stringContaining('at new TsUILibraryError'));
+  });
+
+});

--- a/terminus-ui/utilities/src/error/ui-error.ts
+++ b/terminus-ui/utilities/src/error/ui-error.ts
@@ -1,0 +1,11 @@
+/**
+ * A Terminus UI specific Error
+ */
+export class TsUILibraryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.message = message;
+    this.name = 'TsUILibraryError';
+    this.stack = (new Error(message)).stack;
+  }
+}

--- a/terminus-ui/utilities/src/utilities.module.ts
+++ b/terminus-ui/utilities/src/utilities.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { TsReactiveFormBaseComponent } from './reactive-form-base/reactive-form-base.component';
 
 export * from './cva-provider-factory/cva-provider-factory';
+export * from './error/ui-error';
 export * from './input-has-changed/input-has-changed';
 export * from './merge/merge';
 export * from './reactive-form-base/reactive-form-base.component';


### PR DESCRIPTION
1st commit:
- quick copy icon now appears on hover
- support minimal mode
- support icon mode
- remove scrollbar
- quick copy enabled by default
- updated demo for more control
- using TsTooltip in place of a browser tooltip for content

2nd commit:
- update ToC that was missed in previous PR

![example](https://user-images.githubusercontent.com/270193/63544547-732df700-c4f3-11e9-8756-8cc99ee78263.gif)
