### PR TITLE
Navigation items in drop down respect external links

### DIFF
--- a/terminus-ui/navigation/src/navigation.component.html
+++ b/terminus-ui/navigation/src/navigation.component.html
@@ -108,7 +108,18 @@
         class="c-navigation__hidden-item qa-navigation-secondary-item"
         [ngClass]="{'c-navigation__hidden-item--admin': item.alwaysHidden}"
         routerLink="{{ item.destination }}"
-        *ngIf="item.destination"
+        *ngIf="item.destination && !item.isExternal"
+        mat-menu-item
+        #hiddenLinkElement
+      >
+        {{ item.name }}
+      </a>
+
+      <a
+        class="c-navigation__hidden-item qa-navigation-secondary-item"
+        [ngClass]="{'c-navigation__hidden-item--admin': item.alwaysHidden}"
+        href="{{ item.destination }}"
+        *ngIf="item.destination && item.isExternal"
         mat-menu-item
         #hiddenLinkElement
       >


### PR DESCRIPTION
With this change, navigation items displayed by a `ts-navigation` component will properly handle external links by using hrefs for them rather than router links.