### PR TITLE
1688 consumer chip control

### DIFF
--- a/demo/app/components/chip/chip.component.html
+++ b/demo/app/components/chip/chip.component.html
@@ -1,14 +1,39 @@
-<ts-card>
-  <ts-chip-collection 
-    [chipsInput]="options" 
-    [allowMultipleSelections]="true"
-    [isSelectable]="true"
-    [isDisabled]="false"
-    orientation="vertical"
-    (removed)="removingOption($event)"
-    (collectionChange)="change($event)"
-    #tsChipCollection
-  >
-  </ts-chip-collection>
+<ts-card tsVerticalSpacing>
+  <div tsVerticalSpacing>
+    <label>
+      Orientation:
+      <select [(ngModel)]="orientation">
+        <option selected="selected" value="horizontal">Horizontal</option>
+        <option value="vertical">Vertical</option>
+      </select>
+    </label>
+    <br>
+    <label>
+      Allow removal:
+      <input type="checkbox" [(ngModel)]="removable">
+    </label>
+    <br>
+    <label>
+      Allow selection:
+      <input type="checkbox" [(ngModel)]="selectable">
+    </label>
+  </div>
 
+
+  <ts-chip-collection
+    [allowMultipleSelections]="true"
+    [isSelectable]="selectable"
+    [orientation]="orientation"
+    (collectionChange)="change($event)"
+  >
+    <ts-chip
+      *ngFor="let chip of options;"
+      [isRemovable]="!readonly && removable"
+      [isDisabled]="disabled"
+      [isSelectable]="selectable"
+      [value]="chip"
+      (remove)="removeChip($event)"
+    >{{ chip }}</ts-chip>
+  </ts-chip-collection>
 </ts-card>
+

--- a/demo/app/components/chip/chip.component.ts
+++ b/demo/app/components/chip/chip.component.ts
@@ -1,36 +1,38 @@
-import { Component, OnInit, ViewChild, AfterViewInit, QueryList, ElementRef, TemplateRef } from '@angular/core';
+import { Component } from '@angular/core';
 import {
-  TsChipCollectionComponent,
-  TsChipComponent,
- } from '@terminus/ui/chip';
+  TsChipCollectionChange,
+  TsChipCollectionOrientation,
+  TsChipEvent,
+} from '@terminus/ui/chip';
+
 
 @Component({
   selector: 'demo-chip',
   templateUrl: './chip.component.html',
 })
-export class ChipComponent implements OnInit {
+export class ChipComponent {
+  public orientation: TsChipCollectionOrientation = 'horizontal';
+  public removable = true;
+  public disabled = false;
+  public readonly = false;
+  public selectable = true;
+  public optionsOriginal = ['banana', 'apple', 'orange', 'pear'];
+  public options = this.optionsOriginal.slice();
 
-  options = ['banana', 'apple', 'orange', 'pear'];
-
-  constructor() { }
-
-  ngOnInit() {
-  }
-
-  removingOption(value: string) {
-    const ctrlValue = this.options;
-    const index = ctrlValue.indexOf(value);
-    const selections = ctrlValue.slice();
-    // If not found
+  public removeChip(event: TsChipEvent): void {
+    console.log('DEMO: remove chip: ', event);
+    if (!event.chip.value) {
+      return;
+    }
+    const index = this.options.indexOf(event.chip.value);
     if (index < 0) {
       return;
     }
-    selections.splice(index, 1);
-    this.options = selections;
+    this.options.splice(index, 1);
   }
 
-  change(value: string | string[]) {
-    console.log('DEMO: collection change triggered value: ', value);
+  public change(value: TsChipCollectionChange) {
+    console.log('DEMO: collection change triggered: value: ', value);
   }
 
 }

--- a/terminus-ui/autocomplete/src/autocomplete.component.html
+++ b/terminus-ui/autocomplete/src/autocomplete.component.html
@@ -16,14 +16,20 @@
 
     <ng-container *ngIf="allowMultiple">
       <ts-chip-collection
-        [chipsInput]="autocompleteFormControl.value"
         [allowMultipleSelections]="true"
-        [displayFormatter]="displayFormatter"
         [isDisabled]="false"
         [isReadonly]="false"
-        (removed)="autocompleteDeselectItem($event)"
         (tabUpdateFocus)="focusInput()"
-        #chipCollection="tsChipCollection">
+        #chipCollection="tsChipCollection"
+      >
+        <ts-chip
+          *ngFor="let chip of autocompleteFormControl.value; trackBy: trackByFn"
+          [isRemovable]="true"
+          [isDisabled]="isDisabled"
+          [value]="chip"
+          (remove)="autocompleteDeselectItem($event.chip)"
+        >{{ displayFormatter(chip) }}</ts-chip>
+
         <input
           class="ts-autocomplete__input qa-select-autocomplete-input"
           [tsAutocompleteTrigger]="auto"

--- a/terminus-ui/autocomplete/src/autocomplete.component.spec.ts
+++ b/terminus-ui/autocomplete/src/autocomplete.component.spec.ts
@@ -143,7 +143,7 @@ describe(`TsAutocompleteComponent`, function() {
       expect(chips.length).toEqual(1);
 
       const chip = getChipElement(fixture);
-      const chipRemovalButton = chip.querySelector('.ts-chip-remove');
+      const chipRemovalButton = chip.querySelector('.c-chip__remove');
       const instance = getAutocompleteInstance(fixture);
 
       // Open the panel so that overlayRef is created
@@ -504,7 +504,7 @@ describe(`TsAutocompleteComponent`, function() {
       const instance = getAutocompleteInstance(fixture);
       const triggerInstance = instance.autocompleteTrigger;
       const chip = getChipElement(fixture);
-      const chipRemovalButton = chip.querySelector('.ts-chip-remove');
+      const chipRemovalButton = chip.querySelector('.c-chip__remove');
 
       triggerInstance.openPanel();
       fixture.detectChanges();

--- a/terminus-ui/autocomplete/src/autocomplete.component.ts
+++ b/terminus-ui/autocomplete/src/autocomplete.component.ts
@@ -26,17 +26,21 @@ import {
 import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import { TsDocumentService } from '@terminus/ngx-tools/browser';
 import { coerceNumberProperty } from '@terminus/ngx-tools/coercion';
+import { isArray } from '@terminus/ngx-tools/type-guards';
 import {
   hasRequiredControl,
   untilComponentDestroyed,
 } from '@terminus/ngx-tools/utilities';
+import {
+  TsChipCollectionComponent,
+  TsChipComponent,
+} from '@terminus/ui/chip';
 import { TsFormFieldControl } from '@terminus/ui/form-field';
 import {
   TS_OPTION_PARENT_COMPONENT,
   TsOptgroupComponent,
   TsOptionComponent,
 } from '@terminus/ui/option';
-import { TS_SPACING } from '@terminus/ui/spacing';
 import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 import {
   BehaviorSubject,
@@ -50,8 +54,6 @@ import {
   switchMap,
 } from 'rxjs/operators';
 
-import { isArray } from '@terminus/ngx-tools';
-import { TsChipCollectionComponent } from '@terminus/ui/chip';
 import {
   TsAutocompletePanelComponent,
   TsAutocompletePanelSelectedEvent,
@@ -164,7 +166,7 @@ export class TsAutocompleteComponent implements OnInit,
   private document: Document;
 
   /**
-   * Subject used to alert the parent {@link FormFieldComponent} when the label gap should be recalculated
+   * Subject used to alert the parent {@link TsFormFieldComponent} when the label gap should be recalculated
    *
    * Implemented as part of TsFormFieldControl.
    */
@@ -176,31 +178,23 @@ export class TsAutocompleteComponent implements OnInit,
   private keyManager!: ActiveDescendantKeyManager<TsOptionComponent>;
 
   /**
-   * Define the flex gap spacing
-   */
-  public flexGap = TS_SPACING.small[0];
-
-  /**
    * The IDs of child options to be passed to the aria-owns attribute.
    */
   public optionIds = '';
-
-  /**
-   * Emits when the panel element is finished transforming in.
-   */
-  public panelDoneAnimatingStream = new Subject<string>();
 
   /**
    * Whether or not the overlay panel is open
    */
   public panelOpen = false;
 
-  // Since the FormFieldComponent is inside this template, we cannot use a provider to pass this component instance to the form field.
-  // Instead, we pass it manually through the template with this reference.
+  /**
+   * Since the {@link TsFormFieldComponent} is inside this template, we cannot use a provider to pass this component instance to the form
+   * field. Instead, we pass it manually through the template with this reference.
+   */
   public selfReference = this;
 
   /*
-   * Implemented as part of TsFormFieldControl.
+   * Implemented as part of {@link TsFormFieldControl}
    */
   public readonly stateChanges: Subject<void> = new Subject<void>();
 
@@ -847,6 +841,7 @@ export class TsAutocompleteComponent implements OnInit,
     this.selectionChange.emit(new TsAutocompleteChange(this, this.autocompleteFormControl.value));
   }
 
+
   /**
    * Chip component emit a focusInput event, autocomplete puts focus on input field.
    */
@@ -854,15 +849,15 @@ export class TsAutocompleteComponent implements OnInit,
     this.focus();
   }
 
+
   /**
    * Deselect an item
    *
-   * @param value - The value of the item to remove
+   * @param option - The value of the item to remove
    */
-  public autocompleteDeselectItem(option: unknown): void {
-    // Find the key of the selection in the selectedOptions array
-    const options = (this.autocompleteFormControl.value || [])
-      .filter(opt => !this.valueComparator(opt, option));
+  public autocompleteDeselectItem(option: TsChipComponent): void {
+    // Remove the selection from the array of selections
+    const options = (this.autocompleteFormControl.value || []).filter(opt => !this.valueComparator(opt, option.value));
 
     // Update the form control
     this.autocompleteFormControl.setValue(options);
@@ -887,6 +882,7 @@ export class TsAutocompleteComponent implements OnInit,
     this.selectionChange.emit(new TsAutocompleteChange(this, options));
   }
 
+
   /**
    * Function for tracking for-loops changes
    *
@@ -896,4 +892,5 @@ export class TsAutocompleteComponent implements OnInit,
   public trackByFn(index): number {
     return index;
   }
+
 }

--- a/terminus-ui/autocomplete/testing/src/test-helpers.ts
+++ b/terminus-ui/autocomplete/testing/src/test-helpers.ts
@@ -2,11 +2,11 @@ import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { TsAutocompleteComponent } from '@terminus/ui/autocomplete';
+import { TsChipComponent } from '@terminus/ui/chip';
 import {
   TsOptgroupComponent,
   TsOptionComponent,
 } from '@terminus/ui/option';
-import { TsChipComponent } from '@terminus/ui/chip';
 
 /**
  * Get the DebugElement for a TsAutocompleteComponent
@@ -132,7 +132,7 @@ export function getChipInstance(fixture: ComponentFixture<any>, selectIndex = 0,
  */
 export function getChipElement(fixture: ComponentFixture<any>, selectIndex = 0, chipIndex = 0): HTMLElement {
   const chip = getChipInstance(fixture, selectIndex, chipIndex);
-  return chip._elementRef.nativeElement;
+  return chip.elementRef.nativeElement;
 }
 
 /**

--- a/terminus-ui/chip/src/chip-collection.component.html
+++ b/terminus-ui/chip/src/chip-collection.component.html
@@ -1,17 +1,3 @@
-<div 
-  class="ts-chip-collection-wrapper"
-  fxLyaout="row"
-  [ngClass]="(orientation==='vertical') ? 'ts-chip-collection--stacked':''"
->
-  <ts-chip
-    *ngFor="let chip of chipsInput; trackBy: trackByFn"
-    [isRemovable]="!isReadonly"
-    [isDisabled]="isDisabled"
-    [isSelectable]="isSelectable"
-    [value]="displayFormatter(chip)"
-    (removed)="remove(chip)"
-    (clicked)="clickSelect($event)"
-  >
-  </ts-chip>
+<div class="ts-chip-collection-wrapper">
   <ng-content></ng-content>
 </div>

--- a/terminus-ui/chip/src/chip-collection.component.md
+++ b/terminus-ui/chip/src/chip-collection.component.md
@@ -1,0 +1,191 @@
+<h1>Chip Collection</h1>
+
+A collection of individual, keyboard accessible, chips. Useful for displaying choice collections.
+
+NOTE: This component does not support a `FormControl`; it is a simple collection display.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [Basic Usage](#basic-usage)
+  - [Using the DOM as value](#using-the-dom-as-value)
+  - [Theme](#theme)
+  - [Orientation](#orientation)
+  - [Removable](#removable)
+  - [Selectable](#selectable)
+- [Events](#events)
+  - [Collection events](#collection-events)
+  - [Chip events](#chip-events)
+- [Test Helpers](#test-helpers)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
+## Basic Usage
+
+Loop through a collection to generate chips:
+
+```html
+<ts-chip-collection>
+  <ts-chip
+    *ngFor="let chip of chips;"
+    [value]="chip"
+  >{{ chip }}</ts-chip>
+</ts-chip-collection>
+```
+
+### Using the DOM as value
+
+For string based collections, the value input can be disregarded as the value will be pulled directly from the DOM.
+
+```html
+<ts-chip-collection>
+  <ts-chip *ngFor="let chip of ['foo', 'bar', 'baz']">
+    {{ chip }}
+  </ts-chip>
+</ts-chip-collection>
+```
+
+### Theme
+
+A theme can be set a the chip level:
+
+```html
+<ts-chip-collection>
+  <ts-chip
+    *ngFor="let chip of chips"
+    theme="accent"
+  >{{ chip }}</ts-chip>
+</ts-chip-collection>
+```
+
+### Orientation
+
+A collection can be displayed in a row (`horizontal`) or a column (`vertical`) via the `orientation` input. By default it displays as a row.
+
+```html
+<ts-chip-collection>
+  <ts-chip
+    *ngFor="let chip of chips"
+    orientation="vertical"
+  >{{ chip }}</ts-chip>
+</ts-chip-collection>
+```
+
+### Removable
+
+By default, chips are 'removable'. Since this component does not directly manage the data, when a user tries to remove a chip, an event is
+emitted. The consumer is responsible to using that event to remove the item from the collection. (See [Events](#events))
+
+```html
+<ts-chip-collection>
+  <ts-chip
+    *ngFor="let chip of myChips"
+    (remove)="removeChip($event)"
+  >{{ chip }}</ts-chip>
+</ts-chip-collection>
+```
+
+```typescript
+myChips = ['apple', 'banana'];
+
+removeChip(event: TsChipEvent): void {
+  if (!event.chip.value) {
+    return;
+  }
+  const index = this.myChips.indexOf(event.chip.value);
+  if (index < 0) {
+    return;
+  }
+  this.myChips.splice(index, 1);
+}
+```
+
+The ability to remove a chip can be disabled per chip or as a collection:
+
+```html
+<!-- Disable on the chip directly -->
+<ts-chip-collection>
+  <ts-chip
+    *ngFor="let chip of chips"
+    [isRemovable]="chip.removable"
+  >{{ chip }}</ts-chip>
+</ts-chip-collection>
+
+<!-- Disable for the entire collection -->
+<ts-chip-collection [isRemovable]="false">
+  <ts-chip *ngFor="let chip of chips">
+    {{ chip }}
+  </ts-chip>
+</ts-chip-collection>
+```
+
+### Selectable
+
+Chips can be selected and visually show that selection. The style of the selected state reflects the current [theme](#theme).
+
+The ability to select chips can be disabled at the collection or chip level.
+
+```html
+<!-- Disable on the chip directly -->
+<ts-chip-collection>
+  <ts-chip
+    *ngFor="let chip of chips"
+    [isSelectable]="chip.canSelect"
+  >{{ chip }}</ts-chip>
+</ts-chip-collection>
+
+<!-- Disable for the entire collection -->
+<ts-chip-collection [isSelectable]="false">
+  <ts-chip *ngFor="let chip of chips">
+    {{ chip }}
+  </ts-chip>
+</ts-chip-collection>
+```
+
+## Events
+
+Since this component does not directly manage the data, we rely on emitting events to alert the consumer as to what needs to happen.
+
+### Collection events
+
+| Event              | Description                                    | Payload                  |
+|:-------------------|:-----------------------------------------------|:-------------------------|
+| `collectionChange` | Fired when any chips are added or removed      | `TsChipCollectionChange` |
+| `removed`          | Fired when a chip is removed                   | `TsChipEvent`            |
+| `tabUpdateFocus`   | Fired when the user tabs out of the collection | `void`                   |
+
+### Chip events
+
+| Event             | Description                                 | Payload                 |
+|:------------------|:--------------------------------------------|:------------------------|
+| `clicked`         | Fired when the chip is clicked              | `TsChipClickEvent`      |
+| `destroyed`       | Fired when the chip is destroyed            | `TsChipEvent`           |
+| `blurred`         | Fired when focus leaves the chip            | `void`                  |
+| `remove`          | Fired when the chip should be removed       | `TsChipEvent`           |
+| `selectionChange` | Fired when the chip selection state changes | `TsChipSelectionChange` |
+
+
+## Test Helpers
+
+Some helpers are exposed to assist with testing. These are imported from `@terminus/ui/chip/testing`;
+
+[[source]][test-helpers-src]
+
+| Function                                  |
+|-------------------------------------------|
+| `getAllChipDebugElements`                 |
+| `getAllChipCollectionDebugElements`       |
+| `getAllChipInstances`                     |
+| `getChipInstance`                         |
+| `getAllChipCollectionInstances`           |
+| `getChipCollectionInstanceInAutocomplete` |
+| `getChipDebugElement`                     |
+| `getChipCollectionDebugElement`           |
+| `getChipCollectionInstance`               |
+| `getChipElement`                          |
+| `getChipCollectionElement`                |
+
+
+[test-helpers-src]: https://github.com/GetTerminus/terminus-ui/blob/release/terminus-ui/chip/testing/src/test-helpers.ts

--- a/terminus-ui/chip/src/chip-collection.component.scss
+++ b/terminus-ui/chip/src/chip-collection.component.scss
@@ -1,0 +1,22 @@
+@import './../../scss/helpers/spacing';
+
+
+.ts-chip-collection {
+  display: block;
+
+  &--vertical {
+    display: inline-block;
+
+    .ts-chip-collection-wrapper {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+  }
+}
+
+.ts-chip-collection-wrapper {
+  $negative-spacing: spacing(small, 2);
+  align-items: center;
+  display: flex;
+  margin: $negative-spacing;
+}

--- a/terminus-ui/chip/src/chip.component.html
+++ b/terminus-ui/chip/src/chip.component.html
@@ -7,11 +7,12 @@
   [attr.id]="id"
   (click)="click($event)"
 >
-  <span class="ts-chip-value">
-    {{ value }}
+  <span #content>
+     <ng-content></ng-content>
   </span>
-  <ts-icon tsChipRemove *ngIf="isRemovable">
+
+  <ts-icon class="c-chip__remove" (click)="removeChip($event)">
     cancel
   </ts-icon>
-  
+
 </div>

--- a/terminus-ui/chip/src/chip.component.scss
+++ b/terminus-ui/chip/src/chip.component.scss
@@ -4,36 +4,33 @@
 @import './../../scss/helpers/spacing';
 @import './../../scss/helpers/typography';
 
-$ts-chips-chip-margin: 4px;
 $ts-chip-height: 35px;
 $ts-chip-vertical-padding: 3px;
 $ts-chip-horizontal-padding: 8px;
 $ts-chip-remove-width: 18px;
 $ts-chip-remove-height: 18px;
-$ts-chip-background-color: color(utility, light);
 $ts-chip-focus-background-color: color(utility);
-$ts-chip-color: rgba(0, 0, 0, .87);
+$ts-chip-color: color(pure, dark);
 $c-chip-top-margin: 7px;
 $c-chip-right-margin: 4px;
 $c-chip-padding: 25px;
 
 .ts-chip {
-  @include reset;
   @include typography;
   align-items: center;
-  background-color: $ts-chip-background-color;
+  background-color: color(utility, light);
   border-radius: 16px;
   box-sizing: border-box;
   color: $ts-chip-color;
   display: inline-flex;
   height: $ts-chip-height;
-  margin: $ts-chips-chip-margin;
+  margin: spacing(small, 2);
   overflow: hidden;
   padding: $ts-chip-vertical-padding $ts-chip-horizontal-padding;
   position: relative;
   -webkit-tap-highlight-color: transparent;
   transform: translateZ(0);
-  transition: box-shadow 280ms cubic-bezier(.4, 0, .2, 1);
+  transition: background-color 200ms ease-out;
 
   &:focus,
   &:hover {
@@ -41,16 +38,32 @@ $c-chip-padding: 25px;
     transition: opacity 200ms cubic-bezier(.35, 0, .25, 1);
   }
 
-  &.ts-chip-selected {
-    background-color: color(primary);
+  &.ts-chip--selected {
     color: color(pure);
+    $themes: primary accent warn;
+
+    @each $theme in $themes {
+      &.ts-chip--#{$theme} {
+        background-color: color(#{$theme});
+      }
+    }
+
+    .c-chip__remove {
+      color: color(pure);
+    }
   }
 
-  .ts-chip-remove {
+  .c-chip__remove {
     color: $ts-chip-color;
     cursor: cursor(pointer);
+    display: none;
     height: $ts-chip-remove-height;
     opacity: .4;
+    position: absolute;
+    right: 5%;
+    top: 42%;
+    transform: translate(-50%, -50%);
+    transition: color 200ms ease-out;
     width: $ts-chip-remove-width;
 
     &:hover {
@@ -59,27 +72,16 @@ $c-chip-padding: 25px;
   }
 }
 
-.ts-icon {
-  position: absolute;
-  right: 5%;
-  top: 42%;
-  transform: translate(-50%, -50%);
-}
 
-.ts-chip-collection-wrapper {
-  align-items: center;
-  display: flex;
-  margin: -$ts-chips-chip-margin;
-  &.ts-chip-collection--stacked {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-}
 
 .c-chip {
   margin: $c-chip-top-margin $c-chip-right-margin;
 
   &--removable {
     padding-right: $c-chip-padding;
+
+    .c-chip__remove {
+      display: block;
+    }
   }
 }

--- a/terminus-ui/chip/src/chip.module.ts
+++ b/terminus-ui/chip/src/chip.module.ts
@@ -4,11 +4,7 @@ import { MatRippleModule } from '@angular/material/core';
 import { TsIconModule } from '@terminus/ui/icon';
 
 import { TsChipCollectionComponent } from './chip-collection.component';
-import {
-  TsChipComponent,
-  TsChipRemoveDirective,
-  TsChipTrailingIconDirective,
-} from './chip.component';
+import { TsChipComponent } from './chip.component';
 
 export * from './chip.component';
 export * from './chip-collection.component';
@@ -23,14 +19,10 @@ export * from './chip-collection.component';
   declarations: [
     TsChipComponent,
     TsChipCollectionComponent,
-    TsChipRemoveDirective,
-    TsChipTrailingIconDirective,
   ],
   exports: [
     TsChipComponent,
     TsChipCollectionComponent,
-    TsChipRemoveDirective,
-    TsChipTrailingIconDirective,
   ],
 })
 export class TsChipModule { }

--- a/terminus-ui/chip/testing/src/test-components.ts
+++ b/terminus-ui/chip/testing/src/test-components.ts
@@ -1,27 +1,29 @@
+import { CommonModule } from '@angular/common';
 import {
   Component,
   NgModule,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import {
+  FormControl,
   FormsModule,
   ReactiveFormsModule,
-  FormControl,
 } from '@angular/forms';
+import { TsAutocompleteModule } from '@terminus/ui/autocomplete';
 import {
-  TsChipModule,
+  TsChipComponent,
   TsChipEvent,
+  TsChipModule,
   TsChipSelectionChange,
 } from '@terminus/ui/chip';
-import { TsAutocompleteModule } from '@terminus/ui/autocomplete';
 import { TsOptionModule } from '@terminus/ui/option';
 
 @Component({
   template: `
-    <ts-chip-collection
-      [chipsInput]="options"
-      #tsChipCollection
-    >
+    <ts-chip-collection>
+      <ts-chip
+        *ngFor="let chip of options"
+        [value]="chip"
+      >{{ chip }}</ts-chip>
     </ts-chip-collection>
   `,
 })
@@ -29,13 +31,14 @@ export class RegularChip {
   public options = ['banana', 'apple', 'orange'];
 }
 
+// FIXME: Combine `OneChip` and `SingleChip`?
 @Component({
   template: `
-    <ts-chip-collection
-      [chipsInput]="options"
-      (removed)="removed()"
-      #tsChipCollection
-    >
+    <ts-chip-collection (removed)="removed()">
+      <ts-chip
+        *ngFor="let chip of options"
+        [value]="chip"
+      >{{ chip }}</ts-chip>
     </ts-chip-collection>
   `,
 })
@@ -51,39 +54,34 @@ export class OneChip {
     <ts-chip
       [value]="option"
       [selected]="selected"
-      (removed)="removed()"
+      (remove)="removed()"
       (destroyed)="chipDestroy($event)"
       (selectionChange)="selectionChange($event)"
-    >
-    </ts-chip>
+    ></ts-chip>
   `,
 })
 export class SingleChip {
   public option = 'banana';
   public selected = false;
-  removed: (event?: TsChipEvent) => void = () => { }
-  chipDestroy: (event?: TsChipEvent) => void = () => { };
-  selectionChange: (event?: TsChipSelectionChange) => void = () => { };
+  public removed: (event?: TsChipEvent) => void = () => { };
+  public chipDestroy: (event?: TsChipEvent) => void = () => { };
+  public selectionChange: (event?: TsChipSelectionChange) => void = () => { };
 }
 
 @Component({
   template: `
-    <ts-chip-collection
-      #tsChipCollection
-    >
-    </ts-chip-collection>
+    <ts-chip-collection></ts-chip-collection>
   `,
 })
-export class NoChip {
-}
+export class NoChip { }
 
 @Component({
   template: `
-    <ts-chip-collection
-      [chipsInput]="options"
-      [isDisabled]="isDisabled"
-      #tsChipCollection
-    >
+    <ts-chip-collection [isDisabled]="isDisabled" id="foooooooooooooo">
+      <ts-chip
+        *ngFor="let chip of options"
+        [value]="chip"
+      >{{ chip }}</ts-chip>
     </ts-chip-collection>
   `,
 })
@@ -94,11 +92,11 @@ export class DisabledChip {
 
 @Component({
   template: `
-    <ts-chip-collection
-      [chipsInput]="options"
-      [isReadonly]="isReadonly"
-      #tsChipCollection
-    >
+    <ts-chip-collection [isReadonly]="isReadonly">
+      <ts-chip
+        *ngFor="let chip of options"
+        [value]="chip"
+      >{{ chip }}</ts-chip>
     </ts-chip-collection>
   `,
 })
@@ -109,119 +107,136 @@ export class ReadonlyChip {
 
 @Component({
   template: `
-    <form
-    novalidate
-    fxLayout="column"
-    fxLayout.gt-sm="row"
-    fxLayoutGap="1rem"
-    >
     <ts-autocomplete
       [formControl]="myCtrl"
       [allowMultiple]="allowMultiple"
     >
       <ts-option
-        *ngFor="let option of items"
+        *ngFor="let option of options"
         [value]="option"
         [option]="option"
       >
         {{ option }}
       </ts-option>
     </ts-autocomplete>
-  </form>
-  `
-  ,
+  `,
 })
 export class Autocomplete {
   public allowMultiple = true;
   public myCtrl = new FormControl(['apple', 'orange']);
-  public items = ['apple', 'banana', 'orange'];
+  public options = ['apple', 'banana', 'orange'];
 }
 
 @Component({
   template: `
-    <ts-chip-collection
-      [isSelectable]="selectable"
-      [chipsInput]="options"
-    >
+    <ts-chip-collection [isSelectable]="selectable">
+      <ts-chip
+        *ngFor="let chip of options"
+        [value]="chip"
+      >{{ chip }}</ts-chip>
     </ts-chip-collection>`,
 })
 export class StandardChipCollection {
-  name: string = 'Test';
-  selectable: boolean = true;
-  chipSelect: (index?: number) => void = () => { };
-  chipDeselect: (index?: number) => void = () => { };
-  options = [0, 1, 2, 3, 4];
+  public options = [0, 1, 2, 3, 4];
+  public selectable = true;
 }
 
 @Component({
   template: `
     <ts-chip-collection
-      [chipsInput]="options"
       [tabIndex]="index"
       [isDisabled]="isDisabled"
     >
+      <ts-chip
+        *ngFor="let chip of options"
+        [value]="chip"
+      >{{ chip }}</ts-chip>
     </ts-chip-collection>
   `,
 })
 export class Tabindex {
-  index = 4;
-  options = [1, 2, 3];
-  isDisabled = false;
+  public options = [1, 2, 3];
+  public index = 4;
+  public isDisabled = false;
 }
 
 @Component({
   template: `
-    <ts-chip-collection
-      [chipsInput]="options"
-      [id]="myId"
-    >
+    <ts-chip-collection [id]="myId">
+      <ts-chip
+        *ngFor="let chip of options"
+        [value]="chip"
+      >{{ chip }}</ts-chip>
     </ts-chip-collection>
   `,
 })
 export class Id {
-  options = [1, 2, 3];
-  myId = 100;
+  public options = [1, 2, 3];
+  public myId = 100;
 }
 
 @Component({
   template: `
-    <ts-chip-collection
-      [chipsInput]="options"
-      [id]="myId"
-      [isSelectable]="isSelectable"
-    >
-    </ts-chip-collection>
-  `,
-})
-export class isSelectable {
-  isSelectable = false;
-  myId = 'foo';
-  options = [1, 2, 3];
-}
-
-@Component({
-  template: `
-    <ts-chip-collection
-      [chipsInput]="options"
-      [allowMultipleSelections]="allowMultipleSelections"
-    >
+    <ts-chip-collection [allowMultipleSelections]="allowMultipleSelections">
+      <ts-chip
+        *ngFor="let chip of options"
+        [value]="chip"
+      >{{ chip }}</ts-chip>
     </ts-chip-collection>
   `,
 })
 export class NotAllowMultipleSelections {
-  allowMultipleSelections = false;
-  options = [1, 2, 3];
+  public options = [1, 2, 3];
+  public allowMultipleSelections = false;
+}
+
+@Component({
+  template: `
+    <ts-chip-collection>
+      <ts-chip *ngFor="let chip of options">{{ chip }}</ts-chip>
+    </ts-chip-collection>
+  `,
+})
+export class NoValueChip {
+  public options = [];
 }
 
 @Component({
   template: `
     <ts-chip-collection
+        (tabUpdateFocus)="tabbed()"
+        (removed)="removed($event)"
+        (collectionChange)="change($event)"
     >
+       <ts-chip
+           *ngFor="let chip of options"
+           [value]="chip"
+           (remove)="remove($event.chip)"
+       >{{ chip }}</ts-chip>
     </ts-chip-collection>
   `,
 })
-export class NoValueChip {
+export class Events {
+  public options = ['banana', 'apple'];
+  public change = v => { };
+  public removed = (v: TsChipEvent) => { };
+  public tabbed = () => { };
+  public remove = (v: TsChipComponent) => {
+    this.options = this.options.filter(option => v.value === option);
+  }
 }
+
+@Component({
+  template: `
+    <ts-chip-collection>
+      <ts-chip *ngFor="let chip of options">{{ chip }}</ts-chip>
+    </ts-chip-collection>
+  `,
+})
+export class ChipNoValue {
+  public options = ['banana'];
+}
+
 
 /**
  * NOTE: Currently all exported Components must belong to a module. So this is our useless module to avoid the build error.
@@ -238,9 +253,10 @@ export class NoValueChip {
   declarations: [
     Autocomplete,
     RegularChip,
+    ChipNoValue,
     DisabledChip,
+    Events,
     Id,
-    isSelectable,
     OneChip,
     NoChip,
     NotAllowMultipleSelections,

--- a/terminus-ui/chip/testing/src/test-helpers.ts
+++ b/terminus-ui/chip/testing/src/test-helpers.ts
@@ -1,14 +1,16 @@
-import { ComponentFixture } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
+import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import {
-  TsChipComponent,
-  TsChipCollectionComponent,
-} from '@terminus/ui/chip';
 import { getAutocompleteInstance } from '@terminus/ui/autocomplete/testing';
+import {
+  TsChipCollectionComponent,
+  TsChipComponent,
+} from '@terminus/ui/chip';
+import { TsUILibraryError } from '@terminus/ui/utilities';
+
 
 /**
- * Get an array of all DebugElements for TsChipComponents
+ * Get an array of all DebugElements for {@link TsChipComponent}s
  *
  * @param fixture - The component fixture
  * @return An array of DebugElements
@@ -18,7 +20,7 @@ export function getAllChipDebugElements(fixture: ComponentFixture<any>): DebugEl
 }
 
 /**
- * Get an array of all DebugElements for TsChipCollections
+ * Get an array of all DebugElements for {@link TsChipCollectionComponent}s
  *
  * @param fixture - The component fixture
  * @return An array of DebugElements
@@ -28,47 +30,46 @@ export function getAllChipCollectionDebugElements(fixture: ComponentFixture<any>
 }
 
 /**
- * Get an array of all chip instances for a TsSelectComponent
+ * Get an array of all chip instances for a {@link TsChipCollectionComponent}
  *
  * @param fixture - The component fixture
- * @param index - The index of the desired TsSelectComponent
+ * @param index - The index of the desired {@link TsChipCollectionComponent}
  * @return An array of chip instances
  */
 export function getAllChipInstances(fixture: ComponentFixture<any>, index = 0): TsChipComponent[] {
   const instance = getChipCollectionInstance(fixture, index);
   if (!instance.chips) {
-    throw new Error(`'getAllChipInstances' did not find a chips collection from the select at index '${index}'`);
+    throw new TsUILibraryError(`'getAllChipInstances' did not find a chips collection from the select at index '${index}'`);
   }
   return instance.chips.toArray();
 }
 
 /**
- * Get a specific chip instance for a TsChipCollection
+ * Get a specific chip instance for a {@link TsChipCollectionComponent}
  *
  * @param fixture - The component fixture
- * @param selectIndex - The index of the desired TsChipCollection
+ * @param selectIndex - The index of the desired {@link TsChipCollectionComponent
  * @param chipIndex - The index of the desired chip
- * @return A chip instances
+ * @return A chip instance
  */
 export function getChipInstance(fixture: ComponentFixture<any>, selectIndex = 0, chipIndex = 0): TsChipComponent {
   const chips = getAllChipInstances(fixture, selectIndex);
   if (!chips[chipIndex]) {
-    throw new Error(`'getChipInstance' did not find a chip at index '${chipIndex}'`);
+    throw new TsUILibraryError(`'getChipInstance' did not find a chip at index '${chipIndex}'`);
   }
   return chips[chipIndex];
 }
 
-
 /**
- * Get an array of all TsChipCollectionComponent instances
+ * Get an array of all {@link TsChipCollectionComponent} instances
  *
  * @param fixture - The component fixture
- * @return An array of TsChipCollectionComponent
+ * @return An array of {@link TsChipCollectionComponent}
  */
 export function getAllChipCollectionInstances(fixture: ComponentFixture<any>): TsChipCollectionComponent[] {
   const debugElements = getAllChipCollectionDebugElements(fixture);
   if (debugElements.length < 1) {
-    throw new Error(`getAllChipCollectionInstances did not find any instances`);
+    throw new TsUILibraryError(`getAllChipCollectionInstances did not find any instances`);
   }
   return debugElements.map(debugElement => debugElement.componentInstance);
 }
@@ -82,46 +83,46 @@ export function getAllChipCollectionInstances(fixture: ComponentFixture<any>): T
 export function getChipCollectionInstanceInAutocomplete(fixture: ComponentFixture<any>): TsChipCollectionComponent {
   const instance = getAutocompleteInstance(fixture);
   if (!instance.chipCollection) {
-    throw new Error('no chip collection');
+    throw new TsUILibraryError(`'getChipCollectionInstanceInAutocomplete' found no chip collection.`);
   }
   return instance.chipCollection;
 }
 
 /**
- * Get the DebugElement for a TsChipComponent
+ * Get the DebugElement for a {@link TsChipComponent}
  *
  * @param fixture - The component fixture
- * @param index - The index of the desired TsChipComponent
+ * @param index - The index of the desired {@link TsChipComponent}
  * @return The DebugElement
  */
 export function getChipDebugElement(fixture: ComponentFixture<any>, index = 0): DebugElement {
   const all = getAllChipDebugElements(fixture);
   if (!all[index]) {
-    throw new Error(`getChipDebugElement could not find a debug element at index '${index}'`);
+    throw new TsUILibraryError(`'getChipDebugElement' could not find a debug element at index '${index}'`);
   }
   return all[index];
 }
 
 /**
- * Get the DebugElement for a TsChipCollection
+ * Get the DebugElement for a {@link TsChipCollectionComponent}
  *
  * @param fixture - The component fixture
- * @param index - The index of the desired TsChipCollection
+ * @param index - The index of the desired {@link TsChipCollectionComponent}
  * @return The DebugElement
  */
 export function getChipCollectionDebugElement(fixture: ComponentFixture<any>, index = 0): DebugElement {
   const all = getAllChipCollectionDebugElements(fixture);
   if (!all[index]) {
-    throw new Error(`getChipCollectionDebugElement could not find a debug element at index '${index}'`);
+    throw new TsUILibraryError(`'getChipCollectionDebugElement' could not find a debug element at index '${index}'`);
   }
   return all[index];
 }
 
 /**
- * Get the component instance for a TsChipCollection
+ * Get the component instance for a {@link TsChipCollectionComponent}
  *
  * @param fixture - The component fixture
- * @param index - The index of the desired TsChipCollection
+ * @param index - The index of the desired {@link TsChipCollectionComponent}
  * @return The instance
  */
 
@@ -131,10 +132,10 @@ export function getChipCollectionInstance(fixture: ComponentFixture<any>, index 
 }
 
 /**
- * Get the element for a TsChipComponent
+ * Get the element for a {@link TsChipComponent}
  *
  * @param fixture - The component fixture
- * @param index - The index of the desired TsChipComponent
+ * @param index - The index of the desired {@link TsChipComponent}
  * @return The element
  */
 export function getChipElement(fixture: ComponentFixture<any>, index = 0): HTMLElement {
@@ -143,10 +144,10 @@ export function getChipElement(fixture: ComponentFixture<any>, index = 0): HTMLE
 }
 
 /**
- * Get the element for a TsChipCollection
+ * Get the element for a {@link TsChipCollectionComponent}
  *
  * @param fixture - The component fixture
- * @param index - The index of the desired TsChipCollection
+ * @param index - The index of the desired {@link TsChipCollectionComponent}
  * @return The element
  */
 export function getChipCollectionElement(fixture: ComponentFixture<any>, index = 0): HTMLElement {


### PR DESCRIPTION
Closes #1688 
Closes #1687

- chips now passed into collection
- removed material class mixins
- renamed blur functions and emitters to not use native event names or be prefixed with `on`
- reorganized public/private/static items
- removed directive for the remove icon since it is not controlled by the consumer
- selecting a chip via shift key now takes `isSelected` into account
- updated all test components
- updated demo and added more controls
- updated jsdoc comments
- added jsdoc links where applicable
- added usage docs
- converted errors to UI errors
- removed boolean coercion since we no longer do that for boolean inputs
- moved test components back to our standard import method to enable IDE support