### PR TITLE
fix(Chip): chips now wrap if content is too long

### DIFF
--- a/terminus-ui/chip/src/chip-collection.component.scss
+++ b/terminus-ui/chip/src/chip-collection.component.scss
@@ -18,5 +18,6 @@
   $negative-spacing: spacing(small, 2);
   align-items: center;
   display: flex;
+  flex-wrap: wrap;
   margin: $negative-spacing;
 }


### PR DESCRIPTION
<img width="711" alt="Screen Shot 2019-09-26 at 2 18 56 PM" src="https://user-images.githubusercontent.com/270193/65714167-973ba580-e068-11e9-8add-deed09a4202c.png">
