### PR TITLE
SelectionList bugs

### DIFF
--- a/demo/app/components/components.component.ts
+++ b/demo/app/components/components.component.ts
@@ -72,7 +72,6 @@ export class ComponentsComponent implements OnInit {
    * Pass the query change to our search
    */
   public queryHasChanged(query: string): void {
-    console.log('queryHasChanged: ', query);
     this.query$.next(query);
   }
 
@@ -104,7 +103,6 @@ export class ComponentsComponent implements OnInit {
    */
   private queryComponents(query: string): Route[] {
     query = query.toLowerCase();
-    console.warn('queryComponents: ', query);
 
     if (query) {
       const letters = query.split('').map(l => `${l}.*`).join('');

--- a/terminus-ui/form-field/src/form-field.component.scss
+++ b/terminus-ui/form-field/src/form-field.component.scss
@@ -89,12 +89,12 @@ $date-picker-width: 200px;
   &:not(.ts-form-field--disabled) {
     .ts-form-field__container {
       &:hover {
-        &.ts-form-field__outline {
+        .ts-form-field__outline {
           opacity: 0;
           transition: opacity 600ms $swift-ease-out-timing-function;
         }
 
-        &.ts-form-field__outline--thick {
+        .ts-form-field__outline--thick {
           opacity: 1;
         }
       }

--- a/terminus-ui/selection-list/src/selection-list-panel/selection-list-panel.component.html
+++ b/terminus-ui/selection-list/src/selection-list-panel/selection-list-panel.component.html
@@ -1,7 +1,7 @@
 <ng-template>
   <div
     class="ts-selection-list-panel__inner"
-    [class.ts-selection-list-visible]="showPanel"
+    [class.ts-selection-list--visible]="showPanel"
     role="listbox"
     [attr.id]="id"
     #panel

--- a/terminus-ui/selection-list/src/selection-list-panel/selection-list-panel.component.scss
+++ b/terminus-ui/selection-list/src/selection-list-panel/selection-list-panel.component.scss
@@ -54,12 +54,8 @@ $ts-selection-list-panel-border-radius: 4px !default;
     }
   }
 
-  &.ts-selection-list-visible {
+  &.ts-selection-list--visible {
     visibility: visible;
-  }
-
-  &.ts-selection-list-hidden {
-    visibility: hidden;
   }
 
   .ts-selection-list-panel-above & {

--- a/terminus-ui/selection-list/src/selection-list-panel/selection-list-panel.component.ts
+++ b/terminus-ui/selection-list/src/selection-list-panel/selection-list-panel.component.ts
@@ -81,6 +81,29 @@ export class TsSelectionListPanelComponent implements AfterContentInit {
   public readonly uid = `ts-selection-list-panel-${nextUniqueId++}`;
 
   /**
+   * Return the panel's scrollTop
+   *
+   * @return The scrolltop number
+   */
+  public get scrollTop(): number {
+    return this.panel ? this.panel.nativeElement.scrollTop : 0;
+  }
+
+  /**
+   * Set the panel scrollTop
+   *
+   * This allows us to manually scroll to display options above or below the fold, as they are not actually being focused when active.
+   *
+   * @param scrollTop - The number of pixels to move
+   */
+  public set scrollTop(scrollTop: number) {
+    // istanbul ignore else
+    if (this.panel) {
+      this.panel.nativeElement.scrollTop = scrollTop;
+    }
+  }
+
+  /**
    * Access the template. Used by {@link TsSelectionListTriggerDirective}
    */
   @ViewChild(TemplateRef, { static: false })
@@ -90,7 +113,7 @@ export class TsSelectionListPanelComponent implements AfterContentInit {
   /**
    * Access the element for the panel containing the options
    */
-  @ViewChild('panel', { static: true })
+  @ViewChild('panel', { static: false })
   public panel!: ElementRef;
 
   /**

--- a/terminus-ui/selection-list/src/selection-list-panel/selection-list-trigger.directive.ts
+++ b/terminus-ui/selection-list/src/selection-list-panel/selection-list-trigger.directive.ts
@@ -770,7 +770,8 @@ export class TsSelectionListTriggerDirective<ValueType = string> implements Cont
         // Create a new stream of panelClosingActions, replacing any previous streams that were created, and flatten it so our stream only
         // emits closing events...
         switchMap(() => {
-          this.resetActiveItem();
+          // Focus the first option when options change
+          this.selectionListPanel.keyManager.setActiveItem(0);
           this.selectionListPanel.setVisibility();
 
           return this.panelClosingActions;
@@ -820,14 +821,12 @@ export class TsSelectionListTriggerDirective<ValueType = string> implements Cont
       // top of the option, because it allows the user to read the top group's label.
       this.selectionListPanel.scrollTop = 0;
     } else {
-      const newScrollPosition = getOptionScrollPosition(
+      this.selectionListPanel.scrollTop = getOptionScrollPosition(
         index + labelCount,
         this.itemHeight,
         this.selectionListPanel.scrollTop,
         SELECTION_LIST_PANEL_MAX_HEIGHT,
       );
-
-      this.selectionListPanel.scrollTop = newScrollPosition;
     }
   }
 

--- a/terminus-ui/selection-list/src/selection-list.component.scss
+++ b/terminus-ui/selection-list/src/selection-list.component.scss
@@ -1,5 +1,6 @@
 @import './../../scss/helpers/animation';
 @import './../../scss/helpers/color';
+@import './../../scss/helpers/cursors';
 @import './../../scss/helpers/layout';
 @import './../../scss/helpers/reset';
 @import './../../scss/helpers/spacing';
@@ -9,6 +10,7 @@
 $transition-duration: 200;
 
 .ts-selection-list {
+  cursor: cursor(pointer);
   display: block;
 }
 

--- a/terminus-ui/selection-list/src/selection-list.component.spec.ts
+++ b/terminus-ui/selection-list/src/selection-list.component.spec.ts
@@ -965,11 +965,24 @@ describe(`TsSelectionListComponent`, function() {
     expect(fixture.componentInstance.clicked).toHaveBeenCalled();
   }));
 
+  // Note: Simply dispatching the arrow down key on the trigger repeatedly did not work
+  test.todo(`should update panel scroll position when focusing an out-of-view option`);
 
-  describe(`scroll into view`, () => {
+  test(`should focus first option when the options collection changes`, fakeAsync(() => {
+    const fixture = createComponent(testComponents.Basic);
+    fixture.detectChanges();
+    const instance = getSelectionListInstance(fixture);
 
-    test.todo(`should update panel scroll position when focusing option out of view`);
+    expect(instance.panel.keyManager.activeItemIndex).toEqual(-1);
 
-  });
+    const input = getSelectionListInput(fixture);
+    const states = fixture.componentInstance.states;
+    const name = states[3].name.substring(0, 2);
+    typeInElement(name, input);
+    tick(1000);
+    fixture.detectChanges();
+
+    expect(instance.panel.keyManager.activeItemIndex).toEqual(0);
+  }));
 
 });

--- a/terminus-ui/selection-list/src/selection-list.component.spec.ts
+++ b/terminus-ui/selection-list/src/selection-list.component.spec.ts
@@ -965,4 +965,11 @@ describe(`TsSelectionListComponent`, function() {
     expect(fixture.componentInstance.clicked).toHaveBeenCalled();
   }));
 
+
+  describe(`scroll into view`, () => {
+
+    test.todo(`should update panel scroll position when focusing option out of view`);
+
+  });
+
 });

--- a/terminus-ui/selection-list/testing/src/test-helpers.ts
+++ b/terminus-ui/selection-list/testing/src/test-helpers.ts
@@ -200,3 +200,18 @@ export function getOptgroupElement(fixture: ComponentFixture<any>, selectIndex =
   const group = getOptgroup(fixture, selectIndex, groupIndex);
   return group.elementRef.nativeElement;
 }
+
+/**
+ * Open the panel
+ *
+ * @param fixture - The component fixture
+ * @param index - The index of the desired TsSelectionListComponent
+ * @return The whenStable promise
+ */
+// tslint:disable-next-line no-any
+export function openSelectionList(fixture: ComponentFixture<any>, index = 0): Promise<any> {
+  const trigger = getSelectionListTriggerElement(fixture, index);
+  trigger.click();
+  fixture.detectChanges();
+  return fixture.whenStable();
+}


### PR DESCRIPTION
- cursor correct on hover. closes #1730 
- form field hover now has correct styles
- focused options are now scrolled into view. closes #1727 
- first option focused by default. closes #1729 