### PR TITLE
1617 table column sizing

### DIFF
--- a/demo/app/components/table/table.component.html
+++ b/demo/app/components/table/table.component.html
@@ -17,38 +17,13 @@
 <div class="example-container">
   <ts-table
     [dataSource]="dataSource"
+    [columns]="resizableColumns"
     tsSort
     tsVerticalSpacing
+    #myTable="tsTable"
   >
 
-    <ng-container tsColumnDef="created" noWrap="true" minWidth="200px">
-      <ts-header-cell *tsHeaderCellDef ts-sort-header>
-        Created
-      </ts-header-cell>
-      <ts-cell *tsCellDef="let item">
-        {{ item.created_at | date:"shortDate" }}
-      </ts-cell>
-    </ng-container>
-
-    <ng-container tsColumnDef="updated" noWrap="true" minWidth="200px" sticky>
-      <ts-header-cell *tsHeaderCellDef ts-sort-header>
-        Updated
-      </ts-header-cell>
-      <ts-cell *tsCellDef="let item">
-        {{ item.updated_at | date:"shortDate" }}
-      </ts-cell>
-    </ng-container>
-
-    <ng-container tsColumnDef="number" noWrap="true" minWidth="100px">
-      <ts-header-cell *tsHeaderCellDef>
-        Number
-      </ts-header-cell>
-      <ts-cell *tsCellDef="let item">
-        {{ item.number }}
-      </ts-cell>
-    </ng-container>
-
-    <ng-container tsColumnDef="title" minWidth="400px">
+    <ng-container tsColumnDef="title" sticky>
       <ts-header-cell *tsHeaderCellDef>
         Title
       </ts-header-cell>
@@ -57,25 +32,16 @@
       </ts-cell>
     </ng-container>
 
-    <ng-container tsColumnDef="body" minWidth="500px">
-      <ts-header-cell *tsHeaderCellDef>
-        Body
+    <ng-container tsColumnDef="updated" noWrap="true">
+      <ts-header-cell *tsHeaderCellDef ts-sort-header>
+        Updated
       </ts-header-cell>
       <ts-cell *tsCellDef="let item">
-        <span [innerHTML]="item.body"></span>
+        {{ item.updated_at | date:"shortDate" }}
       </ts-cell>
     </ng-container>
 
-    <ng-container tsColumnDef="state" noWrap="true" minWidth="200px">
-      <ts-header-cell *tsHeaderCellDef>
-        State
-      </ts-header-cell>
-      <ts-cell *tsCellDef="let item">
-        {{ item.state }}
-      </ts-cell>
-    </ng-container>
-
-    <ng-container tsColumnDef="comments" noWrap="true" alignment="right" minWidth="200px">
+    <ng-container tsColumnDef="comments" noWrap="true">
       <ts-header-cell *tsHeaderCellDef ts-sort-header>
         Comments
       </ts-header-cell>
@@ -84,7 +50,7 @@
       </ts-cell>
     </ng-container>
 
-    <ng-container tsColumnDef="assignee" noWrap="true" minWidth="200px">
+    <ng-container tsColumnDef="assignee" noWrap="true">
       <ts-header-cell *tsHeaderCellDef ts-sort-header>
         Assignee
       </ts-header-cell>
@@ -93,7 +59,16 @@
       </ts-cell>
     </ng-container>
 
-    <ng-container tsColumnDef="labels" minWidth="200px">
+    <ng-container tsColumnDef="number" noWrap="true" alignment="right">
+      <ts-header-cell *tsHeaderCellDef>
+        Number
+      </ts-header-cell>
+      <ts-cell *tsCellDef="let item">
+        {{ item.number }}
+      </ts-cell>
+    </ng-container>
+
+    <ng-container tsColumnDef="labels">
       <ts-header-cell *tsHeaderCellDef>
         Labels
       </ts-header-cell>
@@ -104,27 +79,67 @@
       </ts-cell>
     </ng-container>
 
-    <ng-container tsColumnDef="id" minWidth="200px" stickyEnd>
+    <ng-container tsColumnDef="created" noWrap="true">
+      <ts-header-cell *tsHeaderCellDef ts-sort-header>
+        Created
+      </ts-header-cell>
+      <ts-cell *tsCellDef="let item">
+        {{ item.created_at | date:"shortDate" }}
+      </ts-cell>
+    </ng-container>
+
+    <ng-container tsColumnDef="body">
+      <ts-header-cell *tsHeaderCellDef>
+        Body
+      </ts-header-cell>
+      <ts-cell *tsCellDef="let item">
+        <span class="truncate" [innerHTML]="sanitize(item.body)"></span>
+      </ts-cell>
+    </ng-container>
+
+    <ng-container tsColumnDef="state" noWrap="true">
+      <ts-header-cell *tsHeaderCellDef>
+        State
+      </ts-header-cell>
+      <ts-cell *tsCellDef="let item">
+        {{ item.state }}
+      </ts-cell>
+    </ng-container>
+
+    <ng-container tsColumnDef="id" alignment="right">
       <ts-header-cell *tsHeaderCellDef>
         ID
       </ts-header-cell>
       <ts-cell *tsCellDef="let item">
-        {{ item.id }},
+        {{ item.id }}
       </ts-cell>
     </ng-container>
 
-    <ts-header-row *tsHeaderRowDef="displayedColumns; sticky: true"></ts-header-row>
+    <ng-container tsColumnDef="html_url" noWrap="true" stickyEnd>
+      <ts-header-cell *tsHeaderCellDef>
+        View
+      </ts-header-cell>
+      <ts-cell *tsCellDef="let item">
+        <a href="{{ item.html_url }}">
+          <ts-icon>open_in_new</ts-icon>
+        </a>
+      </ts-cell>
+    </ng-container>
 
-    <ts-row *tsRowDef="let row; columns: displayedColumns;">
+    <ts-header-row *tsHeaderRowDef="myTable.columnNames; sticky: true"></ts-header-row>
+
+    <ts-row *tsRowDef="let row; columns: myTable.columnNames;">
     </ts-row>
 
   </ts-table>
 </div>
 
-<ts-paginator
-  [totalRecords]="resultsLength"
-  recordCountTooHighMessage="Please refine your filters."
-  (pageSelect)="onPageSelect($event)"
-  (recordsPerPageChange)="perPageChange($event)"
-></ts-paginator>
+<div fxLayout="row" fxLayoutAlign="end start">
+  <ts-paginator
+    [totalRecords]="resultsLength"
+    recordCountTooHighMessage="Please refine your filters."
+    (pageSelect)="onPageSelect($event)"
+    (recordsPerPageChange)="perPageChange($event)"
+  ></ts-paginator>
+</div>
 

--- a/demo/app/components/table/table.component.scss
+++ b/demo/app/components/table/table.component.scss
@@ -6,3 +6,10 @@
   overflow: auto;
   @include visible-scrollbars;
 }
+
+.truncate {
+  display: block;
+  max-height: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/demo/app/components/table/table.component.scss
+++ b/demo/app/components/table/table.component.scss
@@ -1,4 +1,8 @@
+@import '~@terminus/ui/helpers';
+
+
 .example-container {
   height: 400px;
   overflow: auto;
+  @include visible-scrollbars;
 }

--- a/demo/app/components/table/table.component.ts
+++ b/demo/app/components/table/table.component.ts
@@ -4,12 +4,16 @@ import {
   Component,
   ViewChild,
 } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import {
   TsPaginatorComponent,
   TsPaginatorMenuItem,
 } from '@terminus/ui/paginator';
 import { TsSortDirective } from '@terminus/ui/sort';
-import { TsTableDataSource } from '@terminus/ui/table';
+import {
+  TsColumn,
+  TsTableDataSource,
+} from '@terminus/ui/table';
 import {
   merge,
   Observable,
@@ -76,10 +80,14 @@ const COLUMNS_SOURCE_GITHUB = [
 
 export interface GithubApi {
   items: GithubIssue[];
+  // NOTE: Format controlled by GitHub
+  // eslint-disable-next-line camelcase
   total_count: number;
 }
 
 export interface GithubIssue {
+  // NOTE: Format controlled by GitHub
+  // eslint-disable-next-line camelcase
   created_at: string;
   number: string;
   state: string;
@@ -92,11 +100,10 @@ export interface GithubIssue {
 export class ExampleHttpDao {
   constructor(private http: HttpClient) {}
 
-  getRepoIssues(sort: string, order: string, page: number, perPage: number): Observable<GithubApi> {
-    const href = 'https://api.github.com/search/issues';
+  public getRepoIssues(sort: string, order: string, page: number, perPage: number): Observable<GithubApi> {
+    const href = `https://api.github.com/search/issues`;
     const requestUrl = `${href}?q=repo:GetTerminus/terminus-ui`;
     const requestParams = `&sort=${sort}&order=${order}&page=${page + 1}&per_page=${perPage}`;
-
     return this.http.get<GithubApi>(`${requestUrl}${requestParams}`);
   }
 }
@@ -108,8 +115,8 @@ export class ExampleHttpDao {
   styleUrls: ['./table.component.scss'],
 })
 export class TableComponent implements AfterViewInit {
-  allColumns = COLUMNS_SOURCE_GITHUB.slice(0);
-  displayedColumns: string[] = [
+  public allColumns = COLUMNS_SOURCE_GITHUB.slice(0);
+  public displayedColumns = [
     'title',
     'updated',
     'comments',
@@ -117,26 +124,52 @@ export class TableComponent implements AfterViewInit {
     'number',
     'labels',
     'created',
-    'id',
     'body',
+    'id',
+    'html_url',
   ];
-  exampleDatabase!: ExampleHttpDao;
-  dataSource: TsTableDataSource<GithubIssue> = new TsTableDataSource();
-  resultsLength = 0;
+  public exampleDatabase!: ExampleHttpDao;
+  public dataSource = new TsTableDataSource<GithubIssue>();
+  public resultsLength = 0;
+  public resizableColumns: TsColumn[] = [
+    {
+      name: 'title',
+      width: '400px',
+    },
+    { name: 'updated' },
+    { name: 'comments' },
+    {
+      name: 'assignee',
+      width: '160px',
+    },
+    { name: 'number' },
+    {
+      name: 'labels',
+      width: '260px',
+    },
+    { name: 'created' },
+    { name: 'id' },
+    {
+      name: 'body',
+      width: '500px',
+    },
+    { name: 'html_url' },
+  ];
 
-  @ViewChild(TsSortDirective, {static: true})
-  sort!: TsSortDirective;
+  @ViewChild(TsSortDirective, { static: true })
+  public sort!: TsSortDirective;
 
-  @ViewChild(TsPaginatorComponent, {static: true})
-  paginator!: TsPaginatorComponent;
+  @ViewChild(TsPaginatorComponent, { static: true })
+  public readonly paginator!: TsPaginatorComponent;
 
 
   constructor(
+    private domSanitizer: DomSanitizer,
     private http: HttpClient,
   ) {}
 
 
-  ngAfterViewInit(): void {
+  public ngAfterViewInit(): void {
     this.exampleDatabase = new ExampleHttpDao(this.http);
 
     // If the user changes the sort order, reset back to the first page.
@@ -171,12 +204,16 @@ export class TableComponent implements AfterViewInit {
   }
 
 
-  perPageChange(e: number): void {
+  public perPageChange(e: number): void {
     console.log('DEMO records per page changed: ', e);
   }
 
-  onPageSelect(e: TsPaginatorMenuItem): void {
+  public onPageSelect(e: TsPaginatorMenuItem): void {
     console.log('DEMO page selected: ', e);
+  }
+
+  public sanitize(content): SafeHtml {
+    return this.domSanitizer.bypassSecurityTrustHtml(content);
   }
 
 }

--- a/demo/app/components/table/table.module.ts
+++ b/demo/app/components/table/table.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
 import { TsCardModule } from '@terminus/ui/card';
+import { TsIconModule } from '@terminus/ui/icon';
 import { TsOptionModule } from '@terminus/ui/option';
 import { TsPaginatorModule } from '@terminus/ui/paginator';
 import { TsSelectModule } from '@terminus/ui/select';
@@ -21,6 +22,7 @@ import { TableComponent } from './table.component';
     FormsModule,
     TableRoutingModule,
     TsCardModule,
+    TsIconModule,
     TsOptionModule,
     TsPaginatorModule,
     TsSelectModule,

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "@angular/platform-browser": "^8.2.4",
     "@angular/platform-browser-dynamic": "^8.2.4",
     "@angular/router": "^8.2.4",
-    "@terminus/ngx-tools": "^7.2.4",
+    "@terminus/ngx-tools": "^7.2.6",
     "@terminus/ui": "14.9.3",
     "date-fns": "2.0.1",
     "jsdom": "15.1.1",

--- a/terminus-ui/sort/src/sort-header.component.ts
+++ b/terminus-ui/sort/src/sort-header.component.ts
@@ -13,10 +13,7 @@ import {
   Optional,
   ViewEncapsulation,
 } from '@angular/core';
-import {
-  CanDisable,
-  mixinDisabled,
-} from '@angular/material/core';
+import { CanDisable } from '@angular/material/core';
 import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { isBoolean } from '@terminus/ngx-tools/type-guards';
 import { untilComponentDestroyed } from '@terminus/ngx-tools/utilities';
@@ -48,12 +45,10 @@ import {
  * <example-url>https://getterminus.github.io/ui-demos-release/components/table</example-url>
  */
 @Component({
-  // NOTE(B$): This component needs to be added to another component so we need a non-element
-  // selector
+  // NOTE: This component needs to be added to another component so we need a non-element selector
   // tslint:disable: component-selector
   selector: '[ts-sort-header]',
   // tslint:enable: component-selector
-  exportAs: 'tsSortHeader',
   templateUrl: './sort-header.component.html',
   styleUrls: ['./sort-header.component.scss'],
   host: {
@@ -63,8 +58,6 @@ import {
     '(click)': '_handleClick()',
   },
   preserveWhitespaces: false,
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   // NOTE: @Inputs are defined here rather than using decorators since we are extending the @Inputs of the base class
   // tslint:disable-next-line:no-inputs-metadata-property
   inputs: ['disabled'],
@@ -74,6 +67,9 @@ import {
     tsSortAnimations.rightPointer,
     tsSortAnimations.indicatorToggle,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'tsSortHeader',
 })
 export class TsSortHeaderComponent implements TsSortableItem, CanDisable, OnInit, OnDestroy  {
   public disabled = false;

--- a/terminus-ui/table/package.json
+++ b/terminus-ui/table/package.json
@@ -1,7 +1,10 @@
 {
   "ngPackage": {
     "lib": {
-      "entryFile": "src/public-api.ts"
+      "entryFile": "src/public-api.ts",
+      "umdModuleIds": {
+        "@terminus/ngx-tools/type-guards": "terminus.ngxTools.type-guards"
+      }
     }
   }
 }

--- a/terminus-ui/table/src/design-decisions.md
+++ b/terminus-ui/table/src/design-decisions.md
@@ -22,3 +22,5 @@ recreate a spreadsheet.
 
 Row selection (single or multiple) is not implemented. UX needs a better use-case for this need
 before we take the time to build it in.
+
+This can be added by the consumer fairly easily.

--- a/terminus-ui/table/src/row.ts
+++ b/terminus-ui/table/src/row.ts
@@ -11,6 +11,7 @@ import {
   Directive,
   ViewEncapsulation,
 } from '@angular/core';
+import { TsTableComponent } from './table.component';
 
 
 /**

--- a/terminus-ui/table/src/table-data-source.spec.ts
+++ b/terminus-ui/table/src/table-data-source.spec.ts
@@ -10,19 +10,17 @@ interface Foo {
 // Additional tests for parts missed by the {@link TsTableComponent} integration test
 describe(`TsTableDataSource`, function() {
   let source: TsTableDataSource<Foo>;
-  let seededSource: TsTableDataSource<Foo>;
+  let seededSource: TsTableDataSource<any>;
 
   beforeEach(() => {
     source = new TsTableDataSource();
     seededSource = new TsTableDataSource([{ foo: 'bar' }]);
   });
 
-
   test(`should initialize an empty array if no data passed in`, () => {
     expect(source.data).toEqual([]);
     expect(seededSource.data).toEqual([{ foo: 'bar' }]);
   });
-
 
   describe(`in _renderChangesSubscription exists`, () => {
 
@@ -34,7 +32,6 @@ describe(`TsTableDataSource`, function() {
     });
 
   });
-
 
   test(`should have a disconnected() noop`, () => {
     expect(source.disconnect()).toEqual(undefined);

--- a/terminus-ui/table/src/table.component.scss
+++ b/terminus-ui/table/src/table.component.scss
@@ -1,7 +1,6 @@
 @import './../../scss/helpers/color';
 @import './../../scss/helpers/layout';
 @import './../../scss/helpers/reset';
-@import './../../scss/helpers/scrollbars';
 @import './../../scss/helpers/spacing';
 @import './../../scss/helpers/typography';
 
@@ -21,7 +20,6 @@ $ts-row-hover: rgba(color(utility, xlight), .5);
 .ts-table {
   @include reset;
   @include typography;
-  @include visible-scrollbars;
   display: inline-block;
   max-height: 100%;
 
@@ -66,7 +64,6 @@ $ts-row-hover: rgba(color(utility, xlight), .5);
     box-sizing: border-box;
     display: flex;
   }
-
 
   //
   // Cells

--- a/terminus-ui/table/src/table.component.scss
+++ b/terminus-ui/table/src/table.component.scss
@@ -21,7 +21,6 @@ $ts-row-hover: rgba(color(utility, xlight), .5);
   @include reset;
   @include typography;
   display: inline-block;
-  max-height: 100%;
 
   //
   // Rows
@@ -71,23 +70,24 @@ $ts-row-hover: rgba(color(utility, xlight), .5);
 
   // Body cell
   .ts-cell {
+    $sticky-border: 1px solid color(utility, xlight);
     background-color: color(pure);
     padding: spacing(default);
     vertical-align: middle;
 
-    &.ts-table--sticky {
-      border-right: 1px solid color(utility, xlight);
+    &--sticky {
+      border-right: $sticky-border;
+    }
+
+    &--sticky-end {
+      border-left: $sticky-border;
     }
   }
 
   // Header cell
   .ts-header-cell {
     background-color: color(pure);
-    // If the column isn't sortable, add padding here that would normally be added by
-    // `ts-sort-header-container`
-    &:not(.ts-sortable) {
-      padding: spacing(default);
-    }
+    padding: spacing(default);
 
     &.ts-sortable {
       border-bottom: 3px solid color(utility, light);
@@ -100,11 +100,6 @@ $ts-row-hover: rgba(color(utility, xlight), .5);
       border-bottom-color: color(accent);
       color: color(accent);
     }
-
-    // <div> inner container wrapping the sort control
-    .ts-sort-header-container {
-      padding: spacing(default);
-    }
   }
 
   // Any cell
@@ -112,7 +107,6 @@ $ts-row-hover: rgba(color(utility, xlight), .5);
   .ts-header-cell {
     align-items: stretch;
     background-color: color(pure);
-    display: flex;
     flex: 1;
     flex-basis: 6em;
     min-height: inherit;

--- a/terminus-ui/table/src/table.component.spec.ts
+++ b/terminus-ui/table/src/table.component.spec.ts
@@ -1,18 +1,31 @@
 /* eslint-disable no-underscore-dangle */
 import { ComponentFixture } from '@angular/core/testing';
-import { createComponent } from '@terminus/ngx-tools/testing';
+import {
+  createComponent,
+  ElementRefMock,
+} from '@terminus/ngx-tools/testing';
 import * as testComponents from '@terminus/ui/table/testing';
 // eslint-disable-next-line no-duplicate-imports
 import {
   expectTableToMatchContent,
+  getCells,
   getHeaderCells,
   getHeaderRow,
 } from '@terminus/ui/table/testing';
 
+import {
+  TsCellDirective,
+  TsColumnDefDirective,
+} from './cell';
 import { TsTableDataSource } from './table-data-source';
 import { TsTableModule } from './table.module';
 
 
+interface TestData {
+  a: string|number|undefined;
+  b: string|number|undefined;
+  c: string|number|undefined;
+}
 
 
 describe(`TsTableComponent`, function() {
@@ -34,7 +47,6 @@ describe(`TsTableComponent`, function() {
       ]);
     });
 
-
     test(`should create a table with special when row`, function() {
       const fixture = createComponent(testComponents.TableWithWhenRowApp, [], [TsTableModule]);
       fixture.detectChanges();
@@ -49,7 +61,6 @@ describe(`TsTableComponent`, function() {
       ]);
     });
   });
-
 
   describe(`with TsTableDataSource`, function() {
     let tableElement: HTMLElement;
@@ -66,7 +77,6 @@ describe(`TsTableComponent`, function() {
       dataSource = fixture.componentInstance.dataSource;
     });
 
-
     test(`should create table and display data source contents`, function() {
       expectTableToMatchContent(tableElement, [
         ['Column A', 'Column B', 'Column C'],
@@ -75,7 +85,6 @@ describe(`TsTableComponent`, function() {
         ['a_3', 'b_3', 'c_3'],
       ]);
     });
-
 
     test(`changing data should update the table contents`, function() {
       // Add data
@@ -102,13 +111,11 @@ describe(`TsTableComponent`, function() {
       ]);
     });
 
-
     test(`should add the no wrap class`, function() {
       const noWrapColumn = fixture.nativeElement.querySelector('.ts-column-no-wrap');
 
       expect(noWrapColumn).toBeTruthy();
     });
-
 
     test(`should add the min-width style`, function() {
       const column = fixture.nativeElement.querySelector('.ts-cell.ts-column-column_b');
@@ -121,12 +128,11 @@ describe(`TsTableComponent`, function() {
         headerStyle = headerColumn.style._values['flex-basis'];
       }
 
-      expect(style).toEqual('100px');
-      expect(headerStyle).toEqual('100px');
+      expect(style).toEqual('7rem');
+      expect(headerStyle).toEqual('7rem');
     });
 
   });
-
 
   describe(`table column alignment`, () => {
     let fixture: ComponentFixture<testComponents.TableColumnAlignmentTableApp>;
@@ -171,19 +177,16 @@ describe(`TsTableComponent`, function() {
 
   });
 
+  test(`should throw error for invalid alignment arguments`, () => {
+    const col = new TsColumnDefDirective();
+    Object.defineProperties(col, { alignment: { get: () => 'foo' } });
 
-  describe(`invalid alignment argument`, () => {
+    const actual = () => {
+      const test = new TsCellDirective(col, new ElementRefMock(), {} as any, {} as any);
+    };
 
-    test(`should throw warning`, () => {
-      window.console.warn = jest.fn();
-      const fixture = createComponent(testComponents.TableColumnInvalidAlignmentTableApp, [], [TsTableModule]);
-      fixture.detectChanges();
-
-      expect(window.console.warn).toHaveBeenCalled();
-    });
-
+    expect(actual).toThrowError('TsCellDirective: ');
   });
-
 
   describe(`pinned header and column`, () => {
     let fixture: ComponentFixture<testComponents.PinnedTableHeaderColumn>;
@@ -198,13 +201,16 @@ describe(`TsTableComponent`, function() {
 
     test(`should set a header to be sticky`, () => {
       const header = getHeaderRow(tableElement);
-      expect(header.classList).toContain('ts-table--sticky');
+      expect(header.classList).toContain('ts-cell--sticky');
     });
 
     test(`should set a column to be sticky`, () => {
       const headerCells = getHeaderCells(tableElement);
-      expect(headerCells[0].classList).toContain('ts-table--sticky');
-      expect(headerCells[1].classList).not.toContain('ts-table--sticky');
+      const cells = getCells(tableElement);
+      expect(headerCells[0].classList).toContain('ts-cell--sticky');
+      expect(headerCells[1].classList).not.toContain('ts-cell--sticky');
+      expect(cells[0].classList).not.toContain('ts-cell--sticky-end');
+      expect(cells[2].classList).toContain('ts-cell--sticky-end');
     });
 
   });

--- a/terminus-ui/table/src/table.component.ts
+++ b/terminus-ui/table/src/table.component.ts
@@ -2,8 +2,27 @@ import { CdkTable } from '@angular/cdk/table';
 import {
   ChangeDetectionStrategy,
   Component,
+  Input,
   ViewEncapsulation,
 } from '@angular/core';
+import { isUndefined } from '@terminus/ngx-tools/type-guards';
+
+
+/**
+ * The definition for a single column
+ */
+export interface TsColumn {
+  // The column name
+  name: string;
+  // The desired width as a string (eg '200px', '14rem' etc)
+  width?: string;
+  // Allow any other data properties the consumer may need
+  // tslint:disable-next-line no-any
+  [key: string]: any;
+}
+
+// Default column width = ~112px
+const DEFAULT_COLUMN_WIDTH = '7rem';
 
 
 /**
@@ -47,13 +66,40 @@ import {
     provide: CdkTable,
     useExisting: TsTableComponent,
   }],
-  exportAs: 'tsTable',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  exportAs: 'tsTable',
 })
 export class TsTableComponent<T> extends CdkTable<T> {
   /**
-   * Override CDK's class
+   * Override the sticky CSS class set by the `CdkTable`
    */
-  protected stickyCssClass = 'ts-table--sticky';
+  protected stickyCssClass = 'ts-cell--sticky';
+
+  /**
+   * Return a simple array of column names
+   *
+   * Used by {@link TsHeaderRowDefDirective} and {@link TsRowDefDirective}.
+   */
+  public get columnNames(): string[] {
+    return this.columns.map(c => c.name);
+  }
+
+  /**
+   * Define the array of columns
+   */
+  @Input()
+  public set columns(value: ReadonlyArray<TsColumn>) {
+    this._columns = value.map(column => {
+      if (isUndefined(column.width)) {
+        column.width = DEFAULT_COLUMN_WIDTH;
+      }
+      return column;
+    });
+  }
+  public get columns(): ReadonlyArray<TsColumn> {
+    return this._columns;
+  }
+  private _columns: ReadonlyArray<TsColumn>;
+
 }

--- a/terminus-ui/table/testing/src/test-components.ts
+++ b/terminus-ui/table/testing/src/test-components.ts
@@ -21,7 +21,7 @@ import {
 
 @Component({
   template: `
-    <ts-table [dataSource]="dataSource">
+    <ts-table [dataSource]="dataSource" [columns]="columns">
       <ng-container tsColumnDef="column_a">
         <ts-header-cell *tsHeaderCellDef> Column A</ts-header-cell>
         <ts-cell *tsCellDef="let row">{{ row.a }}</ts-cell>
@@ -53,13 +53,17 @@ export class TableApp {
 
   public dataSource: FakeDataSource | null = new FakeDataSource();
   public columnsToRender = ['column_a', 'column_b', 'column_c'];
+  public columns = this.columnsToRender.map(c => ({
+    name: c,
+    width: '112px',
+  }));
   public isFourthRow = (i: number, _rowData: TestData) => i === 3;
 }
 
 
 @Component({
   template: `
-    <ts-table [dataSource]="dataSource">
+    <ts-table [dataSource]="dataSource" [columns]="columns">
       <ng-container tsColumnDef="column_a">
         <ts-header-cell *tsHeaderCellDef> Column A</ts-header-cell>
         <ts-cell *tsCellDef="let row">{{ row.a }}</ts-cell>
@@ -80,18 +84,20 @@ export class TableWithWhenRowApp {
   public table!: TsTableComponent<TestData>;
   public dataSource: FakeDataSource | null = new FakeDataSource();
   public isFourthRow = (i: number, _rowData: TestData) => i === 3;
+  public columnsToRender = ['column_a'];
+  public columns = this.columnsToRender.map(c => ({ name: c }));
 }
 
 
 @Component({
   template: `
-    <ts-table [dataSource]="dataSource" tsSort>
+    <ts-table [dataSource]="dataSource" [columns]="columns" tsSort>
       <ng-container tsColumnDef="column_a" noWrap="true">
         <ts-header-cell *tsHeaderCellDef ts-sort-header="a">Column A</ts-header-cell>
         <ts-cell *tsCellDef="let row">{{ row.a }}</ts-cell>
       </ng-container>
 
-      <ng-container tsColumnDef="column_b" minWidth="100px"  noWrap="true">
+      <ng-container tsColumnDef="column_b" noWrap="true">
         <ts-header-cell *tsHeaderCellDef>Column B</ts-header-cell>
         <ts-cell *tsCellDef="let row">{{ row.b }}</ts-cell>
       </ng-container>
@@ -110,6 +116,7 @@ export class ArrayDataSourceTableApp {
   public underlyingDataSource = new FakeDataSource();
   public dataSource = new TsTableDataSource<TestData>();
   public columnsToRender = ['column_a', 'column_b', 'column_c'];
+  public columns = this.columnsToRender.map(c => ({ name: c }));
 
   @ViewChild(TsTableComponent, { static: true })
   public table!: TsTableComponent<TestData>;
@@ -134,7 +141,7 @@ export class ArrayDataSourceTableApp {
 
 @Component({
   template: `
-    <ts-table [dataSource]="dataSource" tsSort>
+    <ts-table [dataSource]="dataSource" [columns]="columns" tsSort>
       <ng-container tsColumnDef="column_a" alignment="left">
         <ts-header-cell *tsHeaderCellDef>Column A</ts-header-cell>
         <ts-cell *tsCellDef="let row">{{ row.a }}</ts-cell>
@@ -159,6 +166,7 @@ export class TableColumnAlignmentTableApp {
   public underlyingDataSource = new FakeDataSource();
   public dataSource = new TsTableDataSource<TestData>();
   public columnsToRender = ['column_a', 'column_b', 'column_c'];
+  public columns = this.columnsToRender.map(c => ({ name: c }));
 
   @ViewChild(TsTableComponent, { static: true })
   public table!: TsTableComponent<TestData>;
@@ -177,7 +185,7 @@ export class TableColumnAlignmentTableApp {
 
 @Component({
   template: `
-    <ts-table [dataSource]="dataSource" tsSort>
+    <ts-table [dataSource]="dataSource" [columns]="columns" tsSort>
       <ng-container tsColumnDef="column_a" alignment="top">
         <ts-header-cell *tsHeaderCellDef>Column A</ts-header-cell>
         <ts-cell *tsCellDef="let row">{{ row.a }}</ts-cell>
@@ -191,6 +199,7 @@ export class TableColumnInvalidAlignmentTableApp {
   public underlyingDataSource = new FakeDataSource();
   public dataSource = new TsTableDataSource<TestData>();
   public columnsToRender = ['column_a'];
+  public columns = this.columnsToRender.map(c => ({ name: c }));
 
   @ViewChild(TsTableComponent, { static: true })
   public table!: TsTableComponent<TestData>;
@@ -221,7 +230,7 @@ export class TableColumnInvalidAlignmentTableApp {
         <ts-cell *tsCellDef="let row">{{ row.b }}</ts-cell>
       </ng-container>
 
-      <ng-container tsColumnDef="column_c">
+      <ng-container tsColumnDef="column_c" stickyEnd>
         <ts-header-cell *tsHeaderCellDef> Column C</ts-header-cell>
         <ts-cell *tsCellDef="let row">{{ row.c }}</ts-cell>
       </ng-container>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1433,10 +1433,10 @@
     "@typescript-eslint/eslint-plugin-tslint" "^1.10.2"
     "@typescript-eslint/parser" "^1.10.2"
 
-"@terminus/ngx-tools@^7.2.4":
-  version "7.2.4"
-  resolved "https://registry.yarnpkg.com/@terminus/ngx-tools/-/ngx-tools-7.2.4.tgz#aed4d97fadc314a313ebffd7734f921c5c6088e0"
-  integrity sha512-E7uYMpVjTGDT2ZQHLpCkM5V+arrjqax9E5CqYovvPTFzoj5w7QFdd6BaqKMkfoSSnXnChGyhRCHaZhX+CG5gog==
+"@terminus/ngx-tools@^7.2.6":
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/@terminus/ngx-tools/-/ngx-tools-7.2.6.tgz#b5f975befb787265cdd13d680fa921c9060d9b55"
+  integrity sha512-wP4o9BUp1Ejceaew5U93I/stHt3KwF15N0kE/ZvknxTSLeAgHkyIbfV5XE5VhDBgCBej8B0rI5+kng3c26TkQQ==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
Closes #1617 

BREAKING CHANGE:

- `TsColumn` definitions must be passed to `TsTable`.
- `minWidth` support has been removed in favor of `TsColumn` definitions.
- Scroll/overflow now managed by the consumer. So if always-visible scrollbars are desired, the consumer can add the mixin `visible-scrollbars` to their SCSS.