### PR TITLE
01: 1740 user resizable table columns

### DIFF
--- a/demo/app/components/table/table.component.html
+++ b/demo/app/components/table/table.component.html
@@ -1,4 +1,18 @@
-<div fxLayout="row" fxLayoutAlign="end center">
+<div fxLayout="row" fxLayoutAlign="space-between center">
+  <div style="font-size: 12px;">
+    <p>
+      To get around GitHub rate limiting, we cache response data by default.
+      <br>
+      Clear cached data and/or disable below.
+    </p>
+    <label style="margin-right: 1rem;">
+      Use cached data:
+      <input type="checkbox" [(ngModel)]="useCachedData">
+    </label>
+    <button (click)="clearCachedData()">Clear cached GitHub data</button>
+  </div>
+
+  <span fxFlex></span>
 
   <ts-select
     label="Show/hide columns"
@@ -18,13 +32,14 @@
   <ts-table
     [dataSource]="dataSource"
     [columns]="resizableColumns"
+    (columnsChange)="columnsChange($event)"
     tsSort
     tsVerticalSpacing
     #myTable="tsTable"
   >
 
-    <ng-container tsColumnDef="title" sticky>
-      <ts-header-cell *tsHeaderCellDef>
+    <ng-container tsColumnDef="title">
+      <ts-header-cell *tsHeaderCellDef sticky>
         Title
       </ts-header-cell>
       <ts-cell *tsCellDef="let item">
@@ -32,7 +47,7 @@
       </ts-cell>
     </ng-container>
 
-    <ng-container tsColumnDef="updated" noWrap="true">
+    <ng-container tsColumnDef="updated" noWrap="true" alignment="right">
       <ts-header-cell *tsHeaderCellDef ts-sort-header>
         Updated
       </ts-header-cell>
@@ -60,7 +75,7 @@
     </ng-container>
 
     <ng-container tsColumnDef="number" noWrap="true" alignment="right">
-      <ts-header-cell *tsHeaderCellDef>
+      <ts-header-cell *tsHeaderCellDef ts-sort-header>
         Number
       </ts-header-cell>
       <ts-cell *tsCellDef="let item">
@@ -127,10 +142,7 @@
     </ng-container>
 
     <ts-header-row *tsHeaderRowDef="myTable.columnNames; sticky: true"></ts-header-row>
-
-    <ts-row *tsRowDef="let row; columns: myTable.columnNames;">
-    </ts-row>
-
+    <ts-row *tsRowDef="let row; columns: myTable.columnNames;"></ts-row>
   </ts-table>
 </div>
 
@@ -143,3 +155,6 @@
   ></ts-paginator>
 </div>
 
+<div>
+  <button (click)="log()">Log column definitions</button>
+</div>

--- a/demo/app/components/table/table.component.html
+++ b/demo/app/components/table/table.component.html
@@ -17,38 +17,13 @@
 <div class="example-container">
   <ts-table
     [dataSource]="dataSource"
+    [columns]="resizableColumns"
     tsSort
     tsVerticalSpacing
+    #myTable="tsTable"
   >
 
-    <ng-container tsColumnDef="created" noWrap="true" minWidth="200px">
-      <ts-header-cell *tsHeaderCellDef ts-sort-header>
-        Created
-      </ts-header-cell>
-      <ts-cell *tsCellDef="let item">
-        {{ item.created_at | date:"shortDate" }}
-      </ts-cell>
-    </ng-container>
-
-    <ng-container tsColumnDef="updated" noWrap="true" minWidth="200px" sticky>
-      <ts-header-cell *tsHeaderCellDef ts-sort-header>
-        Updated
-      </ts-header-cell>
-      <ts-cell *tsCellDef="let item">
-        {{ item.updated_at | date:"shortDate" }}
-      </ts-cell>
-    </ng-container>
-
-    <ng-container tsColumnDef="number" noWrap="true" minWidth="100px">
-      <ts-header-cell *tsHeaderCellDef>
-        Number
-      </ts-header-cell>
-      <ts-cell *tsCellDef="let item">
-        {{ item.number }}
-      </ts-cell>
-    </ng-container>
-
-    <ng-container tsColumnDef="title" minWidth="400px">
+    <ng-container tsColumnDef="title" sticky>
       <ts-header-cell *tsHeaderCellDef>
         Title
       </ts-header-cell>
@@ -57,25 +32,16 @@
       </ts-cell>
     </ng-container>
 
-    <ng-container tsColumnDef="body" minWidth="500px">
-      <ts-header-cell *tsHeaderCellDef>
-        Body
+    <ng-container tsColumnDef="updated" noWrap="true">
+      <ts-header-cell *tsHeaderCellDef ts-sort-header>
+        Updated
       </ts-header-cell>
       <ts-cell *tsCellDef="let item">
-        <span [innerHTML]="item.body"></span>
+        {{ item.updated_at | date:"shortDate" }}
       </ts-cell>
     </ng-container>
 
-    <ng-container tsColumnDef="state" noWrap="true" minWidth="200px">
-      <ts-header-cell *tsHeaderCellDef>
-        State
-      </ts-header-cell>
-      <ts-cell *tsCellDef="let item">
-        {{ item.state }}
-      </ts-cell>
-    </ng-container>
-
-    <ng-container tsColumnDef="comments" noWrap="true" alignment="right" minWidth="200px">
+    <ng-container tsColumnDef="comments" noWrap="true">
       <ts-header-cell *tsHeaderCellDef ts-sort-header>
         Comments
       </ts-header-cell>
@@ -84,7 +50,7 @@
       </ts-cell>
     </ng-container>
 
-    <ng-container tsColumnDef="assignee" noWrap="true" minWidth="200px">
+    <ng-container tsColumnDef="assignee" noWrap="true">
       <ts-header-cell *tsHeaderCellDef ts-sort-header>
         Assignee
       </ts-header-cell>
@@ -93,7 +59,16 @@
       </ts-cell>
     </ng-container>
 
-    <ng-container tsColumnDef="labels" minWidth="200px">
+    <ng-container tsColumnDef="number" noWrap="true" alignment="right">
+      <ts-header-cell *tsHeaderCellDef>
+        Number
+      </ts-header-cell>
+      <ts-cell *tsCellDef="let item">
+        {{ item.number }}
+      </ts-cell>
+    </ng-container>
+
+    <ng-container tsColumnDef="labels">
       <ts-header-cell *tsHeaderCellDef>
         Labels
       </ts-header-cell>
@@ -104,27 +79,67 @@
       </ts-cell>
     </ng-container>
 
-    <ng-container tsColumnDef="id" minWidth="200px" stickyEnd>
+    <ng-container tsColumnDef="created" noWrap="true">
+      <ts-header-cell *tsHeaderCellDef ts-sort-header>
+        Created
+      </ts-header-cell>
+      <ts-cell *tsCellDef="let item">
+        {{ item.created_at | date:"shortDate" }}
+      </ts-cell>
+    </ng-container>
+
+    <ng-container tsColumnDef="body">
+      <ts-header-cell *tsHeaderCellDef>
+        Body
+      </ts-header-cell>
+      <ts-cell *tsCellDef="let item">
+        <span class="truncate" [innerHTML]="sanitize(item.body)"></span>
+      </ts-cell>
+    </ng-container>
+
+    <ng-container tsColumnDef="state" noWrap="true">
+      <ts-header-cell *tsHeaderCellDef>
+        State
+      </ts-header-cell>
+      <ts-cell *tsCellDef="let item">
+        {{ item.state }}
+      </ts-cell>
+    </ng-container>
+
+    <ng-container tsColumnDef="id" alignment="right">
       <ts-header-cell *tsHeaderCellDef>
         ID
       </ts-header-cell>
       <ts-cell *tsCellDef="let item">
-        {{ item.id }},
+        {{ item.id }}
       </ts-cell>
     </ng-container>
 
-    <ts-header-row *tsHeaderRowDef="displayedColumns; sticky: true"></ts-header-row>
+    <ng-container tsColumnDef="html_url" noWrap="true" stickyEnd>
+      <ts-header-cell *tsHeaderCellDef>
+        View
+      </ts-header-cell>
+      <ts-cell *tsCellDef="let item">
+        <a href="{{ item.html_url }}">
+          <ts-icon>open_in_new</ts-icon>
+        </a>
+      </ts-cell>
+    </ng-container>
 
-    <ts-row *tsRowDef="let row; columns: displayedColumns;">
+    <ts-header-row *tsHeaderRowDef="myTable.columnNames; sticky: true"></ts-header-row>
+
+    <ts-row *tsRowDef="let row; columns: myTable.columnNames;">
     </ts-row>
 
   </ts-table>
 </div>
 
-<ts-paginator
-  [totalRecords]="resultsLength"
-  recordCountTooHighMessage="Please refine your filters."
-  (pageSelect)="onPageSelect($event)"
-  (recordsPerPageChange)="perPageChange($event)"
-></ts-paginator>
+<div fxLayout="row" fxLayoutAlign="end start">
+  <ts-paginator
+    [totalRecords]="resultsLength"
+    recordCountTooHighMessage="Please refine your filters."
+    (pageSelect)="onPageSelect($event)"
+    (recordsPerPageChange)="perPageChange($event)"
+  ></ts-paginator>
+</div>
 

--- a/demo/app/components/table/table.component.scss
+++ b/demo/app/components/table/table.component.scss
@@ -1,10 +1,5 @@
-@import '~@terminus/ui/helpers';
-
-
 .example-container {
   height: 400px;
-  overflow: auto;
-  @include visible-scrollbars;
 }
 
 .truncate {
@@ -12,4 +7,6 @@
   max-height: 100px;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
+  word-break: break-word;
 }

--- a/demo/app/components/table/table.component.scss
+++ b/demo/app/components/table/table.component.scss
@@ -6,3 +6,10 @@
   overflow: auto;
   @include visible-scrollbars;
 }
+
+.truncate {
+  display: block;
+  max-height: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/demo/app/components/table/table.component.scss
+++ b/demo/app/components/table/table.component.scss
@@ -1,4 +1,8 @@
+@import '~@terminus/ui/helpers';
+
+
 .example-container {
   height: 400px;
   overflow: auto;
+  @include visible-scrollbars;
 }

--- a/demo/app/components/table/table.component.ts
+++ b/demo/app/components/table/table.component.ts
@@ -4,12 +4,16 @@ import {
   Component,
   ViewChild,
 } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import {
   TsPaginatorComponent,
   TsPaginatorMenuItem,
 } from '@terminus/ui/paginator';
 import { TsSortDirective } from '@terminus/ui/sort';
-import { TsTableDataSource } from '@terminus/ui/table';
+import {
+  TsColumn,
+  TsTableDataSource,
+} from '@terminus/ui/table';
 import {
   merge,
   Observable,
@@ -76,10 +80,14 @@ const COLUMNS_SOURCE_GITHUB = [
 
 export interface GithubApi {
   items: GithubIssue[];
+  // NOTE: Format controlled by GitHub
+  // eslint-disable-next-line camelcase
   total_count: number;
 }
 
 export interface GithubIssue {
+  // NOTE: Format controlled by GitHub
+  // eslint-disable-next-line camelcase
   created_at: string;
   number: string;
   state: string;
@@ -92,11 +100,10 @@ export interface GithubIssue {
 export class ExampleHttpDao {
   constructor(private http: HttpClient) {}
 
-  getRepoIssues(sort: string, order: string, page: number, perPage: number): Observable<GithubApi> {
-    const href = 'https://api.github.com/search/issues';
+  public getRepoIssues(sort: string, order: string, page: number, perPage: number): Observable<GithubApi> {
+    const href = `https://api.github.com/search/issues`;
     const requestUrl = `${href}?q=repo:GetTerminus/terminus-ui`;
     const requestParams = `&sort=${sort}&order=${order}&page=${page + 1}&per_page=${perPage}`;
-
     return this.http.get<GithubApi>(`${requestUrl}${requestParams}`);
   }
 }
@@ -108,8 +115,8 @@ export class ExampleHttpDao {
   styleUrls: ['./table.component.scss'],
 })
 export class TableComponent implements AfterViewInit {
-  allColumns = COLUMNS_SOURCE_GITHUB.slice(0);
-  displayedColumns: string[] = [
+  public allColumns = COLUMNS_SOURCE_GITHUB.slice(0);
+  public displayedColumns = [
     'title',
     'updated',
     'comments',
@@ -117,26 +124,52 @@ export class TableComponent implements AfterViewInit {
     'number',
     'labels',
     'created',
-    'id',
     'body',
+    'id',
+    'html_url',
   ];
-  exampleDatabase!: ExampleHttpDao;
-  dataSource: TsTableDataSource<GithubIssue> = new TsTableDataSource();
-  resultsLength = 0;
+  public exampleDatabase!: ExampleHttpDao;
+  public dataSource = new TsTableDataSource<GithubIssue>();
+  public resultsLength = 0;
+  public resizableColumns: TsColumn[] = [
+    {
+      name: 'title',
+      width: '400px',
+    },
+    { name: 'updated' },
+    { name: 'comments' },
+    {
+      name: 'assignee',
+      width: '160px',
+    },
+    { name: 'number' },
+    {
+      name: 'labels',
+      width: '260px',
+    },
+    { name: 'created' },
+    { name: 'id' },
+    {
+      name: 'body',
+      width: '500px',
+    },
+    { name: 'html_url' },
+  ];
 
-  @ViewChild(TsSortDirective, {static: true})
-  sort!: TsSortDirective;
+  @ViewChild(TsSortDirective, { static: true })
+  public sort!: TsSortDirective;
 
-  @ViewChild(TsPaginatorComponent, {static: true})
-  paginator!: TsPaginatorComponent;
+  @ViewChild(TsPaginatorComponent, { static: true })
+  public readonly paginator!: TsPaginatorComponent;
 
 
   constructor(
+    private domSanitizer: DomSanitizer,
     private http: HttpClient,
   ) {}
 
 
-  ngAfterViewInit(): void {
+  public ngAfterViewInit(): void {
     this.exampleDatabase = new ExampleHttpDao(this.http);
 
     // If the user changes the sort order, reset back to the first page.
@@ -171,12 +204,16 @@ export class TableComponent implements AfterViewInit {
   }
 
 
-  perPageChange(e: number): void {
+  public perPageChange(e: number): void {
     console.log('DEMO records per page changed: ', e);
   }
 
-  onPageSelect(e: TsPaginatorMenuItem): void {
+  public onPageSelect(e: TsPaginatorMenuItem): void {
     console.log('DEMO page selected: ', e);
+  }
+
+  public sanitize(content): SafeHtml {
+    return this.domSanitizer.bypassSecurityTrustHtml(content);
   }
 
 }

--- a/demo/app/components/table/table.module.ts
+++ b/demo/app/components/table/table.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
 import { TsCardModule } from '@terminus/ui/card';
+import { TsIconModule } from '@terminus/ui/icon';
 import { TsOptionModule } from '@terminus/ui/option';
 import { TsPaginatorModule } from '@terminus/ui/paginator';
 import { TsSelectModule } from '@terminus/ui/select';
@@ -21,6 +22,7 @@ import { TableComponent } from './table.component';
     FormsModule,
     TableRoutingModule,
     TsCardModule,
+    TsIconModule,
     TsOptionModule,
     TsPaginatorModule,
     TsSelectModule,

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "@angular/platform-browser": "^8.2.4",
     "@angular/platform-browser-dynamic": "^8.2.4",
     "@angular/router": "^8.2.4",
-    "@terminus/ngx-tools": "^7.2.4",
+    "@terminus/ngx-tools": "^7.2.6",
     "@terminus/ui": "14.9.3",
     "date-fns": "2.0.1",
     "jsdom": "15.1.1",

--- a/terminus-ui/autocomplete/src/autocomplete.module.ts
+++ b/terminus-ui/autocomplete/src/autocomplete.module.ts
@@ -26,6 +26,7 @@ import { TsAutocompleteComponent } from './autocomplete.component';
 
 export * from './autocomplete.component';
 export * from './autocomplete-panel/autocomplete-panel.component';
+export * from './autocomplete-panel/autocomplete-trigger.directive';
 
 @NgModule({
   imports: [

--- a/terminus-ui/scss/docs/cursors.md
+++ b/terminus-ui/scss/docs/cursors.md
@@ -38,12 +38,13 @@ This is also available as a mixin:
 
 | Value         | Meaning                                 |
 |---------------|-----------------------------------------|
-| `auto`        | Let the browser decide                  |
-| `text`        | Indicates text controls                 |
-| `pointer`     | Indicates interaction                   |
-| `not-allowed` | Indicates no available interaction      |
-| `copy`        | Indicates ability to copy               |
 | `alias`       | Indicates an alias or copy will be made |
+| `auto`        | Let the browser decide                  |
+| `col-resize`  | Indicates the ability to resize         |
+| `copy`        | Indicates ability to copy               |
 | `help`        | Indicates help is available             |
+| `not-allowed` | Indicates no available interaction      |
+| `pointer`     | Indicates interaction                   |
+| `text`        | Indicates text controls                 |
 
-Passing an invalid cursor `$type` will throw a Sass compilation warning.
+Passing an invalid cursor `$type` will throw a Sass compilation error.

--- a/terminus-ui/scss/helpers/_cursors.scss
+++ b/terminus-ui/scss/helpers/_cursors.scss
@@ -9,6 +9,8 @@ $g-cursors: (
   alias,
   /* Let the browser decide */
   auto,
+  /* Indicates ability to resize a piece of the dom; often a table column */
+  col-resize,
   /* Indicates ability to copy */
   copy,
   /* Reset to the default cursor */

--- a/terminus-ui/sort/src/sort-header.component.html
+++ b/terminus-ui/sort/src/sort-header.component.html
@@ -10,6 +10,11 @@
   >
     <ng-content></ng-content>
 
+    <ts-icon
+      class="ts-sort-header-container__icon"
+      [class.ts-sort-header-container__icon--hidden]="_isSorted()"
+    >swap_vert</ts-icon>
+
     <div
       class="ts-sort-header-arrow"
       *ngIf="_isSorted()"

--- a/terminus-ui/sort/src/sort-header.component.scss
+++ b/terminus-ui/sort/src/sort-header.component.scss
@@ -19,9 +19,27 @@ $ts-sort-header-arrow-transition: 225ms cubic-bezier(.4, 0, .2, 1);
   align-items: center;
   cursor: cursor(pointer);
   display: flex;
+  // Set up for icon
+  position: relative;
 
   .ts-sort-header-disabled & {
     cursor: cursor(default);
+  }
+
+  // Double arrow icon to signify sortability
+  &__icon {
+    opacity: 1;
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translate(40%, -36%);
+    transition: opacity 200ms ease-out 200ms;
+
+    // Sort direction shown via Angular animation so we hide this icon
+    &--hidden {
+      opacity: 0;
+      transition: opacity 100ms ease-out 100ms;
+    }
   }
 }
 

--- a/terminus-ui/sort/src/sort-header.component.ts
+++ b/terminus-ui/sort/src/sort-header.component.ts
@@ -13,10 +13,7 @@ import {
   Optional,
   ViewEncapsulation,
 } from '@angular/core';
-import {
-  CanDisable,
-  mixinDisabled,
-} from '@angular/material/core';
+import { CanDisable } from '@angular/material/core';
 import { coerceBooleanProperty } from '@terminus/ngx-tools/coercion';
 import { isBoolean } from '@terminus/ngx-tools/type-guards';
 import { untilComponentDestroyed } from '@terminus/ngx-tools/utilities';
@@ -48,12 +45,10 @@ import {
  * <example-url>https://getterminus.github.io/ui-demos-release/components/table</example-url>
  */
 @Component({
-  // NOTE(B$): This component needs to be added to another component so we need a non-element
-  // selector
+  // NOTE: This component needs to be added to another component so we need a non-element selector
   // tslint:disable: component-selector
   selector: '[ts-sort-header]',
   // tslint:enable: component-selector
-  exportAs: 'tsSortHeader',
   templateUrl: './sort-header.component.html',
   styleUrls: ['./sort-header.component.scss'],
   host: {
@@ -63,8 +58,6 @@ import {
     '(click)': '_handleClick()',
   },
   preserveWhitespaces: false,
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   // NOTE: @Inputs are defined here rather than using decorators since we are extending the @Inputs of the base class
   // tslint:disable-next-line:no-inputs-metadata-property
   inputs: ['disabled'],
@@ -74,6 +67,9 @@ import {
     tsSortAnimations.rightPointer,
     tsSortAnimations.indicatorToggle,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'tsSortHeader',
 })
 export class TsSortHeaderComponent implements TsSortableItem, CanDisable, OnInit, OnDestroy  {
   public disabled = false;

--- a/terminus-ui/sort/src/sort.directive.ts
+++ b/terminus-ui/sort/src/sort.directive.ts
@@ -73,12 +73,6 @@ export interface TsSortState {
 }
 
 
-// Boilerplate for applying mixins to TsSort.
-// export class TsSortBase {}
-// eslint-disable-next-line no-underscore-dangle
-// export const _TsSortMixinBase = mixinDisabled(TsSortBase);
-
-
 /**
  * Container for TsSortables to manage the sort state and provide default sort parameters
  *
@@ -119,7 +113,7 @@ export class TsSortDirective implements OnChanges, OnDestroy {
   /**
    * The direction to set when an TsSortable is initially sorted.
    *
-   * May be overriden by the TsSortable's sort start.
+   * May be overridden by the TsSortable's sort start.
    */
   @Input('tsSortStart')
   public start: 'asc' | 'desc' = 'asc';
@@ -142,7 +136,7 @@ export class TsSortDirective implements OnChanges, OnDestroy {
   /**
    * Whether to disable the user from clearing the sort by finishing the sort direction cycle.
    *
-   * May be overriden by the TsSortable's disable clear input.
+   * May be overridden by the TsSortable's disable clear input.
    */
   @Input('tsSortDisableClear')
   public disableClear = false;

--- a/terminus-ui/sort/src/sort.module.ts
+++ b/terminus-ui/sort/src/sort.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { TsIconModule } from '@terminus/ui/icon';
 
 import { TS_SORT_HEADER_INTL_PROVIDER } from './sort-header-intl';
 import { TsSortHeaderComponent } from './sort-header.component';
@@ -19,6 +20,7 @@ export * from './sort.directive';
 @NgModule({
   imports: [
     CommonModule,
+    TsIconModule,
   ],
   providers: [
     TS_SORT_HEADER_INTL_PROVIDER,

--- a/terminus-ui/table/package.json
+++ b/terminus-ui/table/package.json
@@ -3,8 +3,11 @@
     "lib": {
       "entryFile": "src/public-api.ts",
       "umdModuleIds": {
-        "@terminus/ngx-tools/type-guards": "terminus.ngxTools.type-guards"
+        "@terminus/ngx-tools/browser": "terminus.ngxTools.browser",
+        "@terminus/ngx-tools/type-guards": "terminus.ngxTools.type-guards",
+        "@terminus/ngx-tools/utilities": "terminus.ngxTools.utilities"
       }
     }
   }
 }
+

--- a/terminus-ui/table/package.json
+++ b/terminus-ui/table/package.json
@@ -1,7 +1,10 @@
 {
   "ngPackage": {
     "lib": {
-      "entryFile": "src/public-api.ts"
+      "entryFile": "src/public-api.ts",
+      "umdModuleIds": {
+        "@terminus/ngx-tools/type-guards": "terminus.ngxTools.type-guards"
+      }
     }
   }
 }

--- a/terminus-ui/table/src/cell.ts
+++ b/terminus-ui/table/src/cell.ts
@@ -30,6 +30,27 @@ import {
 } from './column';
 
 
+
+/**
+ * Set the column alignment styles
+ *
+ * @param column - The column definition
+ * @param renderer - The Renderer2
+ * @param elementRef - The element ref to add the class to
+ */
+export function setColumnAlignment(column: TsColumnDefDirective, renderer: Renderer2, elementRef: ElementRef): void {
+  if (column.alignment) {
+    // Verify the alignment value is allowed
+    if (tsTableColumnAlignmentTypesArray.indexOf(column.alignment) < 0 && isDevMode()) {
+      throw new TsUILibraryError(`TsCellDirective: "${column.alignment}" is not an allowed alignment.`
+        + `See "TsTableColumnAlignment" type for available options.`);
+    }
+
+    renderer.addClass(elementRef.nativeElement, 'ts-cell--align-right');
+  }
+}
+
+
 /**
  * Cell definition for the {@link TsTableComponent}.
  *
@@ -108,6 +129,11 @@ export class TsHeaderCellDirective extends CdkHeaderCell implements AfterViewIni
   private window: Window;
 
   /**
+   * Store a reference to the column
+   */
+  public column: TsColumnDefDirective;
+
+  /**
    * Store references to event listener removal functions
    */
   private resizeListenerRemover: Function;
@@ -152,6 +178,7 @@ export class TsHeaderCellDirective extends CdkHeaderCell implements AfterViewIni
     private windowService: TsWindowService,
   ) {
     super(columnDef, elementRef);
+    this.column = columnDef as TsColumnDefDirective;
     this.document = documentService.document;
     this.window = windowService.nativeWindow;
     elementRef.nativeElement.classList.add(`ts-column-${columnDef.cssClassFriendlyName}`);
@@ -160,6 +187,8 @@ export class TsHeaderCellDirective extends CdkHeaderCell implements AfterViewIni
     if (columnDef._stickyEnd) {
       elementRef.nativeElement.classList.add(`ts-table--sticky-end`);
     }
+
+    setColumnAlignment(this.column, renderer, elementRef);
   }
 
 
@@ -300,34 +329,13 @@ export class TsCellDirective extends CdkCell {
       elementRef.nativeElement.classList.add(`ts-column-no-wrap`);
     }
 
-    TsCellDirective.setColumnAlignment(this.column, renderer, elementRef);
+    setColumnAlignment(this.column, renderer, elementRef);
 
     // eslint-disable-next-line no-underscore-dangle
     if (columnDef._stickyEnd) {
       elementRef.nativeElement.classList.add(`ts-table--sticky-end`);
     }
 
-  }
-
-
-  /**
-   * Set the column alignment styles
-   *
-   * @param column - The column definition
-   * @param renderer - The Renderer2
-   * @param elementRef - The element ref to add the class to
-   */
-  private static setColumnAlignment(column: TsColumnDefDirective, renderer: Renderer2, elementRef: ElementRef): void {
-    if (column.alignment) {
-      // Verify the alignment value is allowed
-      if (tsTableColumnAlignmentTypesArray.indexOf(column.alignment) < 0 && isDevMode()) {
-        throw new TsUILibraryError(`TsCellDirective: "${column.alignment}" is not an allowed alignment.`
-          + `See "TsTableColumnAlignment" type for available options.`);
-      }
-
-      // Set inline style for text-align
-      renderer.setStyle(elementRef.nativeElement, 'textAlign', column.alignment);
-    }
   }
 
 }

--- a/terminus-ui/table/src/column.ts
+++ b/terminus-ui/table/src/column.ts
@@ -1,0 +1,87 @@
+/**
+ * Column definition for the {@link TsTableComponent}.
+ *
+ * Defines a set of cells available for a table column.
+ */
+import { CdkColumnDef } from '@angular/cdk/table';
+import {
+  Directive,
+  ElementRef,
+  Input,
+} from '@angular/core';
+
+
+/**
+ * Allowed column alignments
+ */
+export type TsTableColumnAlignment
+  = 'left'
+  | 'center'
+  | 'right'
+;
+
+/**
+ * An array of the allowed {@link TsTableColumnAlignment} for checking values
+ */
+export const tsTableColumnAlignmentTypesArray: TsTableColumnAlignment[] = [
+  'left',
+  'center',
+  'right',
+];
+
+
+@Directive({
+  selector: '[tsColumnDef]',
+  providers: [
+    {
+      provide: CdkColumnDef,
+      useExisting: TsColumnDefDirective,
+    },
+    {
+      provide: 'MAT_SORT_HEADER_COLUMN_DEF',
+      useExisting: TsColumnDefDirective,
+    },
+  ],
+})
+export class TsColumnDefDirective extends CdkColumnDef {
+  /**
+   * Define a unique name for this column
+   */
+  // NOTE: We must rename here so that the property matches the extended CdkColumnDef class
+  // tslint:disable: no-input-rename
+  @Input('tsColumnDef')
+  public name!: string;
+  // tslint:enable: no-input-rename
+
+  /**
+   * Define if a column's contents should wrap when long
+   */
+  @Input()
+  public noWrap = false;
+
+  /**
+   * Define an alignment type for the cell.
+   */
+  @Input()
+  public alignment: TsTableColumnAlignment | undefined;
+
+  /**
+   * Define if the column should stick to the start
+   */
+  @Input()
+  public sticky = false;
+
+  /**
+   * Define if a column should stick to the end
+   */
+  @Input()
+  public stickyEnd = false;
+
+
+  constructor(
+    public elementRef: ElementRef,
+  ) {
+    super();
+  }
+
+}

--- a/terminus-ui/table/src/design-decisions.md
+++ b/terminus-ui/table/src/design-decisions.md
@@ -22,3 +22,5 @@ recreate a spreadsheet.
 
 Row selection (single or multiple) is not implemented. UX needs a better use-case for this need
 before we take the time to build it in.
+
+This can be added by the consumer fairly easily.

--- a/terminus-ui/table/src/row.ts
+++ b/terminus-ui/table/src/row.ts
@@ -9,8 +9,10 @@ import {
   ChangeDetectionStrategy,
   Component,
   Directive,
+  ElementRef,
   ViewEncapsulation,
 } from '@angular/core';
+
 import { TsTableComponent } from './table.component';
 
 
@@ -29,7 +31,13 @@ import { TsTableComponent } from './table.component';
   exportAs: 'tsHeaderRow',
   preserveWhitespaces: false,
 })
-export class TsHeaderRowComponent extends CdkHeaderRow {}
+export class TsHeaderRowComponent extends CdkHeaderRow {
+  constructor(
+    public elementRef: ElementRef,
+  ) {
+    super();
+  }
+}
 
 
 /**
@@ -47,7 +55,13 @@ export class TsHeaderRowComponent extends CdkHeaderRow {}
   exportAs: 'tsRow',
   preserveWhitespaces: false,
 })
-export class TsRowComponent extends CdkRow {}
+export class TsRowComponent extends CdkRow {
+  constructor(
+    public elementRef: ElementRef,
+  ) {
+    super();
+  }
+}
 
 /**
  * Header row definition for the {@link TsTableComponent}.

--- a/terminus-ui/table/src/row.ts
+++ b/terminus-ui/table/src/row.ts
@@ -11,6 +11,7 @@ import {
   Directive,
   ViewEncapsulation,
 } from '@angular/core';
+import { TsTableComponent } from './table.component';
 
 
 /**

--- a/terminus-ui/table/src/table-data-source.spec.ts
+++ b/terminus-ui/table/src/table-data-source.spec.ts
@@ -10,19 +10,17 @@ interface Foo {
 // Additional tests for parts missed by the {@link TsTableComponent} integration test
 describe(`TsTableDataSource`, function() {
   let source: TsTableDataSource<Foo>;
-  let seededSource: TsTableDataSource<Foo>;
+  let seededSource: TsTableDataSource<any>;
 
   beforeEach(() => {
     source = new TsTableDataSource();
     seededSource = new TsTableDataSource([{ foo: 'bar' }]);
   });
 
-
   test(`should initialize an empty array if no data passed in`, () => {
     expect(source.data).toEqual([]);
     expect(seededSource.data).toEqual([{ foo: 'bar' }]);
   });
-
 
   describe(`in _renderChangesSubscription exists`, () => {
 
@@ -34,7 +32,6 @@ describe(`TsTableDataSource`, function() {
     });
 
   });
-
 
   test(`should have a disconnected() noop`, () => {
     expect(source.disconnect()).toEqual(undefined);

--- a/terminus-ui/table/src/table.component.html
+++ b/terminus-ui/table/src/table.component.html
@@ -1,3 +1,5 @@
-<ng-container headerRowOutlet></ng-container>
-<ng-container rowOutlet></ng-container>
-<ng-container footerRowOutlet></ng-container>
+<div class="ts-table__inner">
+  <ng-container headerRowOutlet></ng-container>
+  <ng-container rowOutlet></ng-container>
+  <ng-container footerRowOutlet></ng-container>
+</div>

--- a/terminus-ui/table/src/table.component.md
+++ b/terminus-ui/table/src/table.component.md
@@ -17,7 +17,11 @@
 - [Sticky header](#sticky-header)
 - [Sticky column](#sticky-column)
   - [Sticky column at end](#sticky-column-at-end)
+- [Events](#events)
+  - [Table](#table)
+  - [Cell](#cell)
 - [Full example with pagination, sorting, and dynamic columns](#full-example-with-pagination-sorting-and-dynamic-columns)
+- [Test Helpers](#test-helpers)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -58,6 +62,9 @@ const columns: TsColumn = [
 ];
 ```
 
+> NOTE: Any valid CSS string can be passed in for the width: `1rem|12px|13vw|etc`. But when the user resizes the column, the width will be
+> converted into pixels.
+
 ### 3. Define the table's rows
 
 After defining your columns, provide the header and data row templates that will be rendered out by the table. Each row needs to be given a
@@ -66,12 +73,10 @@ list of the columns that it should contain. The order of the names will define t
 NOTE: It is not required to provide a list of all the defined column names, but only the ones that you want to have rendered.
 
 ```html
-<ts-header-row *tsHeaderRowDef="['userName', 'age']">
-</ts-header-row>
+<ts-header-row *tsHeaderRowDef="['userName', 'age']"></ts-header-row>
 
 <!-- `let row;` is  exposing the row data to the template as the variable `row` -->
-<ts-row *tsRowDef="let row; columns: ['userName', 'age']">
-</ts-row>
+<ts-row *tsRowDef="let row; columns: ['userName', 'age']"></ts-row>
 ```
 
 The table component provides an array of column names built from the array of `TsColumn` definitions passed to the table. You can use this
@@ -342,7 +347,62 @@ than one column.
 </ng-container>
 ```
 
----
+## Events
+
+### Table
+
+| Event           | Description                      | Payload                     |
+|:----------------|:---------------------------------|:----------------------------|
+| `columnsChange` | Fired when any column is changed | `TsTableColumnsChangeEvent` |
+
+> NOTE: This event is not throttled or debounced and may be called repeatedly.
+
+```html
+<ts-table (columnsChange)="whenColumnsChange($event)">
+  ...
+</ts-table>
+```
+
+The `TsTableColumnsChangeEvent` structure:
+
+```typescript
+class TsTableColumnsChangeEvent {
+  constructor(
+    // The table instance that originated the event
+    public table: TsTableComponent,
+    // The updated array of columns
+    public columns: TsColumn[],
+  ) {}
+}
+```
+
+###  Cell
+
+| Event     | Description                           | Payload                   |
+|:----------|:--------------------------------------|:--------------------------|
+| `resized` | Fired when the header cell is resized | `TsHeaderCellResizeEvent` |
+
+```html
+<ng-container tsColumnDef="title">
+  <ts-header-cell *tsHeaderCellDef (resized)="whenCellIsResized($event)">
+    Title
+  </ts-header-cell>
+  <ts-cell *tsCellDef="let item">
+    {{ item.title }}
+  </ts-cell>
+</ng-container>
+```
+
+```typescript
+class TsHeaderCellResizeEvent {
+  constructor(
+    // The header cell instance that originated the event
+    public instance: TsHeaderCellDirective,
+    // The new width
+    public width: string,
+  ) {}
+}
+```
 
 
 ## Full example with pagination, sorting, and dynamic columns
@@ -547,3 +607,21 @@ export class ExampleHttpDao {
   }
 }
 ```
+
+## Test Helpers
+
+Some helpers are exposed to assist with testing. These are imported from `@terminus/ui/table/testing`;
+
+[[source]][test-helpers-src]
+
+| Function                    |
+|-----------------------------|
+| `getElements`               |
+| `getHeaderRow`              |
+| `getRows`                   |
+| `getCells`                  |
+| `getHeaderCells`            |
+| `expectTableToMatchContent` |
+
+
+[test-helpers-src]: https://github.com/GetTerminus/terminus-ui/blob/release/terminus-ui/table/testing/src/test-helpers.ts

--- a/terminus-ui/table/src/table.component.scss
+++ b/terminus-ui/table/src/table.component.scss
@@ -1,14 +1,10 @@
 @import './../../scss/helpers/color';
+@import './../../scss/helpers/cursors';
 @import './../../scss/helpers/layout';
 @import './../../scss/helpers/reset';
 @import './../../scss/helpers/spacing';
+@import './../../scss/helpers/scrollbars';
 @import './../../scss/helpers/typography';
-
-$ts-header-row-height: 56px;
-$ts-row-height: 48px;
-$ts-row-horizontal-padding: 24px;
-$ts-row-hover: rgba(color(utility, xlight), .5);
-
 
 
 //
@@ -16,33 +12,118 @@ $ts-row-hover: rgba(color(utility, xlight), .5);
 //  Table
 // @description
 //  A table component
-//
 .ts-table {
+  --table-bg: #{color(pure)};
+  --header-bg: #{color(utility, xlight)};
+  --header-text-color: #{color(utility, dark)};
+  --border-color: #{color(utility, light)};
+  $primary: color(primary);
+  --row-bg--hover: #{desaturate(lighten($primary, 66%), 70%)};
+  // NOTE: This must be above 40 as that is the number of header cell z-indexes set
+  --header-cell-sticky-z-index: 50;
+  --row-cell-sticky-z-index: 3;
+  --z-index-negative: -1;
+  --z-index-base-context: 1;
   @include reset;
   @include typography;
-  display: inline-block;
+  @include visible-scrollbars;
+  border: 1px solid var(--border-color);
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  overflow: scroll;
 
-  //
-  // Rows
-  //
+  // <div> Inner wrapper for the table
+  &__inner {
+    display: table;
+  }
+
+  // Class added to all sticky cells and rows
+  .ts-table--sticky {
+    &:not(.ts-table--sticky-end) {
+      // NOTE: Important needed to overwrite inline style
+      // stylelint-disable-next-line declaration-no-important
+      z-index: var(--row-cell-sticky-z-index) !important;
+    }
+
+    // Since the sticky cell has a right border at all times, we can remove the left border from the cell that immediately follows it.
+    + .ts-cell,
+    + .ts-header-cell {
+      border-left: none;
+    }
+  }
+
+  // Class added to all sticky-end cells
+  .ts-table--sticky-end {
+    z-index: var(--z-index-negative);
+
+    // For the last sticky cell of a row, hide the overflow so that the resize grabber doesn't create extra space past the final cell.
+    &:last-of-type {
+      &.ts-header-cell {
+        overflow: hidden;
+
+        // Move the resizer back into view since we aren't overlapping a following cell
+        .ts-header-cell__resizer {
+          transform: translateX(40%);
+        }
+      }
+    }
+  }
+
+  // Any row
+  .ts-row,
+  .ts-header-row {
+    align-items: stretch;
+    box-sizing: border-box;
+    display: table-row;
+    white-space: nowrap;
+
+    .ts-cell,
+    .ts-header-cell {
+      &:not(last-of-type) {
+        &:not(.ts-table--sticky) {
+          border-right: none;
+        }
+      }
+    }
+
+    // No border needed for the bottom of the last row since the table already has one
+    &:not(last-of-type) {
+      .ts-cell {
+        border-bottom: none;
+      }
+    }
+  }
 
   // Header row
   .ts-header-row {
     @include typography(caption);
-    color: color(utility);
-    min-height: $ts-header-row-height;
+    color: var(--header-text-color);
     transition: background-color 200ms ease-out;
-    will-change: background-color;
+    // Create base z-index context
+    z-index: var(--z-index-base-context);
+
+    .ts-table--sticky {
+      // NOTE: Important needed to overwrite inline style from the CDK
+      // stylelint-disable-next-line declaration-no-important
+      z-index: var(--header-cell-sticky-z-index) !important;
+    }
   }
 
   // Body row
   .ts-row {
-    min-height: $ts-row-height;
-    transition: background-color 200ms ease-out;
-    will-change: background-color;
+    z-index: var(--z-index-negative);
 
     &:hover {
-      background-color: $ts-row-hover;
+      .ts-cell {
+        background-color: var(--row-bg--hover);
+      }
+    }
+
+    &:first-of-type {
+      .ts-cell {
+        border-top: none;
+      }
     }
 
     // Workaround for https://goo.gl/pFmjJD in IE 11. Adds a pseudo
@@ -55,67 +136,115 @@ $ts-row-hover: rgba(color(utility, xlight), .5);
     }
   }
 
-  // Any row
-  .ts-row,
-  .ts-header-row {
-    align-items: stretch;
-    border-bottom: 1px solid color(utility, xlight);
-    box-sizing: border-box;
-    display: flex;
-  }
-
-  //
-  // Cells
-  //
-
-  // Body cell
-  .ts-cell {
-    $sticky-border: 1px solid color(utility, xlight);
-    background-color: color(pure);
-    padding: spacing(default);
-    vertical-align: middle;
-
-    &--sticky {
-      border-right: $sticky-border;
-    }
-
-    &--sticky-end {
-      border-left: $sticky-border;
-    }
-  }
-
-  // Header cell
-  .ts-header-cell {
-    background-color: color(pure);
-    padding: spacing(default);
-
-    &.ts-sortable {
-      border-bottom: 3px solid color(utility, light);
-      transition: border-bottom 200ms ease-out;
-      will-change: border-bottom-color;
-    }
-
-    // Class added when the column is sorted
-    &.ts-sort-header-sorted {
-      border-bottom-color: color(accent);
-      color: color(accent);
-    }
-  }
-
   // Any cell
   .ts-cell,
   .ts-header-cell {
     align-items: stretch;
-    background-color: color(pure);
-    flex: 1;
-    flex-basis: 6em;
+    border: 1px solid var(--border-color);
+    display: table-cell;
     min-height: inherit;
-    overflow: hidden;
+    position: relative;
     word-wrap: break-word;
 
     // Class added if a column should not wrap
     &.ts-column-no-wrap {
       white-space: nowrap;
+    }
+
+    // The table already has a border
+    &:first-of-type {
+      border-left: none;
+    }
+  }
+
+  // Body cell
+  .ts-cell {
+    background-color: var(--table-bg);
+    overflow: hidden;
+    padding: spacing(default);
+    transition: background-color 200ms ease-out;
+    vertical-align: middle;
+
+    &.ts-table--sticky {
+      background-color: var(--table-bg);
+    }
+  }
+
+  // Header cell
+  .ts-header-cell {
+    background-color: var(--header-bg);
+    border-top: none;
+    padding: spacing(default);
+    position: sticky;
+    top: 0;
+
+    // Reverse the natural z-index order so that all borders on the right created with box-shadow are visible above the following cell.
+    // Supports up to 40 columns
+    $possible-columns: 40;
+    @for $i from 1 through $possible-columns {
+      &:nth-child(#{$i}) {
+        $z: #{$possible-columns - $i};
+        z-index: $z;
+      }
+    }
+
+    // Class added when the column is sorted
+    &.ts-sort-header-sorted {
+      color: color(accent);
+    }
+
+    // Class added when the user hovers the resize column hit area
+    &.ts-cell--resizing {
+      .ts-header-cell__resizer {
+        $resizer-width: #{spacing(small, 2)};
+        opacity: 1;
+
+        &::after {
+          width: calc(#{$resizer-width} + 1px);
+        }
+      }
+    }
+
+    // <span> 'Grabber' hit area to resize a column
+    &__resizer {
+      bottom: 0;
+      cursor: cursor(col-resize);
+      display: block;
+      opacity: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+      transform: translateX(50%);
+      transition: opacity 200ms ease-out;
+      width: spacing(large);
+
+      // Visible marker for grabber
+      &::after {
+        background-color: color(primary);
+        bottom: 0;
+        content: '';
+        display: block;
+        left: 50%;
+        position: absolute;
+        top: 0;
+        transform: translateX(-50%);
+        transition: width 100ms ease-out;
+        width: 1px;
+        z-index: var(--z-index-base-context);
+      }
+
+      // Dots inside grabber
+      &::before {
+        --z-index-above-bg: 2;
+        color: color(utility, xlight);
+        content: '\2026';
+        display: block;
+        left: 50%;
+        position: absolute;
+        top: 30%;
+        transform: rotate(90deg) translateY(4%);
+        z-index: var(--z-index-above-bg);
+      }
     }
   }
 }

--- a/terminus-ui/table/src/table.component.scss
+++ b/terminus-ui/table/src/table.component.scss
@@ -1,7 +1,6 @@
 @import './../../scss/helpers/color';
 @import './../../scss/helpers/layout';
 @import './../../scss/helpers/reset';
-@import './../../scss/helpers/scrollbars';
 @import './../../scss/helpers/spacing';
 @import './../../scss/helpers/typography';
 
@@ -21,7 +20,6 @@ $ts-row-hover: rgba(color(utility, xlight), .5);
 .ts-table {
   @include reset;
   @include typography;
-  @include visible-scrollbars;
   display: inline-block;
   max-height: 100%;
 
@@ -66,7 +64,6 @@ $ts-row-hover: rgba(color(utility, xlight), .5);
     box-sizing: border-box;
     display: flex;
   }
-
 
   //
   // Cells

--- a/terminus-ui/table/src/table.component.scss
+++ b/terminus-ui/table/src/table.component.scss
@@ -14,8 +14,8 @@
 //  A table component
 .ts-table {
   --table-bg: #{color(pure)};
-  --header-bg: #{color(utility, xlight)};
-  --header-text-color: #{color(utility, dark)};
+  --header-bg: #{color(utility, light)};
+  --header-text-color: #{color(pure, dark)};
   --border-color: #{color(utility, light)};
   $primary: color(primary);
   --row-bg--hover: #{desaturate(lighten($primary, 66%), 70%)};
@@ -78,8 +78,7 @@
     display: table-row;
     white-space: nowrap;
 
-    .ts-cell,
-    .ts-header-cell {
+    .ts-cell {
       &:not(last-of-type) {
         &:not(.ts-table--sticky) {
           border-right: none;
@@ -98,7 +97,9 @@
   // Header row
   .ts-header-row {
     @include typography(caption);
+    $increased-weight: bold;
     color: var(--header-text-color);
+    font-weight: $increased-weight;
     transition: background-color 200ms ease-out;
     // Create base z-index context
     z-index: var(--z-index-base-context);
@@ -140,26 +141,34 @@
   .ts-cell,
   .ts-header-cell {
     align-items: stretch;
-    border: 1px solid var(--border-color);
     display: table-cell;
     min-height: inherit;
     position: relative;
     word-wrap: break-word;
+
+    // The table already has a border
+    &:first-of-type {
+      border-left: none;
+    }
 
     // Class added if a column should not wrap
     &.ts-column-no-wrap {
       white-space: nowrap;
     }
 
-    // The table already has a border
-    &:first-of-type {
-      border-left: none;
+    &--align-right {
+      text-align: right;
+
+      .ts-sort-header-container {
+        justify-content: flex-end;
+      }
     }
   }
 
   // Body cell
   .ts-cell {
     background-color: var(--table-bg);
+    border: 1px solid var(--border-color);
     overflow: hidden;
     padding: spacing(default);
     transition: background-color 200ms ease-out;
@@ -173,10 +182,15 @@
   // Header cell
   .ts-header-cell {
     background-color: var(--header-bg);
+    border-bottom: 1px solid color(utility);
     border-top: none;
     padding: spacing(default);
     position: sticky;
     top: 0;
+
+    &:not(first-of-type) {
+      border-left: 1px solid color(utility);
+    }
 
     // Reverse the natural z-index order so that all borders on the right created with box-shadow are visible above the following cell.
     // Supports up to 40 columns
@@ -199,27 +213,27 @@
         $resizer-width: #{spacing(small, 2)};
         opacity: 1;
 
-        &::after {
-          width: calc(#{$resizer-width} + 1px);
+        &::before {
+          width: 7px;
         }
       }
     }
 
     // <span> 'Grabber' hit area to resize a column
     &__resizer {
-      bottom: 0;
+      bottom: -1px;
       cursor: cursor(col-resize);
       display: block;
       opacity: 0;
       position: absolute;
       right: 0;
-      top: 0;
+      top: -1px;
       transform: translateX(50%);
       transition: opacity 200ms ease-out;
       width: spacing(large);
 
-      // Visible marker for grabber
-      &::after {
+      // Visible container for grabber
+      &::before {
         background-color: color(primary);
         bottom: 0;
         content: '';
@@ -234,15 +248,18 @@
       }
 
       // Dots inside grabber
-      &::before {
+      &::after {
         --z-index-above-bg: 2;
+        --grabber-icon-font-size: 14px;
         color: color(utility, xlight);
         content: '\2026';
         display: block;
+        font-size: var(--grabber-icon-font-size);
+        height: 11px;
         left: 50%;
         position: absolute;
         top: 30%;
-        transform: rotate(90deg) translateY(4%);
+        transform: rotate(90deg) translate(50%, -3px);
         z-index: var(--z-index-above-bg);
       }
     }

--- a/terminus-ui/table/src/table.component.scss
+++ b/terminus-ui/table/src/table.component.scss
@@ -21,7 +21,6 @@ $ts-row-hover: rgba(color(utility, xlight), .5);
   @include reset;
   @include typography;
   display: inline-block;
-  max-height: 100%;
 
   //
   // Rows
@@ -71,23 +70,24 @@ $ts-row-hover: rgba(color(utility, xlight), .5);
 
   // Body cell
   .ts-cell {
+    $sticky-border: 1px solid color(utility, xlight);
     background-color: color(pure);
     padding: spacing(default);
     vertical-align: middle;
 
-    &.ts-table--sticky {
-      border-right: 1px solid color(utility, xlight);
+    &--sticky {
+      border-right: $sticky-border;
+    }
+
+    &--sticky-end {
+      border-left: $sticky-border;
     }
   }
 
   // Header cell
   .ts-header-cell {
     background-color: color(pure);
-    // If the column isn't sortable, add padding here that would normally be added by
-    // `ts-sort-header-container`
-    &:not(.ts-sortable) {
-      padding: spacing(default);
-    }
+    padding: spacing(default);
 
     &.ts-sortable {
       border-bottom: 3px solid color(utility, light);
@@ -100,11 +100,6 @@ $ts-row-hover: rgba(color(utility, xlight), .5);
       border-bottom-color: color(accent);
       color: color(accent);
     }
-
-    // <div> inner container wrapping the sort control
-    .ts-sort-header-container {
-      padding: spacing(default);
-    }
   }
 
   // Any cell
@@ -112,7 +107,6 @@ $ts-row-hover: rgba(color(utility, xlight), .5);
   .ts-header-cell {
     align-items: stretch;
     background-color: color(pure);
-    display: flex;
     flex: 1;
     flex-basis: 6em;
     min-height: inherit;

--- a/terminus-ui/table/src/table.component.spec.ts
+++ b/terminus-ui/table/src/table.component.spec.ts
@@ -1,18 +1,31 @@
 /* eslint-disable no-underscore-dangle */
 import { ComponentFixture } from '@angular/core/testing';
-import { createComponent } from '@terminus/ngx-tools/testing';
+import {
+  createComponent,
+  ElementRefMock,
+} from '@terminus/ngx-tools/testing';
 import * as testComponents from '@terminus/ui/table/testing';
 // eslint-disable-next-line no-duplicate-imports
 import {
   expectTableToMatchContent,
+  getCells,
   getHeaderCells,
   getHeaderRow,
 } from '@terminus/ui/table/testing';
 
+import {
+  TsCellDirective,
+  TsColumnDefDirective,
+} from './cell';
 import { TsTableDataSource } from './table-data-source';
 import { TsTableModule } from './table.module';
 
 
+interface TestData {
+  a: string|number|undefined;
+  b: string|number|undefined;
+  c: string|number|undefined;
+}
 
 
 describe(`TsTableComponent`, function() {
@@ -34,7 +47,6 @@ describe(`TsTableComponent`, function() {
       ]);
     });
 
-
     test(`should create a table with special when row`, function() {
       const fixture = createComponent(testComponents.TableWithWhenRowApp, [], [TsTableModule]);
       fixture.detectChanges();
@@ -49,7 +61,6 @@ describe(`TsTableComponent`, function() {
       ]);
     });
   });
-
 
   describe(`with TsTableDataSource`, function() {
     let tableElement: HTMLElement;
@@ -66,7 +77,6 @@ describe(`TsTableComponent`, function() {
       dataSource = fixture.componentInstance.dataSource;
     });
 
-
     test(`should create table and display data source contents`, function() {
       expectTableToMatchContent(tableElement, [
         ['Column A', 'Column B', 'Column C'],
@@ -75,7 +85,6 @@ describe(`TsTableComponent`, function() {
         ['a_3', 'b_3', 'c_3'],
       ]);
     });
-
 
     test(`changing data should update the table contents`, function() {
       // Add data
@@ -102,13 +111,11 @@ describe(`TsTableComponent`, function() {
       ]);
     });
 
-
     test(`should add the no wrap class`, function() {
       const noWrapColumn = fixture.nativeElement.querySelector('.ts-column-no-wrap');
 
       expect(noWrapColumn).toBeTruthy();
     });
-
 
     test(`should add the min-width style`, function() {
       const column = fixture.nativeElement.querySelector('.ts-cell.ts-column-column_b');
@@ -121,12 +128,11 @@ describe(`TsTableComponent`, function() {
         headerStyle = headerColumn.style._values['flex-basis'];
       }
 
-      expect(style).toEqual('100px');
-      expect(headerStyle).toEqual('100px');
+      expect(style).toEqual('7rem');
+      expect(headerStyle).toEqual('7rem');
     });
 
   });
-
 
   describe(`table column alignment`, () => {
     let fixture: ComponentFixture<testComponents.TableColumnAlignmentTableApp>;
@@ -171,19 +177,16 @@ describe(`TsTableComponent`, function() {
 
   });
 
+  test(`should throw error for invalid alignment arguments`, () => {
+    const col = new TsColumnDefDirective();
+    Object.defineProperties(col, { alignment: { get: () => 'foo' } });
 
-  describe(`invalid alignment argument`, () => {
+    const actual = () => {
+      const test = new TsCellDirective(col, new ElementRefMock(), {} as any, {} as any);
+    };
 
-    test(`should throw warning`, () => {
-      window.console.warn = jest.fn();
-      const fixture = createComponent(testComponents.TableColumnInvalidAlignmentTableApp, [], [TsTableModule]);
-      fixture.detectChanges();
-
-      expect(window.console.warn).toHaveBeenCalled();
-    });
-
+    expect(actual).toThrowError('TsCellDirective: ');
   });
-
 
   describe(`pinned header and column`, () => {
     let fixture: ComponentFixture<testComponents.PinnedTableHeaderColumn>;
@@ -198,13 +201,16 @@ describe(`TsTableComponent`, function() {
 
     test(`should set a header to be sticky`, () => {
       const header = getHeaderRow(tableElement);
-      expect(header.classList).toContain('ts-table--sticky');
+      expect(header.classList).toContain('ts-cell--sticky');
     });
 
     test(`should set a column to be sticky`, () => {
       const headerCells = getHeaderCells(tableElement);
-      expect(headerCells[0].classList).toContain('ts-table--sticky');
-      expect(headerCells[1].classList).not.toContain('ts-table--sticky');
+      const cells = getCells(tableElement);
+      expect(headerCells[0].classList).toContain('ts-cell--sticky');
+      expect(headerCells[1].classList).not.toContain('ts-cell--sticky');
+      expect(cells[0].classList).not.toContain('ts-cell--sticky-end');
+      expect(cells[2].classList).toContain('ts-cell--sticky-end');
     });
 
   });

--- a/terminus-ui/table/src/table.component.spec.ts
+++ b/terminus-ui/table/src/table.component.spec.ts
@@ -30,7 +30,7 @@ export class TsWindowServiceMock {
 
   public get nativeWindow(): Window {
     return {
-      getComputedStyle: e => this.styleObject as CSSStyleDeclaration,
+      getComputedStyle: e => this.styleObject,
       open: noop,
       location: {
         href: 'foo/bar',
@@ -171,26 +171,16 @@ describe(`TsTableComponent`, function() {
       fixture.detectChanges();
     });
 
-    test(`should add the text-align style and set value to left`, () => {
+    test(`should add the text-align class`, () => {
       const column = fixture.nativeElement.querySelector('.ts-cell.ts-column-column_a');
 
-      let style;
-      if (column.style && column.style._values) {
-        style = column.style._values['text-align'];
-      }
-
-      expect(style).toEqual('left');
+      expect(column.classList).toContain('ts-cell--align-right');
     });
 
     test(`should NOT add the text-align style if alignment is not provided`, () => {
       const column = fixture.nativeElement.querySelector('.ts-cell.ts-column-column_b');
 
-      let style;
-      if (column.style && column.style._values) {
-        style = column.style._values['text-align'];
-      }
-
-      expect(style).toBeUndefined();
+      expect(column.classList).not.toContain('ts-cell--align-right');
     });
 
     test(`should NOT add the text-align style if alignment is not a valid alignment`, () => {

--- a/terminus-ui/table/src/table.component.ts
+++ b/terminus-ui/table/src/table.component.ts
@@ -2,8 +2,27 @@ import { CdkTable } from '@angular/cdk/table';
 import {
   ChangeDetectionStrategy,
   Component,
+  Input,
   ViewEncapsulation,
 } from '@angular/core';
+import { isUndefined } from '@terminus/ngx-tools/type-guards';
+
+
+/**
+ * The definition for a single column
+ */
+export interface TsColumn {
+  // The column name
+  name: string;
+  // The desired width as a string (eg '200px', '14rem' etc)
+  width?: string;
+  // Allow any other data properties the consumer may need
+  // tslint:disable-next-line no-any
+  [key: string]: any;
+}
+
+// Default column width = ~112px
+const DEFAULT_COLUMN_WIDTH = '7rem';
 
 
 /**
@@ -47,13 +66,40 @@ import {
     provide: CdkTable,
     useExisting: TsTableComponent,
   }],
-  exportAs: 'tsTable',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  exportAs: 'tsTable',
 })
 export class TsTableComponent<T> extends CdkTable<T> {
   /**
-   * Override CDK's class
+   * Override the sticky CSS class set by the `CdkTable`
    */
-  protected stickyCssClass = 'ts-table--sticky';
+  protected stickyCssClass = 'ts-cell--sticky';
+
+  /**
+   * Return a simple array of column names
+   *
+   * Used by {@link TsHeaderRowDefDirective} and {@link TsRowDefDirective}.
+   */
+  public get columnNames(): string[] {
+    return this.columns.map(c => c.name);
+  }
+
+  /**
+   * Define the array of columns
+   */
+  @Input()
+  public set columns(value: ReadonlyArray<TsColumn>) {
+    this._columns = value.map(column => {
+      if (isUndefined(column.width)) {
+        column.width = DEFAULT_COLUMN_WIDTH;
+      }
+      return column;
+    });
+  }
+  public get columns(): ReadonlyArray<TsColumn> {
+    return this._columns;
+  }
+  private _columns: ReadonlyArray<TsColumn>;
+
 }

--- a/terminus-ui/table/src/table.module.ts
+++ b/terminus-ui/table/src/table.module.ts
@@ -7,10 +7,10 @@ import { TsSortModule } from '@terminus/ui/sort';
 import {
   TsCellDefDirective,
   TsCellDirective,
-  TsColumnDefDirective,
   TsHeaderCellDefDirective,
   TsHeaderCellDirective,
 } from './cell';
+import { TsColumnDefDirective } from './column';
 import {
   TsHeaderRowComponent,
   TsHeaderRowDefDirective,
@@ -21,6 +21,7 @@ import { TsTableComponent } from './table.component';
 
 export * from './table-data-source';
 export * from './cell';
+export * from './column';
 export * from './row';
 export * from './table.component';
 

--- a/terminus-ui/table/testing/src/test-components.ts
+++ b/terminus-ui/table/testing/src/test-components.ts
@@ -21,7 +21,7 @@ import {
 
 @Component({
   template: `
-    <ts-table [dataSource]="dataSource">
+    <ts-table [dataSource]="dataSource" [columns]="columns">
       <ng-container tsColumnDef="column_a">
         <ts-header-cell *tsHeaderCellDef> Column A</ts-header-cell>
         <ts-cell *tsCellDef="let row">{{ row.a }}</ts-cell>
@@ -53,13 +53,17 @@ export class TableApp {
 
   public dataSource: FakeDataSource | null = new FakeDataSource();
   public columnsToRender = ['column_a', 'column_b', 'column_c'];
+  public columns = this.columnsToRender.map(c => ({
+    name: c,
+    width: '112px',
+  }));
   public isFourthRow = (i: number, _rowData: TestData) => i === 3;
 }
 
 
 @Component({
   template: `
-    <ts-table [dataSource]="dataSource">
+    <ts-table [dataSource]="dataSource" [columns]="columns">
       <ng-container tsColumnDef="column_a">
         <ts-header-cell *tsHeaderCellDef> Column A</ts-header-cell>
         <ts-cell *tsCellDef="let row">{{ row.a }}</ts-cell>
@@ -80,18 +84,20 @@ export class TableWithWhenRowApp {
   public table!: TsTableComponent<TestData>;
   public dataSource: FakeDataSource | null = new FakeDataSource();
   public isFourthRow = (i: number, _rowData: TestData) => i === 3;
+  public columnsToRender = ['column_a'];
+  public columns = this.columnsToRender.map(c => ({ name: c }));
 }
 
 
 @Component({
   template: `
-    <ts-table [dataSource]="dataSource" tsSort>
+    <ts-table [dataSource]="dataSource" [columns]="columns" tsSort>
       <ng-container tsColumnDef="column_a" noWrap="true">
         <ts-header-cell *tsHeaderCellDef ts-sort-header="a">Column A</ts-header-cell>
         <ts-cell *tsCellDef="let row">{{ row.a }}</ts-cell>
       </ng-container>
 
-      <ng-container tsColumnDef="column_b" minWidth="100px"  noWrap="true">
+      <ng-container tsColumnDef="column_b" noWrap="true">
         <ts-header-cell *tsHeaderCellDef>Column B</ts-header-cell>
         <ts-cell *tsCellDef="let row">{{ row.b }}</ts-cell>
       </ng-container>
@@ -110,6 +116,7 @@ export class ArrayDataSourceTableApp {
   public underlyingDataSource = new FakeDataSource();
   public dataSource = new TsTableDataSource<TestData>();
   public columnsToRender = ['column_a', 'column_b', 'column_c'];
+  public columns = this.columnsToRender.map(c => ({ name: c }));
 
   @ViewChild(TsTableComponent, { static: true })
   public table!: TsTableComponent<TestData>;
@@ -134,7 +141,7 @@ export class ArrayDataSourceTableApp {
 
 @Component({
   template: `
-    <ts-table [dataSource]="dataSource" tsSort>
+    <ts-table [dataSource]="dataSource" [columns]="columns" tsSort>
       <ng-container tsColumnDef="column_a" alignment="left">
         <ts-header-cell *tsHeaderCellDef>Column A</ts-header-cell>
         <ts-cell *tsCellDef="let row">{{ row.a }}</ts-cell>
@@ -159,6 +166,7 @@ export class TableColumnAlignmentTableApp {
   public underlyingDataSource = new FakeDataSource();
   public dataSource = new TsTableDataSource<TestData>();
   public columnsToRender = ['column_a', 'column_b', 'column_c'];
+  public columns = this.columnsToRender.map(c => ({ name: c }));
 
   @ViewChild(TsTableComponent, { static: true })
   public table!: TsTableComponent<TestData>;
@@ -177,7 +185,7 @@ export class TableColumnAlignmentTableApp {
 
 @Component({
   template: `
-    <ts-table [dataSource]="dataSource" tsSort>
+    <ts-table [dataSource]="dataSource" [columns]="columns" tsSort>
       <ng-container tsColumnDef="column_a" alignment="top">
         <ts-header-cell *tsHeaderCellDef>Column A</ts-header-cell>
         <ts-cell *tsCellDef="let row">{{ row.a }}</ts-cell>
@@ -191,6 +199,7 @@ export class TableColumnInvalidAlignmentTableApp {
   public underlyingDataSource = new FakeDataSource();
   public dataSource = new TsTableDataSource<TestData>();
   public columnsToRender = ['column_a'];
+  public columns = this.columnsToRender.map(c => ({ name: c }));
 
   @ViewChild(TsTableComponent, { static: true })
   public table!: TsTableComponent<TestData>;
@@ -221,7 +230,7 @@ export class TableColumnInvalidAlignmentTableApp {
         <ts-cell *tsCellDef="let row">{{ row.b }}</ts-cell>
       </ng-container>
 
-      <ng-container tsColumnDef="column_c">
+      <ng-container tsColumnDef="column_c" stickyEnd>
         <ts-header-cell *tsHeaderCellDef> Column C</ts-header-cell>
         <ts-cell *tsCellDef="let row">{{ row.c }}</ts-cell>
       </ng-container>

--- a/terminus-ui/table/testing/src/test-components.ts
+++ b/terminus-ui/table/testing/src/test-components.ts
@@ -8,6 +8,7 @@ import {
   TsSortHeaderComponent,
 } from '@terminus/ui/sort';
 import {
+  TsTableColumnsChangeEvent,
   TsTableComponent,
   TsTableDataSource,
   TsTableModule,
@@ -21,7 +22,12 @@ import {
 
 @Component({
   template: `
-    <ts-table [dataSource]="dataSource" [columns]="columns">
+    <ts-table
+      [dataSource]="dataSource"
+      [columns]="columns"
+      (columnsChange)="columnsChanged($event)"
+      #myTable="tsTable"
+    >
       <ng-container tsColumnDef="column_a">
         <ts-header-cell *tsHeaderCellDef> Column A</ts-header-cell>
         <ts-cell *tsCellDef="let row">{{ row.a }}</ts-cell>
@@ -41,8 +47,8 @@ import {
         <ts-cell *tsCellDef="let row">fourth_row</ts-cell>
       </ng-container>
 
-      <ts-header-row *tsHeaderRowDef="columnsToRender"></ts-header-row>
-      <ts-row *tsRowDef="let row; columns: columnsToRender"></ts-row>
+      <ts-header-row *tsHeaderRowDef="myTable.columnNames"></ts-header-row>
+      <ts-row *tsRowDef="let row; columns: myTable.columnNames"></ts-row>
       <ts-row *tsRowDef="let row; columns: ['special_column']; when: isFourthRow"></ts-row>
     </ts-table>
   `,
@@ -55,9 +61,10 @@ export class TableApp {
   public columnsToRender = ['column_a', 'column_b', 'column_c'];
   public columns = this.columnsToRender.map(c => ({
     name: c,
-    width: '112px',
+    width: '100px',
   }));
   public isFourthRow = (i: number, _rowData: TestData) => i === 3;
+  public columnsChanged(e: TsTableColumnsChangeEvent) {}
 }
 
 

--- a/terminus-ui/table/testing/src/test-helpers.ts
+++ b/terminus-ui/table/testing/src/test-helpers.ts
@@ -11,7 +11,6 @@ export interface TestData {
   c: string;
 }
 
-// TODO: change to my datasource - says properties connect aren't the same???
 export class FakeDataSource extends DataSource<TestData> {
   public _dataChange = new BehaviorSubject<TestData[]>([]);
   public set data(data: TestData[]) {
@@ -50,28 +49,76 @@ export class FakeDataSource extends DataSource<TestData> {
 
 
 
-// Utilities copied from CDKTable's spec
+/**
+ * Query elements within another element
+ *
+ * @param element - The element to search within
+ * @param query - The selector to query
+ * @return An array of Elements
+ */
 export function getElements(element: Element, query: string): Element[] {
   return [].slice.call(element.querySelectorAll(query));
 }
 
+/**
+ * Get the header row
+ *
+ * @param tableElement - The table element to search within
+ * @return The table element
+ */
 export function getHeaderRow(tableElement: Element): Element {
   return tableElement.querySelector('.ts-header-row')!;
 }
 
+/**
+ * Get all row elements
+ *
+ * @param tableElement - The table to search within
+ * @return An array of row elements
+ */
 export function getRows(tableElement: Element): Element[] {
   return getElements(tableElement, '.ts-row');
 }
 
+/**
+ * Get all cells within a row
+ *
+ * @param row - The row to search within
+ * @return An array of cells
+ */
 export function getCells(row: Element): Element[] {
   return row ? getElements(row, '.ts-cell') : [];
 }
 
+/**
+ * Get all header cells
+ *
+ * @param tableElement - The table to search within
+ * @return An array of header cells
+ */
 export function getHeaderCells(tableElement: Element): Element[] {
   return getElements(getHeaderRow(tableElement), '.ts-header-cell');
 }
 
-export function expectTableToMatchContent(tableElement: Element, expectedTableContent: any[]) {
+/**
+ * Get all cells within a column
+ *
+ * @param columnName - The name of the column to search for
+ * @param tableElement - The table to search within
+ * @return An array of column cells
+ */
+export function getColumnElements(columnName: string, tableElement: Element): HTMLElement[] {
+  const className = `.ts-column-${columnName}`;
+  return Array.from(tableElement.querySelectorAll(className));
+}
+
+/**
+ * Custom matcher to determine if the table's contents are correct
+ *
+ * @param tableElement - The table element to check
+ * @param expectedTableContent - The content that should be found in the table
+ */
+export function expectTableToMatchContent(tableElement: Element, expectedTableContent: any[]): void {
   const missedExpectations: string[] = [];
   function checkCellContent(cell: Element, expectedTextContent: string) {
     const actualTextContent = cell.textContent!.trim();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1433,10 +1433,10 @@
     "@typescript-eslint/eslint-plugin-tslint" "^1.10.2"
     "@typescript-eslint/parser" "^1.10.2"
 
-"@terminus/ngx-tools@^7.2.4":
-  version "7.2.4"
-  resolved "https://registry.yarnpkg.com/@terminus/ngx-tools/-/ngx-tools-7.2.4.tgz#aed4d97fadc314a313ebffd7734f921c5c6088e0"
-  integrity sha512-E7uYMpVjTGDT2ZQHLpCkM5V+arrjqax9E5CqYovvPTFzoj5w7QFdd6BaqKMkfoSSnXnChGyhRCHaZhX+CG5gog==
+"@terminus/ngx-tools@^7.2.6":
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/@terminus/ngx-tools/-/ngx-tools-7.2.6.tgz#b5f975befb787265cdd13d680fa921c9060d9b55"
+  integrity sha512-wP4o9BUp1Ejceaew5U93I/stHt3KwF15N0kE/ZvknxTSLeAgHkyIbfV5XE5VhDBgCBej8B0rI5+kng3c26TkQQ==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
Closes #1740 

- Table: User resizable columns
- Demo: Update table demo with more functionality
- CSS: Allow CSS cursor `col-resize`
- Autocomplete: Add missing export
- Sort: Better visual representation of the ability to sort

![tableResizeDemo](https://user-images.githubusercontent.com/270193/66948319-7c829e00-f022-11e9-99d5-bd012873edd0.gif)
