### PR TITLE
fix(LoginForm): remove deprecated submit emitter

### DIFF
--- a/terminus-ui/login-form/src/login-form.component.html
+++ b/terminus-ui/login-form/src/login-form.component.html
@@ -3,7 +3,7 @@
   [formGroup]="loginForm"
   fxLayout="column"
   *ngIf="showForm"
-  (keydown.enter)="loginForm?.valid && submit.emit(loginForm?.value)"
+  (keydown.enter)="loginForm?.valid && submission.emit(loginForm?.value)"
 >
 
   <ts-input
@@ -59,7 +59,6 @@
       buttonType="submit"
       [showProgress]="inProgress || isRedirecting"
       [isDisabled]="!loginForm?.valid"
-      (clicked)="submit.emit(loginForm?.value)"
       (clicked)="submission.emit(loginForm?.value)"
       tabindex="-1"
       tabIndex="4"

--- a/terminus-ui/login-form/src/login-form.component.spec.ts
+++ b/terminus-ui/login-form/src/login-form.component.spec.ts
@@ -18,6 +18,7 @@ import {
 } from '@terminus/ngx-tools/testing';
 import { sendInput } from '@terminus/ui/input/testing';
 import { TsValidatorsServiceMock } from '@terminus/ui/validators/testing';
+
 import { TsLoginFormComponent } from './login-form.component';
 import { TsLoginFormModule } from './login-form.module';
 

--- a/terminus-ui/login-form/src/login-form.component.ts
+++ b/terminus-ui/login-form/src/login-form.component.ts
@@ -186,17 +186,6 @@ export class TsLoginFormComponent implements OnChanges {
   /**
    * Emit an event on form submission
    */
-  // TODO: Rename to avoid conflict with native events: https://github.com/GetTerminus/terminus-ui/issues/1469
-  /**
-   * @deprecated Use 'submission' instead
-   */
-  // tslint:disable-next-line: no-output-native
-  @Output()
-  public readonly submit: EventEmitter<TsLoginFormResponse> = new EventEmitter();
-
-  /**
-   * Emit an event on form submission
-   */
   // tslint:disable-next-line: no-output-native
   @Output()
   public readonly submission: EventEmitter<TsLoginFormResponse> = new EventEmitter();


### PR DESCRIPTION
BREAKING CHANGE:
`submit` emitter removed in favor of `submission`

ISSUES CLOSED: #1469