### PR TITLE
TABLE 02: re-orderable columns

### DIFF
--- a/demo/app/components/table/table.component.html
+++ b/demo/app/components/table/table.component.html
@@ -14,27 +14,52 @@
 
   <span fxFlex></span>
 
-  <ts-select
-    label="Show/hide columns"
-    [allowMultiple]="true"
-    [(ngModel)]="displayedColumns"
-  >
-    <ts-option
-      [value]="column.value"
-      *ngFor="let column of allColumns"
-    >{{ column.name }}</ts-option>
-  </ts-select>
+  <ts-menu [menuItemsTemplate]="columns" theme="accent">
+    Edit Columns
+  </ts-menu>
 
+  <ng-template #columns>
+    <form
+      [formGroup]="columnsForm"
+      cdkDropList
+      cdkDropListLockAxis="y"
+      (cdkDropListDropped)="columnDropped($event)"
+    >
+      <ng-container *ngFor="let column of allPossibleColumns">
+        <!-- The menu normally closes after each interaction, so we need to stop propagation here to
+        support multiple selections while open -->
+        <ts-checkbox
+          [formControl]="column.control"
+          (click)="$event.stopPropagation()"
+          theme="accent"
+          cdkDrag
+        >
+          <span>
+            {{ column.display }}
+          </span>
+
+          <!-- Stop drag interactions from affecting the checkbox status -->
+          <ts-icon
+            cdkDragHandle
+            (click)="$event.preventDefault() && $event.stopPropagation()"
+          >drag_indicator</ts-icon>
+
+          <div *cdkDragPlaceholder></div>
+        </ts-checkbox>
+      </ng-container>
+    </form>
+  </ng-template>
 </div>
 
 
 <div class="example-container">
   <ts-table
     [dataSource]="dataSource"
-    [columns]="resizableColumns"
+    [columns]="visibleColumns"
     (columnsChange)="columnsChange($event)"
     tsSort
     tsVerticalSpacing
+    [trackBy]="trackBy"
     #myTable="tsTable"
   >
 
@@ -136,7 +161,7 @@
       </ts-header-cell>
       <ts-cell *tsCellDef="let item">
         <a href="{{ item.html_url }}">
-          <ts-icon>open_in_new</ts-icon>
+          <ts-icon theme="accent">open_in_new</ts-icon>
         </a>
       </ts-cell>
     </ng-container>

--- a/demo/app/components/table/table.module.ts
+++ b/demo/app/components/table/table.module.ts
@@ -1,9 +1,15 @@
+import { DragDropModule } from '@angular/cdk/drag-drop';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
-import { FormsModule } from '@angular/forms';
+import {
+  FormsModule,
+  ReactiveFormsModule,
+} from '@angular/forms';
 import { TsCardModule } from '@terminus/ui/card';
+import { TsCheckboxModule } from '@terminus/ui/checkbox';
 import { TsIconModule } from '@terminus/ui/icon';
+import { TsMenuModule } from '@terminus/ui/menu';
 import { TsOptionModule } from '@terminus/ui/option';
 import { TsPaginatorModule } from '@terminus/ui/paginator';
 import { TsSelectModule } from '@terminus/ui/select';
@@ -18,11 +24,15 @@ import { TableComponent } from './table.component';
 @NgModule({
   imports: [
     CommonModule,
+    DragDropModule,
     FlexLayoutModule,
     FormsModule,
+    ReactiveFormsModule,
     TableRoutingModule,
     TsCardModule,
+    TsCheckboxModule,
     TsIconModule,
+    TsMenuModule,
     TsOptionModule,
     TsPaginatorModule,
     TsSelectModule,

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,1 +1,4 @@
-module.exports = {extends: '@terminus/stylelint-config-frontend'}
+module.exports = {
+  extends: '@terminus/stylelint-config-frontend',
+  rules: { 'no-eol-whitespace': [true, { ignore: 'empty-lines' }] },
+}

--- a/terminus-ui/checkbox/src/checkbox.component.scss
+++ b/terminus-ui/checkbox/src/checkbox.component.scss
@@ -60,11 +60,20 @@ $ts-select-item-height: 3em !default;
   }
 
   // Target checkboxes inside a material menu dropdown panel
-  .mat-menu-panel & {
+  .ts-menu__panel & {
     // Match the material button line-height and spacing
     .c-checkbox {
       line-height: 2em;
       padding: 0 spacing(default);
+    }
+    
+    // By default the label doesn't fill the width even though the cursor signifies interaction
+    .mat-checkbox-layout {
+      width: 100%;
+    }
+
+    .mat-checkbox-label {
+      flex: 1;
     }
   }
 

--- a/terminus-ui/checkbox/src/checkbox.component.scss
+++ b/terminus-ui/checkbox/src/checkbox.component.scss
@@ -66,7 +66,13 @@ $ts-select-item-height: 3em !default;
       line-height: 2em;
       padding: 0 spacing(default);
     }
-    
+
+    &.cdk-drag {
+      .c-checkbox {
+        padding: 0 spacing(large, 1) 2px spacing(default);
+      }
+    }
+
     // By default the label doesn't fill the width even though the cursor signifies interaction
     .mat-checkbox-layout {
       width: 100%;

--- a/terminus-ui/menu/src/menu.component.html
+++ b/terminus-ui/menu/src/menu.component.html
@@ -7,6 +7,8 @@
     [yPosition]="menuPositionY"
     [xPosition]="menuPositionX"
     [overlapTrigger]="shouldOverlapTrigger"
+    backdropClass="ts-menu__backdrop"
+    class="ts-menu__panel"
   >
     <ng-container [ngTemplateOutlet]="menuItemsTemplate"></ng-container>
   </mat-menu>

--- a/terminus-ui/menu/src/menu.component.scss
+++ b/terminus-ui/menu/src/menu.component.scss
@@ -1,4 +1,7 @@
+@import './../../scss/helpers/color';
 @import './../../scss/helpers/cursors';
+// NOTE: Drag and drop included to add classes rather than mixins etc
+@import './../../scss/helpers/drag-and-drop';
 @import './../../scss/helpers/reset';
 @import './../../scss/helpers/spacing';
 @import './../../scss/helpers/typography';
@@ -61,12 +64,34 @@ $icon-margin: 16px;
 }
 
 
-.mat-menu-panel {
+.ts-menu__panel {
   .mat-menu-content {
     // NOTE: Universal selector needed since we don't know what the first child will be
     > * {
       display: block;
     }
+  }
+
+  // Set a background so .cdk-drag items don't have a transparent background
+  .ts-checkbox {
+    background-color: color(pure);
+  }
+
+  // Drop area
+  .cdk-drag-placeholder {
+    // Match the height of the default checkbox
+    min-height: 50px;
+  }
+}
+
+// NOTE: When being dragged the element is not nested inside the panel
+.ts-checkbox {
+  // Item being dragged
+  &.cdk-drag-preview {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    padding: 0 spacing();
   }
 }
 

--- a/terminus-ui/scss/docs/cursors.md
+++ b/terminus-ui/scss/docs/cursors.md
@@ -2,12 +2,12 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
-- [Cursors](#cursors)
+- [Cursor](#cursor)
 - [Available cursor values](#available-cursor-values)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## Cursors
+## Cursor
 
 The `cursor()` function returns the correct cursor value based on the desired type.
 
@@ -36,15 +36,18 @@ This is also available as a mixin:
 > These values are currently basically 1-to-1 with the actual CSS values. We expect this to change
 > over time as we create usage-driven names.
 
-| Value         | Meaning                                 |
-|---------------|-----------------------------------------|
-| `alias`       | Indicates an alias or copy will be made |
-| `auto`        | Let the browser decide                  |
-| `col-resize`  | Indicates the ability to resize         |
-| `copy`        | Indicates ability to copy               |
-| `help`        | Indicates help is available             |
-| `not-allowed` | Indicates no available interaction      |
-| `pointer`     | Indicates interaction                   |
-| `text`        | Indicates text controls                 |
+| Value         | Meaning                                  |
+|---------------|------------------------------------------|
+| `alias`       | Indicates an alias or copy will be made  |
+| `auto`        | Let the browser decide                   |
+| `col-resize`  | Indicates the ability to resize          |
+| `copy`        | Indicates ability to copy                |
+| `default`     | The default browser cursor               |
+| `help`        | Indicates help is available              |
+| `move`        | Indicates the ability to move an item    |
+| `not-allowed` | Indicates no available interaction       |
+| `ns-resized`  | Indicates the ability to move vertically |
+| `pointer`     | Indicates interaction                    |
+| `text`        | Indicates text controls                  |
 
 Passing an invalid cursor `$type` will throw a Sass compilation error.

--- a/terminus-ui/scss/helpers/_cursors.scss
+++ b/terminus-ui/scss/helpers/_cursors.scss
@@ -18,6 +18,8 @@ $g-cursors: (
   move,
   /* Indicates no available interaction */
   not-allowed,
+  /* Indicates the ability to move North and South */
+  ns-resize,
   /* Indicates interaction */
   pointer,
   /* Indicates text controls */

--- a/terminus-ui/scss/helpers/_cursors.scss
+++ b/terminus-ui/scss/helpers/_cursors.scss
@@ -1,8 +1,5 @@
 /**
  * The map of available cursors
- *
- * @nuclide
- * @section Cursors
  */
 $g-cursors: (
   /* Indicates an alias or copy will be made */
@@ -17,6 +14,8 @@ $g-cursors: (
   default,
   /* Indicates help is available */
   help,
+  /* Indicates the ability to drag an item */
+  move,
   /* Indicates no available interaction */
   not-allowed,
   /* Indicates interaction */
@@ -29,10 +28,8 @@ $g-cursors: (
 /**
  * Retrieve a space from the $g-cursors list.
  *
- * The primary purpose for this function is to enforce which cursors can be used.
+ * The primary purpose of this function is to enforce which cursors can be used.
  *
- * @mixin cursor
- * @section Functions
  * @param $type
  *  The cursor value to use. Default: auto
  * @example
@@ -54,8 +51,6 @@ $g-cursors: (
 /**
  * Include a custom cursor
  *
- * @mixin cursor
- * @section Mixins
  * @param $type
  *  The cursor value to use.
  * @example

--- a/terminus-ui/scss/helpers/_cursors.spec.scss
+++ b/terminus-ui/scss/helpers/_cursors.spec.scss
@@ -1,2 +1,26 @@
 @import 'true';
 @import './cursors';
+
+
+@include describe ('cursors') {
+  @include test ('should output a cursor') {
+    @include assert {
+      @include output {
+        .foo {
+          cursor: cursor(col-resize);
+        }
+        .bar {
+          cursor: cursor(help);
+        }
+      }
+      @include expect {
+        .foo {
+          cursor: col-resize;
+        }
+        .bar {
+          cursor: help;
+        }
+      }
+    }
+  }
+}

--- a/terminus-ui/scss/helpers/_drag-and-drop.scss
+++ b/terminus-ui/scss/helpers/_drag-and-drop.scss
@@ -1,0 +1,54 @@
+@import './color';
+@import './cursors';
+@import './spacing';
+
+
+// Draggable item
+.cdk-drag {
+  // Set up for drag indicator
+  position: relative;
+
+  // Animate items as they are dragged
+  &:not(.cdk-drag-placeholder) {
+    transition: transform 250ms cubic-bezier(0, 0, .2, 1);
+  }
+
+  .cdk-drag-handle {
+    color: color(utility, light);
+    cursor: cursor(ns-resize);
+    position: absolute;
+    right: spacing(small, 1);
+  }
+
+  // Container for item currently being moved
+  &.cdk-drag-preview {
+    /* stylelint-disable-next-line plugin/stylelint-no-indistinguishable-colors */
+    --shadow:
+      0 5px 5px -3px rgba(0, 0, 0, .2),
+      0 8px 10px 1px rgba(0, 0, 0, .14),
+      0 3px 14px 2px rgba(0, 0, 0, .12);
+    background-color: color(pure);
+    box-shadow: var(--shadow);
+    min-height: 50px;
+    // NOTE: Since the width is dynamically set by the CDK, we zero out the padding here and fake it with left margin below.
+    /* stylelint-disable-next-line declaration-no-important */
+    padding: 0 !important;
+
+    .c-checkbox {
+      margin-left: spacing(default);
+    }
+  }
+}
+
+// Container that represents the current drop location
+.cdk-drag-placeholder {
+  $primary: #{color(primary)};
+  // TODO: Fix hardcoded colors once the color update happens: https://github.com/GetTerminus/terminus-ui/issues/966
+  --drop-bg: #cce8d5;
+  --drop-border: #7fd09c;
+  background: var(--drop-bg);
+  border: 2px dotted var(--drop-border);
+  // NOTE: This is the cursor the user will see when dragging an item (the drag preview has `pointer-events: none`)
+  cursor: cursor(ns-resize);
+  transition: transform 250ms cubic-bezier(0, 0, .2, 1);
+}

--- a/terminus-ui/sort/src/sort-header.component.html
+++ b/terminus-ui/sort/src/sort-header.component.html
@@ -7,6 +7,7 @@
     type="button"
     [attr.aria-label]="_intl.sortButtonLabel(id)"
     [attr.disabled]="_isDisabled() || null"
+    (click)="_handleClick()"
   >
     <ng-content></ng-content>
 

--- a/terminus-ui/sort/src/sort-header.component.scss
+++ b/terminus-ui/sort/src/sort-header.component.scss
@@ -17,7 +17,6 @@ $ts-sort-header-arrow-transition: 225ms cubic-bezier(.4, 0, .2, 1);
 // <div> primary container
 .ts-sort-header-container {
   align-items: center;
-  cursor: cursor(pointer);
   display: flex;
   // Set up for icon
   position: relative;
@@ -28,11 +27,11 @@ $ts-sort-header-arrow-transition: 225ms cubic-bezier(.4, 0, .2, 1);
 
   // Double arrow icon to signify sortability
   &__icon {
-    opacity: 1;
+    opacity: 0;
     position: absolute;
     right: 0;
     top: 50%;
-    transform: translate(40%, -36%);
+    transform: translate(22%, -42%);
     transition: opacity 200ms ease-out 200ms;
 
     // Sort direction shown via Angular animation so we hide this icon
@@ -54,13 +53,24 @@ $ts-sort-header-arrow-transition: 225ms cubic-bezier(.4, 0, .2, 1);
   background: 0 0;
   border: none;
   color: currentColor;
-  cursor: inherit;
-  display: flex;
+  cursor: cursor(pointer);
+  display: block;
   font: inherit;
   outline: 0;
+  overflow: hidden;
   padding: 0 1.4em 0 0;
   // Set up for absolutely positioned arrow
   position: relative;
+  text-overflow: ellipsis;
+
+  &:focus,
+  &:hover {
+    .ts-sort-header-container__icon {
+      &:not(.ts-sort-header-container__icon--hidden) {
+        opacity: 1;
+      }
+    }
+  }
 }
 
 // <div> container for sorting arrow

--- a/terminus-ui/sort/src/sort-header.component.ts
+++ b/terminus-ui/sort/src/sort-header.component.ts
@@ -55,7 +55,6 @@ import {
     'class': 'ts-sortable',
     '[class.ts-sort-header-sorted]': '_isSorted()',
     '[class.ts-sort-header-disabled]': '_isDisabled()',
-    '(click)': '_handleClick()',
   },
   preserveWhitespaces: false,
   // NOTE: @Inputs are defined here rather than using decorators since we are extending the @Inputs of the base class

--- a/terminus-ui/sort/src/sort.spec.ts
+++ b/terminus-ui/sort/src/sort.spec.ts
@@ -131,7 +131,8 @@ class SimpleTsSortApp {
 
   sort(id: string) {
     const sortElement = this.elementRef.nativeElement.querySelector(`#${id}`);
-    dispatchMouseEvent(sortElement, 'click');
+    const sortButton = sortElement.querySelector('.ts-sort-header-button');
+    dispatchMouseEvent(sortButton, 'click');
   }
 }
 

--- a/terminus-ui/table/src/table.component.scss
+++ b/terminus-ui/table/src/table.component.scss
@@ -18,7 +18,7 @@
   --header-text-color: #{color(pure, dark)};
   --border-color: #{color(utility, light)};
   $primary: color(primary);
-  --row-bg--hover: #{desaturate(lighten($primary, 66%), 70%)};
+  --drop-bg: #{desaturate(lighten($primary, 66%), 70%)};
   // NOTE: This must be above 40 as that is the number of header cell z-indexes set
   --header-cell-sticky-z-index: 50;
   --row-cell-sticky-z-index: 3;
@@ -117,7 +117,7 @@
 
     &:hover {
       .ts-cell {
-        background-color: var(--row-bg--hover);
+        background-color: var(--drop-bg);
       }
     }
 
@@ -140,7 +140,6 @@
   // Any cell
   .ts-cell,
   .ts-header-cell {
-    align-items: stretch;
     display: table-cell;
     min-height: inherit;
     position: relative;
@@ -171,6 +170,7 @@
     border: 1px solid var(--border-color);
     overflow: hidden;
     padding: spacing(default);
+    text-overflow: ellipsis;
     transition: background-color 200ms ease-out;
     vertical-align: middle;
 

--- a/terminus-ui/table/src/table.component.spec.ts
+++ b/terminus-ui/table/src/table.component.spec.ts
@@ -18,7 +18,9 @@ import {
   getHeaderRow,
 } from '@terminus/ui/table/testing';
 
-import { TsCellDirective } from './cell';
+import {
+  TsCellDirective, TsHeaderCellDirective,
+} from './cell';
 import { TsColumnDefDirective } from './column';
 import { TsTableDataSource } from './table-data-source';
 import { TsTableModule } from './table.module';
@@ -310,6 +312,15 @@ describe(`TsTableComponent`, function() {
       fixture.detectChanges();
 
       expect(clickEvent.stopPropagation).toHaveBeenCalled();
+    });
+
+    describe(`TsHeaderCellDirective.determineWidth`, () => {
+
+      test(`should not allow column to go below minimum width`, () => {
+        expect(TsHeaderCellDirective['determineWidth'](100, -50)).toEqual(70);
+        expect(TsHeaderCellDirective['determineWidth'](140, -50)).toEqual(90);
+      });
+
     });
 
   });


### PR DESCRIPTION
Closes #1717 

- SCSS: Add cursor support for `move` and `ns-resize`
- Table: Update label styles
- Table: Support reorderable columns
- Table: Update demo to show reorderable columns
- Table: Add usage docs for resizable columns

![Kapture 2019-10-21 at 15 21 36](https://user-images.githubusercontent.com/270193/67236084-83d8eb80-f416-11e9-9861-ba7f37722b9c.gif)
