### PR TITLE
1706 simple paginator

### DIFF
--- a/demo/app/components/paginator/paginator.component.html
+++ b/demo/app/components/paginator/paginator.component.html
@@ -23,6 +23,13 @@
     Pagination is zero-based:
     <input type="checkbox" [(ngModel)]="zeroBased" (ngModelChange)="updatePages($event)">
   </label>
+
+  <br>
+
+  <label>
+    Simple mode:
+    <input type="checkbox" [(ngModel)]="simpleMode">
+  </label>
 </ts-card>
 
 
@@ -34,6 +41,7 @@
   [menuLocation]="location"
   [paginatorMessageTemplate]="myTemplate"
   [isZeroBased]="zeroBased"
+  [isSimpleMode]="simpleMode"
   recordCountTooHighMessage="Please refine your filters."
   (recordsPerPageChange)="perPageChange($event)"
   (pageSelect)="onPageSelect($event)"

--- a/demo/app/components/paginator/paginator.component.ts
+++ b/demo/app/components/paginator/paginator.component.ts
@@ -22,6 +22,7 @@ export class PaginatorComponent {
   location = 'below';
   pages: number[] = [0, 1, 2, 3, 4, 5];
   zeroBased = true;
+  simpleMode = false;
 
   @ViewChild(TsPaginatorComponent, {static: true})
   paginator!: TsPaginatorComponent;

--- a/terminus-ui/button/src/button.component.scss
+++ b/terminus-ui/button/src/button.component.scss
@@ -56,9 +56,9 @@ $shadow-transition: box-shadow $icon-transition-duration-expand $g-material-shad
 //  A button component
 //
 .ts-button {
+  $vertical-alignment-adjustment-for-inputs: 4px 0;
   @include reset;
   display: inline-block;
-  $vertical-alignment-adjustment-for-inputs: 4px 0;
   margin: $vertical-alignment-adjustment-for-inputs;
 
   // Top level styles should be nested here

--- a/terminus-ui/paginator/src/paginator.component.html
+++ b/terminus-ui/paginator/src/paginator.component.html
@@ -1,6 +1,9 @@
-<div class="c-paginator">
+<div
+  class="c-paginator qa-paginator"
+  [class.c-paginator--simple-mode]="isSimpleMode"
+>
 
-  <div fxLayout="row" fxLayoutAlign="start start">
+<div fxLayout="row" fxLayoutAlign="start start">
 
     <ts-select
       class="qa-paginator-per-page-select"
@@ -40,6 +43,7 @@
 
 
     <ts-menu
+      *ngIf="!isSimpleMode"
       class="qa-paginator-current-page-menu"
       [theme]="theme"
       [menuItemsTemplate]="menuItems"
@@ -48,6 +52,10 @@
       [ngClass]="{'disabled': menuIsDisabled(pagesArray?.length)}"
     >{{ currentPageLabel }}</ts-menu>
 
+    <div
+      class="c-paginator__current-page"
+      *ngIf="isSimpleMode"
+    >{{ currentPageLabel }}</div>
 
     <ts-tooltip [tooltipValue]="isLastPage(currentPageIndex) ? '' : nextPageTooltip">
       <ts-button
@@ -60,8 +68,11 @@
     </ts-tooltip>
 
 
-    <ts-tooltip [tooltipValue]="isLastPage(currentPageIndex) ? '' : lastPageTooltip">
-      <ts-button
+  <ts-tooltip
+    [tooltipValue]="isLastPage(currentPageIndex) ? '' : lastPageTooltip"
+    *ngIf="!isSimpleMode"
+  >
+    <ts-button
         class="qa-paginator-last-page-button"
         [theme]="theme"
         [iconName]="lastPageIcon"

--- a/terminus-ui/paginator/src/paginator.component.scss
+++ b/terminus-ui/paginator/src/paginator.component.scss
@@ -32,6 +32,21 @@
     text-align: right;
   }
 
+  // <div> container for current page in simple mode
+  .c-paginator__current-page {
+    $button-margin: 4px;
+    $width-to-match-menu: 8em;
+    display: inline-block;
+    // Center vertically
+    line-height: 2.6em;
+    // Match margin added to buttons
+    margin-right: $button-margin;
+    margin-top: $button-margin;
+    text-align: center;
+    // Add a width so the layout is close to the original
+    width: $width-to-match-menu;
+  }
+
   .ts-select,
   .ts-button {
     margin-right: spacing(small, 2);

--- a/terminus-ui/paginator/src/paginator.component.spec.ts
+++ b/terminus-ui/paginator/src/paginator.component.spec.ts
@@ -10,6 +10,8 @@ import { createComponent as createComponentInner } from '@terminus/ngx-tools/tes
 import * as TestComponents from '../testing/src/test-components';
 import {
   clickToChangePage,
+  expectAllButtonsEnabled,
+  getPaginatorInstance,
   updateRecordsPerPage,
 } from '../testing/src/test-helpers';
 import { TsPaginatorMenuItem } from './paginator.component';
@@ -68,14 +70,14 @@ describe(`TsPaginatorComponent`, function() {
     });
 
     test(`should go to the next page`, fakeAsync(() => {
-      const hostComponent = fixture.componentInstance;
       fixture.detectChanges();
       const dir = 'next';
       tick(2000);
       clickToChangePage(fixture, dir);
 
       const titleEl = fixture.debugElement.query(By.css('.qa-paginator-current-page-menu .c-button__content')).nativeElement as HTMLElement;
-      const nextPageIndex = hostComponent.paginatorComponent.nextPageIndex;
+      const instance = getPaginatorInstance(fixture);
+      const nextPageIndex = instance.nextPageIndex;
 
       expect(titleEl.textContent).toContain('11 - 20 of 100');
       expect(nextPageIndex).toEqual(1);
@@ -151,42 +153,32 @@ describe(`TsPaginatorComponent`, function() {
       fixture.detectChanges();
 
       const titleEl = fixture.debugElement.query(By.css('.qa-paginator-current-page-menu .c-button__content')).nativeElement as HTMLElement;
-      const firstPageIndex = hostComponent.paginatorComponent.firstPageIndex;
+      const instance = getPaginatorInstance(fixture);
+      const firstPageIndex = instance.firstPageIndex;
 
       expect(titleEl.textContent).toContain('1 - 10 of 100');
-      expect(hostComponent.paginatorComponent.isFirstPage(firstPageIndex)).toEqual(true);
+      expect(instance.isFirstPage(firstPageIndex)).toEqual(true);
     });
 
-    /** TODO revisit this after menu component has been converted to INT
+    /**
+     * TODO: revisit this after menu component has been converted to integration tests
      * menu:  https://github.com/GetTerminus/terminus-ui/issues/1288
      * paginator: https://github.com/GetTerminus/terminus-ui/issues/1512
-     *
-    test(`should change page when another page is selected from the menu`, () => {});
      */
+    test.todo(`should change page when another page is selected from the menu`);
 
     test(`should show all results if they fit on a page, zeroBased`, () => {
       hostComponent.totalRecords = 8;
       fixture.detectChanges();
 
       const titleEl = fixture.debugElement.query(By.css('.qa-paginator-current-page-menu .c-button__content')).nativeElement as HTMLElement;
-      const firstPageIndex = hostComponent.paginatorComponent.firstPageIndex;
+      const instance = getPaginatorInstance(fixture);
+      const firstPageIndex = instance.firstPageIndex;
 
       expect(titleEl.textContent).toContain('1 - 8 of 8');
-      expect(hostComponent.paginatorComponent.isFirstPage(firstPageIndex)).toEqual(true);
+      expect(instance.isFirstPage(firstPageIndex)).toEqual(true);
 
-      const firstPageBut =
-        fixture.debugElement.query(By.css(`.qa-paginator-first-page-button .c-button`)).nativeElement as HTMLButtonElement;
-      const previousPageBut =
-        fixture.debugElement.query(By.css(`.qa-paginator-previous-page-button .c-button`)).nativeElement as HTMLButtonElement;
-      const lastPageBut =
-        fixture.debugElement.query(By.css(`.qa-paginator-last-page-button .c-button`)).nativeElement as HTMLButtonElement;
-      const nextPageBut =
-        fixture.debugElement.query(By.css(`.qa-paginator-next-page-button .c-button`)).nativeElement as HTMLButtonElement;
-
-      expect(firstPageBut.disabled).toEqual(true);
-      expect(previousPageBut.disabled).toEqual(true);
-      expect(lastPageBut.disabled).toEqual(true);
-      expect(nextPageBut.disabled).toEqual(true);
+      expectAllButtonsEnabled(fixture);
     });
 
     test(`should show all results if they fit on a page, not zeroBased`, () => {
@@ -195,24 +187,13 @@ describe(`TsPaginatorComponent`, function() {
       fixture.detectChanges();
 
       const titleEl = fixture.debugElement.query(By.css('.qa-paginator-current-page-menu .c-button__content')).nativeElement as HTMLElement;
-      const firstPageIndex = hostComponent.paginatorComponent.firstPageIndex;
+      const instance = getPaginatorInstance(fixture);
+      const firstPageIndex = instance.firstPageIndex;
 
       expect(titleEl.textContent).toContain('1 - 8 of 8');
-      expect(hostComponent.paginatorComponent.isFirstPage(firstPageIndex)).toEqual(true);
+      expect(instance.isFirstPage(firstPageIndex)).toEqual(true);
 
-      const firstPageBut =
-        fixture.debugElement.query(By.css(`.qa-paginator-first-page-button .c-button`)).nativeElement as HTMLButtonElement;
-      const previousPageBut =
-        fixture.debugElement.query(By.css(`.qa-paginator-previous-page-button .c-button`)).nativeElement as HTMLButtonElement;
-      const lastPageBut =
-        fixture.debugElement.query(By.css(`.qa-paginator-last-page-button .c-button`)).nativeElement as HTMLButtonElement;
-      const nextPageBut =
-        fixture.debugElement.query(By.css(`.qa-paginator-next-page-button .c-button`)).nativeElement as HTMLButtonElement;
-
-      expect(firstPageBut.disabled).toEqual(true);
-      expect(previousPageBut.disabled).toEqual(true);
-      expect(lastPageBut.disabled).toEqual(true);
-      expect(nextPageBut.disabled).toEqual(true);
+      expectAllButtonsEnabled(fixture);
     });
 
     test(`should specify partial results on the last page, zeroBased`, fakeAsync(() => {
@@ -223,10 +204,11 @@ describe(`TsPaginatorComponent`, function() {
       clickToChangePage(fixture, 'last');
 
       const titleEl = fixture.debugElement.query(By.css('.qa-paginator-current-page-menu .c-button__content')).nativeElement as HTMLElement;
-      const lastPageIndex = hostComponent.paginatorComponent.lastPageIndex;
+      const instance = getPaginatorInstance(fixture);
+      const lastPageIndex = instance.lastPageIndex;
 
       expect(titleEl.textContent).toContain('91 - 95 of 95');
-      expect(hostComponent.paginatorComponent.isLastPage(lastPageIndex)).toEqual(true);
+      expect(instance.isLastPage(lastPageIndex)).toEqual(true);
     }));
 
     test(`should specify partial results on the last page, not zeroBased`, fakeAsync(() => {
@@ -237,10 +219,11 @@ describe(`TsPaginatorComponent`, function() {
       clickToChangePage(fixture, 'last');
 
       const titleEl = fixture.debugElement.query(By.css('.qa-paginator-current-page-menu .c-button__content')).nativeElement as HTMLElement;
-      const lastPageIndex = hostComponent.paginatorComponent.lastPageIndex;
+      const instance = getPaginatorInstance(fixture);
+      const lastPageIndex = instance.lastPageIndex;
 
       expect(titleEl.textContent).toContain('11 - 15 of 15');
-      expect(hostComponent.paginatorComponent.isLastPage(lastPageIndex)).toEqual(true);
+      expect(instance.isLastPage(lastPageIndex)).toEqual(true);
     }));
 
     test(`should return to current page if invalid page is requested`, () => {
@@ -249,12 +232,13 @@ describe(`TsPaginatorComponent`, function() {
         value: 10,
       };
       fixture.detectChanges();
-      hostComponent.paginatorComponent.currentPageChanged(requestedPage);
+      const instance = getPaginatorInstance(fixture);
+      instance.currentPageChanged(requestedPage);
 
       const titleEl = fixture.debugElement.query(By.css('.qa-paginator-current-page-menu .c-button__content')).nativeElement as HTMLElement;
 
       expect(titleEl.textContent).toContain('91 - 100 of 100');
-      expect(hostComponent.paginatorComponent.currentPageIndex).toEqual(hostComponent.paginatorComponent.lastPageIndex);
+      expect(instance.currentPageIndex).toEqual(instance.lastPageIndex);
     });
   });
 
@@ -262,37 +246,39 @@ describe(`TsPaginatorComponent`, function() {
 
     test(`should be zero-based by default`, () => {
       const fixture = createComponent(TestComponents.Basic);
-      const hostComponent = fixture.componentInstance;
       fixture.detectChanges();
+      const instance = getPaginatorInstance(fixture);
 
-      expect(hostComponent.paginatorComponent.isZeroBased).toEqual(true);
-      expect(hostComponent.paginatorComponent.firstPageIndex).toEqual(0);
-      expect(hostComponent.paginatorComponent.currentPageIndex).toEqual(0);
+      expect(instance.isZeroBased).toEqual(true);
+      expect(instance.firstPageIndex).toEqual(0);
+      expect(instance.currentPageIndex).toEqual(0);
     });
 
     test(`should not be zero-based when set`, () => {
       const fixture = createComponent(TestComponents.ZeroBased);
+      const instance = getPaginatorInstance(fixture);
       const hostComponent = fixture.componentInstance;
       hostComponent.isZeroBased = false;
       fixture.detectChanges();
 
-      expect(hostComponent.paginatorComponent.isZeroBased).toEqual(false);
-      expect(hostComponent.paginatorComponent.firstPageIndex).toEqual(1);
-      expect(hostComponent.paginatorComponent.currentPageIndex).toEqual(1);
+      expect(instance.isZeroBased).toEqual(false);
+      expect(instance.firstPageIndex).toEqual(1);
+      expect(instance.currentPageIndex).toEqual(1);
     });
 
     test(`should adjust lastPageIndex`, () => {
       const fixture = createComponent(TestComponents.ZeroBased);
+      const instance = getPaginatorInstance(fixture);
       const hostComponent = fixture.componentInstance;
       hostComponent.isZeroBased = true;
       fixture.detectChanges();
 
-      expect(hostComponent.paginatorComponent.lastPageIndex).toEqual(9);
+      expect(instance.lastPageIndex).toEqual(9);
 
       hostComponent.isZeroBased = false;
       fixture.detectChanges();
 
-      expect(hostComponent.paginatorComponent.lastPageIndex).toEqual(10);
+      expect(instance.lastPageIndex).toEqual(10);
     });
   });
 
@@ -301,12 +287,12 @@ describe(`TsPaginatorComponent`, function() {
 
     test(`should not display message when totalRecords is less than maxPreferredRecords`, () => {
       const fixture = createComponent(TestComponents.RecordsPerPage);
-      const hostComponent = fixture.componentInstance;
+      const instance = getPaginatorInstance(fixture);
       fixture.detectChanges();
 
       expect(fixture.debugElement.query(By.css('.c-paginator__message'))).toBeFalsy();
-      expect(hostComponent.paginatorComponent.totalRecords).toEqual(100);
-      expect(hostComponent.paginatorComponent.maxPreferredRecords).toEqual(100);
+      expect(instance.totalRecords).toEqual(100);
+      expect(instance.maxPreferredRecords).toEqual(100);
     });
 
     test(`should display message when totalRecords is greater than maxPreferredRecords`, () => {
@@ -315,10 +301,8 @@ describe(`TsPaginatorComponent`, function() {
       hostComponent.totalRecords = 125;
       fixture.detectChanges();
 
-      // check default message
       const messageEl = fixture.debugElement.query(By.css('.c-paginator__message')).nativeElement as HTMLElement;
-
-      expect(messageEl.textContent.trim()).toEqual('That\'s a lot of results! Try refining your filters for better results.');
+      expect(messageEl.textContent!.trim()).toEqual('That\'s a lot of results! Try refining your filters for better results.');
     });
 
     test(`should update message text`, () => {
@@ -329,31 +313,35 @@ describe(`TsPaginatorComponent`, function() {
 
       const messageEl = fixture.debugElement.query(By.css('.c-paginator__message')).nativeElement as HTMLElement;
 
-      expect(messageEl.textContent.trim()).toEqual('There are too many results!');
+      expect(messageEl.textContent!.trim()).toEqual('There are too many results!');
     });
 
     test(`should set maxPreferredRecords`, () => {
       const fixture = createComponent(TestComponents.RecordsCount);
       const hostComponent = fixture.componentInstance;
+      const instance = getPaginatorInstance(fixture);
       hostComponent.maxPreferredRecords = 200;
       fixture.detectChanges();
 
-      expect(hostComponent.paginatorComponent.maxPreferredRecords).toEqual(200);
+      expect(instance.maxPreferredRecords).toEqual(200);
       expect(fixture.debugElement.query(By.css('.c-paginator__message'))).toBeFalsy();
     });
   });
 
 
-/* TODO: revisit this after tooltip tests have been converted to INT
- * tooltip:   https://github.com/GetTerminus/terminus-ui/issues/1296
- * paginator: https://github.com/GetTerminus/terminus-ui/issues/1512
+  /*
+   * TODO: revisit this after tooltip tests have been converted to integration tests
+   * tooltip:   https://github.com/GetTerminus/terminus-ui/issues/1296
+   * paginator: https://github.com/GetTerminus/terminus-ui/issues/1512
+   */
   describe(`tooltips`, () => {
 
-    test(`should display default tooltips by default`, () => { });
+    test.todo(`should display default tooltips by default`);
 
-    test(`should update tooltips if set`, () => { });
+    test.todo(`should update tooltips if set`);
+
   });
- */
+
 });
 
 

--- a/terminus-ui/paginator/src/paginator.component.ts
+++ b/terminus-ui/paginator/src/paginator.component.ts
@@ -45,13 +45,13 @@ const DEFAULT_RECORDS_PER_PAGE = 10;
 /**
  * Default max records before message is shown
  */
-const DEFAULT_MAX_PREFERED_RECORDS = 100;
+const DEFAULT_MAX_PREFERRED_RECORDS = 100;
 
 /**
  * Define the default options for the records per page select menu
  */
 // eslint-disable-next-line no-magic-numbers
-const DEFAULT_RECORDS_PER_PAGE_OPTIONS: number[] = [10, 20, 50];
+const DEFAULT_RECORDS_PER_PAGE_OPTIONS = [10, 20, 50];
 
 
 /**
@@ -60,18 +60,19 @@ const DEFAULT_RECORDS_PER_PAGE_OPTIONS: number[] = [10, 20, 50];
  * @example
  * <ts-paginator
  *              currentPageIndex="1"
+ *              firstPageTooltip="View first results"
+ *              [isSimpleMode]="true"
+ *              [isZeroBased]="true"
+ *              lastPageTooltip="View last results"
  *              maxPreferredRecords="100"
  *              menuLocation="below"
- *              [isZeroBased]="true"
- *              totalRecords="1450"
+ *              nextPageTooltip="View next results"
+ *              [paginatorMessageTemplate]="myTemplate"
+ *              previousPageTooltip="View previous results"
  *              recordCountTooHighMessage="Please refine your filters."
  *              recordsPerPageChoices="[10, 20, 50]"
  *              [showRecordsPerPageSelector]="true"
- *              firstPageTooltip="View first results"
- *              previousPageTooltip="View previous results"
- *              nextPageTooltip="View next results"
- *              lastPageTooltip="View last results"
- *              [paginatorMessageTemplate]="myTemplate"
+ *              totalRecords="1450"
  *              (pageSelect)="myMethod($event)"
  *              (recordsPerPageChange)="myMethod($event)"
  * ></ts-paginator>
@@ -96,8 +97,7 @@ export class TsPaginatorComponent implements OnChanges, AfterViewInit {
   /**
    * Define the default message to show when too many records are returned
    */
-  private DEFAULT_HIGH_RECORD_MESSAGE = 'That\'s a lot of results! '
-    + 'Try refining your filters for better results.';
+  private DEFAULT_HIGH_RECORD_MESSAGE = `That's a lot of results! Try refining your filters for better results.`;
 
   /**
    * Define the icon for the 'first page' button
@@ -206,7 +206,7 @@ export class TsPaginatorComponent implements OnChanges, AfterViewInit {
    * Define how many pages exist to show a prompt about better filtering
    */
   @Input()
-  public maxPreferredRecords: number = DEFAULT_MAX_PREFERED_RECORDS;
+  public maxPreferredRecords: number = DEFAULT_MAX_PREFERRED_RECORDS;
 
   /**
    * Define the menu location (open up or open down)
@@ -263,16 +263,24 @@ export class TsPaginatorComponent implements OnChanges, AfterViewInit {
   public showRecordsPerPageSelector = true;
 
   /**
+   * Determine if the paginator should be in 'simple' mode
+   *
+   * Simple mode: Page jump dropdown is converted to plain text, jump to last page button removed.
+   */
+  @Input()
+  public isSimpleMode = false;
+
+  /**
    * Emit a page selected event
    */
   @Output()
-  public readonly pageSelect: EventEmitter<TsPaginatorMenuItem> = new EventEmitter();
+  public readonly pageSelect = new EventEmitter<TsPaginatorMenuItem>();
 
   /**
    * Emit a change event when the records per page changes
    */
   @Output()
-  public readonly recordsPerPageChange: EventEmitter<number> = new EventEmitter();
+  public readonly recordsPerPageChange = new EventEmitter<number>();
 
 
   constructor(
@@ -391,7 +399,6 @@ export class TsPaginatorComponent implements OnChanges, AfterViewInit {
       return page === (this.pagesArray.length - (this.isZeroBased ? 1 : 0));
     }
     return false;
-
   }
 
 
@@ -408,7 +415,6 @@ export class TsPaginatorComponent implements OnChanges, AfterViewInit {
       return !!((message && message.length > 0));
     }
     return false;
-
   }
 
 
@@ -441,14 +447,13 @@ export class TsPaginatorComponent implements OnChanges, AfterViewInit {
   /**
    * Determine if the records-per-page menu should be disabled
    *
-   * @param total - The total number of records
+   * @param totalRecords - The total number of records
    * @param recordsPerPageChoices - The array of counts representing how many records may be show
    * per page
    * @return A boolean representing if the records select should be disabled
    */
   public disableRecordsPerPage(totalRecords: number, recordsPerPageChoices: number[]): boolean {
     const lowestPerPage: number = Math.min.apply(Math, recordsPerPageChoices);
-
     return totalRecords < lowestPerPage;
   }
 
@@ -458,6 +463,7 @@ export class TsPaginatorComponent implements OnChanges, AfterViewInit {
    *
    * @param currentPage - The current page
    * @param pages - The array of all pages
+   * @param totalRecords - The number of total records
    * @return The string to use as the current page label
    */
   private createCurrentPageLabel(

--- a/terminus-ui/paginator/testing/src/test-components.ts
+++ b/terminus-ui/paginator/testing/src/test-components.ts
@@ -39,11 +39,7 @@ export class RecordsPerPage {
   public recordsPerPageChoices = [10, 20, 50];
   public totalRecords = 100;
   public zeroBased = true;
-
-  @ViewChild(TsPaginatorComponent, { static: true })
-  public paginatorComponent!: TsPaginatorComponent;
 }
-
 
 @Component({
   template: `
@@ -58,11 +54,7 @@ export class RecordsCount {
   public maxPreferredRecords = 50;
   public recordCountTooHighMessage = 'Too many records';
   public totalRecords = 100;
-
-  @ViewChild(TsPaginatorComponent, { static: true })
-  public paginatorComponent!: TsPaginatorComponent;
 }
-
 
 @Component({
   template: `
@@ -75,9 +67,19 @@ export class RecordsCount {
 export class ZeroBased {
   public isZeroBased: boolean | undefined;
   public totalRecords = 100;
+}
 
-  @ViewChild(TsPaginatorComponent, { static: true })
-  public paginatorComponent!: TsPaginatorComponent;
+@Component({
+  template: `
+      <ts-paginator
+        [isSimpleMode]="isSimple"
+        [totalRecords]="totalRecords"
+      ></ts-paginator>
+  `,
+})
+export class SimpleMode {
+  public isSimple = false;
+  public totalRecords = 100;
 }
 
 
@@ -92,6 +94,7 @@ export class ZeroBased {
     Basic,
     RecordsCount,
     RecordsPerPage,
+    SimpleMode,
     ZeroBased,
   ],
 })

--- a/terminus-ui/paginator/testing/src/test-helpers.ts
+++ b/terminus-ui/paginator/testing/src/test-helpers.ts
@@ -1,6 +1,9 @@
+import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { TsPaginatorComponent } from '@terminus/ui/paginator';
 import { selectOption } from '@terminus/ui/select/testing';
+import { TsUILibraryError } from '@terminus/ui/utilities';
 
 
 export type TsPaginatorPage
@@ -34,4 +37,45 @@ export function clickToChangePage(fixture: ComponentFixture<any>, dir: TsPaginat
 export function updateRecordsPerPage(fixture: ComponentFixture<any>, value: string) {
   selectOption(fixture, value);
   return fixture.whenStable();
+}
+
+/**
+ * Get the debug element for a TsPaginatorComponent
+ *
+ * @param fixture - The test fixture
+ * @return The debug element
+ */
+export function getPaginatorDebug(fixture: ComponentFixture<any>): DebugElement {
+  const debug = fixture.debugElement.query(By.directive(TsPaginatorComponent));
+  if (!debug) {
+    throw new TsUILibraryError(`'getPaginatorDebug' could not find a TsPaginatorComponent.`);
+  }
+  return debug;
+}
+
+/**
+ * Get a paginator instance from a fixture
+ *
+ * @param fixture - The component fixture
+ * @return A TsPaginatorComponent instance
+ */
+export function getPaginatorInstance(fixture: ComponentFixture<any>): TsPaginatorComponent {
+  const debug = getPaginatorDebug(fixture);
+  return debug.componentInstance;
+}
+
+export function expectAllButtonsEnabled(fixture: ComponentFixture<any>) {
+  const firstPageButton =
+    fixture.debugElement.query(By.css(`.qa-paginator-first-page-button .c-button`)).nativeElement as HTMLButtonElement;
+  const previousPageButton =
+    fixture.debugElement.query(By.css(`.qa-paginator-previous-page-button .c-button`)).nativeElement as HTMLButtonElement;
+  const lastPageButton =
+    fixture.debugElement.query(By.css(`.qa-paginator-last-page-button .c-button`)).nativeElement as HTMLButtonElement;
+  const nextPageButton =
+    fixture.debugElement.query(By.css(`.qa-paginator-next-page-button .c-button`)).nativeElement as HTMLButtonElement;
+
+  expect(firstPageButton.disabled).toEqual(true);
+  expect(previousPageButton.disabled).toEqual(true);
+  expect(lastPageButton.disabled).toEqual(true);
+  expect(nextPageButton.disabled).toEqual(true);
 }


### PR DESCRIPTION
⚠️  NOTE: Must be merged after #1764 (it is based off of that code) ⚠️ 

Since it is branched from that PR, only the last of the 6 commits listed here need to be reviewed. Last commit can be found here: https://github.com/GetTerminus/terminus-ui/pull/1765/commits/11cff609ef183244c7d8123af505056639034c33

---


- Paginator
  - Support simple mode
  - Add new test helpers
  - Convert tests to use new helpers
  - Convert commented out tests to `test.todo`s

<img width="434" alt="Screen Shot 2019-10-30 at 7 34 35 AM" src="https://user-images.githubusercontent.com/270193/67858042-a17d1380-faee-11e9-98ea-0cd92b635f1d.png">
