### PR TITLE
fix(SCSS): zindex now starting at 500

### DIFF
--- a/terminus-ui/scss/helpers/_z-index.scss
+++ b/terminus-ui/scss/helpers/_z-index.scss
@@ -28,7 +28,7 @@ $z-layers: (
  */
 @function z($name) {
   @if index($z-layers, $name) {
-    @return (length($z-layers) - index($z-layers, $name)) + 1000;
+    @return (length($z-layers) - index($z-layers, $name)) + 500;
   } @else {
     @error 'There is no item "#{$name}" in this list; choose one of: #{$z-layers}';
     @return null;


### PR DESCRIPTION
The Angular CDK uses 1000 for it's global elements. 500 keeps us well under that while being higher
than any local z-index' should require.