### PR TITLE
1819 date cohort disable change

### DIFF
--- a/demo/app/components/cohort-date-range/cohort-date-range.component.html
+++ b/demo/app/components/cohort-date-range/cohort-date-range.component.html
@@ -1,13 +1,11 @@
 <ts-card>
   <form [formGroup]="myForm" novalidate>
-
     <ts-cohort-date-range
       [cohorts]="cohorts"
       [allowCustomDates]="true"
       (cohortDateRangeChanged)="printRange($event)"
       [isDisabled]="false"
     ></ts-cohort-date-range>
-
   </form>
 
 <pre *ngIf="lastRange">

--- a/demo/app/components/cohort-date-range/cohort-date-range.component.ts
+++ b/demo/app/components/cohort-date-range/cohort-date-range.component.ts
@@ -5,13 +5,16 @@ import {
   Validators,
 } from '@angular/forms';
 import {
+  TsCohortDateRangeChanged,
+  TsDateCohort,
+} from '@terminus/ui/cohort-date-range';
+import {
   endOfDay,
   startOfDay,
   startOfMonth,
   subDays,
   subMonths,
 } from 'date-fns';
-import { TsCohortDateRangeChanged } from '@terminus/ui/cohort-date-range';
 
 const currentDate: Date = new Date();
 
@@ -35,25 +38,22 @@ export class CohortDateRangeComponent {
       ],
     }),
   });
-  public cohorts = [{
-    display: 'Last 90 days',
-    range: {
-      start: startOfDay(subDays(new Date(), 90)),
-      end: currentDate,
+  public cohorts: TsDateCohort[] = [
+    {
+      display: 'Last 90 days',
+      range: {
+        start: startOfDay(subDays(new Date(), 90)),
+        end: currentDate,
+      },
     },
-  }, {
-    display: 'Last full month',
-    range: {
-      start: startOfDay(subMonths(startOfMonth(currentDate), 1)),
-      end: endOfDay(subDays(startOfMonth(currentDate), 1)),
+    {
+      display: 'Last full month',
+      range: {
+        start: startOfDay(subMonths(startOfMonth(currentDate), 1)),
+        end: endOfDay(subDays(startOfMonth(currentDate), 1)),
+      },
     },
-  }, {
-    display: 'Custom dates',
-    range: {
-      start: '',
-      end: '',
-    },
-  }];
+  ];
   public lastRange: TsCohortDateRangeChanged | undefined;
 
 
@@ -64,7 +64,7 @@ export class CohortDateRangeComponent {
 
 
   public printRange(value: TsCohortDateRangeChanged): void {
-    console.log('DEMO: formValue: ', value);
+    // console.log('DEMO: formValue: ', value);
     this.lastRange = value;
   }
 

--- a/terminus-ui/cohort-date-range/src/cohort-date-range.component.html
+++ b/terminus-ui/cohort-date-range/src/cohort-date-range.component.html
@@ -1,7 +1,7 @@
 <ts-date-range
   class="ts-cohort-date-range__date-range"
   [dateFormGroup]="dateRangeFormGroup"
-  [isDisabled]="!allowCustomDates || isDisabled || disableDateRange"
+  [isDisabled]="!allowCustomDates || isDisabled"
   (dateRangeChange)="cohortDateRangeChange($event)"
 ></ts-date-range>
 
@@ -17,5 +17,13 @@
     *ngFor="let option of cohorts; trackBy: trackByFn"
   >
     {{ option.display }}
+  </ts-option>
+
+  <ts-option
+    *ngIf="allowCustomDates"
+    [value]="customDateCohort.range"
+    [option]="customDateCohort"
+  >
+    {{ customDateCohort.display }}
   </ts-option>
 </ts-select>

--- a/terminus-ui/cohort-date-range/src/cohort-date-range.component.md
+++ b/terminus-ui/cohort-date-range/src/cohort-date-range.component.md
@@ -7,7 +7,7 @@
   - [Event driven](#event-driven)
   - [Inputs to the component](#inputs-to-the-component)
     - [allowCustomDates](#allowcustomdates)
-    - [Disable the component](#disable-the-component)
+    - [Disable](#disable)
   - [Test Helpers](#test-helpers)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -50,7 +50,7 @@ cohorts: TsDateCohort[] = [
 ];
 ```
 
-NOTE: The keys inside the passed in `cohorts` object defined as `TsDateCohort` interface has to be in the form of 
+The keys inside the passed in `cohorts` object must match the `TsDateCohort` interface:
 
 ```typescript
 {
@@ -62,25 +62,13 @@ NOTE: The keys inside the passed in `cohorts` object defined as `TsDateCohort` i
 }
 ```
 
-NOTE: For any custom dates which allows user to select a date from date range selection would need to pass in start and end date with empty string:
-
-```typescript
-{
-  display: 'Custom Dates',
-  range: {
-    startDate: '',
-    endDate: '',
-  }
-}
-```
-
 ## Event driven
 
 Anytime the date range is changed, `cohortDateRangeChanged` is emitted.
 
 ```html
 <ts-cohort-date-range
-  [cohorts]="cohorts"
+  [cohorts]="myCohorts"
   (cohortDateRangeChanged)="printRange($event)"
 ></ts-cohort-date-range>
 ```
@@ -90,7 +78,7 @@ Anytime the date range is changed, `cohortDateRangeChanged` is emitted.
 
 ### allowCustomDates
 
-`allowCustomDates` defaults to `true`. When set to `false`, date range is readonly.
+When `allowCustomDates` is set to `false`, the date range is readonly (this defaults to `true`).
 
 ```html
 <ts-cohort-date-range
@@ -99,7 +87,9 @@ Anytime the date range is changed, `cohortDateRangeChanged` is emitted.
 ></ts-cohort-date-range>
 ```
 
-### Disable the component
+When set to `true`, a `Custom Dates` option will be added to the dropdown.
+
+### Disable
 
 The entire component can be disabled:
 

--- a/terminus-ui/cohort-date-range/src/cohort-date-range.component.spec.ts
+++ b/terminus-ui/cohort-date-range/src/cohort-date-range.component.spec.ts
@@ -56,6 +56,25 @@ describe(`TsCohortDateRangeComponent`, () => {
     cohortInstance = cohortDebugElement.componentInstance;
   }
 
+  describe(`id`, () => {
+
+    test(`should allow custom ID and fall back to UID`, () => {
+      setupComponent(testComponents.Basic);
+      const debug = getCohortDebugElement(fixture);
+      const instance: TsCohortDateRangeComponent = debug.componentInstance;
+      instance.id = 'foo';
+      fixture.detectChanges();
+
+      expect(document.getElementById('foo')).toBeTruthy();
+      expect(instance.id).toEqual('foo');
+      instance.id = undefined as any;
+      fixture.detectChanges();
+      expect(document.getElementById('foo')).toBeFalsy();
+      expect(instance.id).toEqual(expect.stringContaining('ts-cohort-date-range-'));
+    });
+
+  });
+
   describe(`allowCustomDates`, () => {
     beforeEach(() => {
       setupComponent(testComponents.Basic);

--- a/terminus-ui/cohort-date-range/src/cohort-date-range.component.spec.ts
+++ b/terminus-ui/cohort-date-range/src/cohort-date-range.component.spec.ts
@@ -39,7 +39,7 @@ function createComponent<T>(component: Type<T>, providers: Provider[] = [], impo
 
 describe(`TsCohortDateRangeComponent`, () => {
   let fixture: ComponentFixture<TsCohortDateRangeTestComponent>;
-  let hostInstance;
+  let hostInstance: TsCohortDateRangeTestComponent;
   let startInputInstance: TsInputComponent;
   let formFieldElement: HTMLElement;
   let cohortDebugElement: DebugElement;
@@ -56,12 +56,12 @@ describe(`TsCohortDateRangeComponent`, () => {
     cohortInstance = cohortDebugElement.componentInstance;
   }
 
-  describe(`allowCustomsDate`, () => {
+  describe(`allowCustomDates`, () => {
     beforeEach(() => {
       setupComponent(testComponents.Basic);
     });
 
-    test(`should have date range readonly if allowCustomsDate is false`, () => {
+    test(`should have date range readonly if false`, () => {
       hostInstance.allowCustomDates = false;
       fixture.detectChanges();
       expect(formFieldElement.classList).toContain('ts-form-field--disabled');
@@ -74,6 +74,39 @@ describe(`TsCohortDateRangeComponent`, () => {
       expect(formFieldElement.classList).not.toContain('ts-form-field--disabled');
       expect(startInputInstance.isDisabled).toBeFalsy();
     });
+  });
+
+  describe(`updateSelectOnRangeChange`, () => {
+
+    test(`should do nothing if no cohorts exist`, () => {
+      setupComponent(testComponents.Basic);
+      const debug = getCohortDebugElement(fixture);
+      const instance: TsCohortDateRangeComponent = debug.componentInstance;
+      instance.selectComponent.options.toArray = jest.fn();
+      instance.cohorts = undefined as any;
+
+      instance.dateRangeFormGroup.setValue({
+        startDate: new Date(),
+        endDate: new Date(),
+      });
+      fixture.detectChanges();
+
+      expect(instance.selectComponent.options.toArray).not.toHaveBeenCalled();
+    });
+
+    test(`should set the select to the custom cohort when the range is manually changed`, () => {
+      setupComponent(testComponents.Basic);
+      const debug = getCohortDebugElement(fixture);
+      const instance: TsCohortDateRangeComponent = debug.componentInstance;
+      const options = instance.selectComponent.options.toArray();
+      const lastOption = options[options.length - 1];
+      lastOption.select = jest.fn();
+      instance.dateRangeFormGroup.patchValue({ startDate: new Date() });
+      fixture.detectChanges();
+
+      expect(lastOption.select).toHaveBeenCalled();
+    });
+
   });
 
   describe(`select emitters`, function() {
@@ -94,19 +127,16 @@ describe(`TsCohortDateRangeComponent`, () => {
       fixture.detectChanges();
 
       expect(hostInstance.cohortDateRangeChanged).toHaveBeenCalled();
-      expect(cohortInstance.disableDateRange).toBeTruthy();
     });
 
     test(`should not emit change event and set date range enabled when there is no start/end date passed in`, () => {
       setupComponent(testComponents.Standard);
       cohortInstance.cohortDateRangeChange = jest.fn();
-      cohortInstance.disableDateRange = true;
       trigger = getSelectTriggerElement(fixture);
       event = createKeydownEvent(KEYS.DOWN_ARROW);
       trigger.dispatchEvent(event);
 
       expect(cohortInstance.cohortDateRangeChange).not.toHaveBeenCalled();
-      expect(cohortInstance.disableDateRange).toBeFalsy();
     });
 
     test(`should emit change event if date range has any changes`, () => {

--- a/terminus-ui/cohort-date-range/src/cohort-date-range.component.ts
+++ b/terminus-ui/cohort-date-range/src/cohort-date-range.component.ts
@@ -52,6 +52,9 @@ export class TsCohortDateRangeChanged {
   ) { }
 }
 
+// Unique ID for each instance
+let nextUniqueId = 0;
+
 /**
  * This is the cohort-date-range UI Component
  *
@@ -60,6 +63,7 @@ export class TsCohortDateRangeChanged {
  * <ts-cohort-date-range
  *              [allowCustomDates]="true"
  *              [cohorts]="myCohorts"
+ *              id="myID"
  *              (cohortDateRangeChange)="myFunc($event)"
  * ></ts-cohort-date-range>
  *
@@ -74,6 +78,7 @@ export class TsCohortDateRangeChanged {
     '[class.ts-cohort-date-range--disabled]': 'isDisabled',
     '[attr.disabled]': 'isDisabled',
     '[attr.aria-disabled]': 'isDisabled',
+    '[id]': 'id',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
@@ -106,6 +111,11 @@ export class TsCohortDateRangeComponent implements OnInit, OnDestroy {
   });
 
   /**
+   * Define the default component ID
+   */
+  public readonly uid = `ts-cohort-date-range-${nextUniqueId++}`;
+
+  /**
    * Get reference of dateRange from formGroup
    *
    * @internal
@@ -133,6 +143,18 @@ export class TsCohortDateRangeComponent implements OnInit, OnDestroy {
    */
   @Input()
   public cohorts!: ReadonlyArray<TsDateCohort>;
+
+  /**
+   * Define an ID for the component
+   */
+  @Input()
+  public set id(value: string) {
+    this._id = value || this.uid;
+  }
+  public get id(): string {
+    return this._id;
+  }
+  protected _id: string = this.uid;
 
   /**
    * Disable the component

--- a/terminus-ui/cohort-date-range/src/cohort-date-range.module.ts
+++ b/terminus-ui/cohort-date-range/src/cohort-date-range.module.ts
@@ -1,10 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
-
+import { ReactiveFormsModule } from '@angular/forms';
 import { TsDateRangeModule } from '@terminus/ui/date-range';
 import { TsOptionModule } from '@terminus/ui/option';
 import { TsSelectModule } from '@terminus/ui/select';
+
 import { TsCohortDateRangeComponent } from './cohort-date-range.component';
 
 export * from './cohort-date-range.component';
@@ -17,6 +18,7 @@ export * from './cohort-date-range.component';
     TsDateRangeModule,
     TsSelectModule,
     TsOptionModule,
+    ReactiveFormsModule,
   ],
   exports: [
     TsCohortDateRangeComponent,

--- a/terminus-ui/input/src/date-adapter.ts
+++ b/terminus-ui/input/src/date-adapter.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { NativeDateAdapter } from '@angular/material/core';
-import { isValid as isValidDate } from 'date-fns';
+import { isDateValue } from '@terminus/ngx-tools/coercion';
 
 
 /**
@@ -62,14 +62,12 @@ export class TsDateAdapter extends NativeDateAdapter {
    * @return Whether it is valid
    */
   public isValid(date: Date): boolean {
-    // HACK: I cannot reproduce a case where the date is valid but date.getTime is not a function.
-    // However, when dynamically updating a date in real use throws an error.
-    return isValidDate(date) && date.getTime && !isNaN(date.getTime());
+    return isDateValue(date);
   }
 
 
   /**
-   * Force a two digit string with a preceeding `0` if needed
+   * Force a two digit string with a preceding `0` if needed
    *
    * @param n - The number
    * @return The two digit number

--- a/terminus-ui/select/src/select.module.ts
+++ b/terminus-ui/select/src/select.module.ts
@@ -3,7 +3,8 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import {
-  FormsModule, ReactiveFormsModule,
+  FormsModule,
+  ReactiveFormsModule,
 } from '@angular/forms';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatRippleModule } from '@angular/material/core';


### PR DESCRIPTION
- date adapter now using our internal date check
- cohort now allows the user to adjust a cohort range (which automatically sets the select to 'custom dates')

![Kapture 2019-12-11 at 7 43 29](https://user-images.githubusercontent.com/270193/70622472-ffbb0d00-1be9-11ea-87cc-f09c2e4fcb35.gif)
