### PR TITLE
chore(CI): disable renovate auto rebase

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "rebaseStalePrs": false
 }


### PR DESCRIPTION
This was causing too many runs while we are still in the setup phase. We can re-enable once we
stabalize.