### PR TITLE
chore(CI): remove limits from renovate (temporary)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,7 @@
   "extends": [
     "config:base"
   ],
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
   "rebaseStalePrs": false
 }


### PR DESCRIPTION
This is to help us get through all of the initial PRs more quickly.
Once we stabilize the limits can be added back if needed.