### PR TITLE
fix(Chart): correctly dispose of the chart when needed

### DIFF
--- a/terminus-ui/chart/src/chart.component.md
+++ b/terminus-ui/chart/src/chart.component.md
@@ -11,6 +11,7 @@
 - [Supported chart types](#supported-chart-types)
   - [Chart Type Coercion](#chart-type-coercion)
 - [amCharts documentation](#amcharts-documentation)
+- [Test Helpers](#test-helpers)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -113,3 +114,18 @@ if (tsChartXYTypeCheck(chart)) {
 ## amCharts documentation
 
 See https://www.amcharts.com/docs/v4/ for full documentation.
+
+
+## Test Helpers
+
+Some helpers are exposed to assist with testing. These are imported from `@terminus/ui/chart/testing`;
+
+[[source]][test-helpers-src]
+
+|        Function        |
+|------------------------|
+| `getChartDebugElement` |
+| `getChartInstance`     |
+
+
+[test-helpers-src]: https://github.com/GetTerminus/terminus-ui/blob/release/terminus-ui/chart/testing/src/test-helpers.ts

--- a/terminus-ui/chart/testing/package.json
+++ b/terminus-ui/chart/testing/package.json
@@ -1,0 +1,7 @@
+{
+  "ngPackage": {
+    "lib": {
+      "entryFile": "src/public-api.ts"
+    }
+  }
+}

--- a/terminus-ui/chart/testing/src/public-api.ts
+++ b/terminus-ui/chart/testing/src/public-api.ts
@@ -1,0 +1,2 @@
+export * from './test-components';
+export * from './test-helpers';

--- a/terminus-ui/chart/testing/src/test-components.ts
+++ b/terminus-ui/chart/testing/src/test-components.ts
@@ -1,0 +1,67 @@
+import {
+  Component,
+  NgModule,
+  ViewChild,
+} from '@angular/core';
+import {
+  TsChart,
+  TsChartComponent,
+  TsChartModule,
+  TsChartVisualizationOptions,
+} from '@terminus/ui/chart';
+
+@Component({ template: `<ts-chart></ts-chart>` })
+export class SimpleHost {
+  @ViewChild(TsChartComponent, { static: true })
+  public component: TsChartComponent;
+}
+
+@Component({ template: `<ts-chart [visualization]="visualization"></ts-chart>` })
+export class VisualizationsHost {
+  public visualization: TsChartVisualizationOptions | undefined;
+
+  @ViewChild(TsChartComponent, { static: true })
+  public component: TsChartComponent;
+}
+
+@Component({
+  template: `
+     <ts-chart
+       visualization="xy"
+       (chartInitialized)="chartCreated($event)"
+     ></ts-chart>
+   `,
+})
+export class TypeChecking {
+  public chart!: TsChart;
+
+  @ViewChild(TsChartComponent, { static: true })
+  public component!: TsChartComponent;
+
+  public chartCreated(chart: TsChart): void {
+    this.chart = chart;
+  }
+}
+
+
+
+export type TsChartTestComponent
+  = SimpleHost
+  | VisualizationsHost
+  | TypeChecking
+;
+
+/**
+ * NOTE: Currently all exported Components must belong to a module. So this is our useless module to avoid the build error.
+ */
+@NgModule({
+  imports: [
+    TsChartModule,
+  ],
+  declarations: [
+    SimpleHost,
+    TypeChecking,
+    VisualizationsHost,
+  ],
+})
+export class TsChipCollectionTestComponentsModule { }

--- a/terminus-ui/chart/testing/src/test-helpers.ts
+++ b/terminus-ui/chart/testing/src/test-helpers.ts
@@ -1,0 +1,26 @@
+import { DebugElement } from '@angular/core';
+import { ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TsChartComponent } from '@terminus/ui/chart';
+
+
+/**
+ * Get the DebugElement for {@link TsChartComponent}
+ *
+ * @param fixture - The component fixture
+ * @return The DebugElement
+ */
+export function getChartDebugElement(fixture: ComponentFixture<any>): DebugElement {
+  return fixture.debugElement.query(By.directive(TsChartComponent));
+}
+
+/**
+ * Get the component instance for a {@link TsChartComponent}
+ *
+ * @param fixture - The component fixture
+ * @return The instance
+ */
+export function getChartInstance(fixture: ComponentFixture<any>): TsChartComponent {
+  const debugElement = getChartDebugElement(fixture);
+  return debugElement.componentInstance;
+}


### PR DESCRIPTION
ISSUES CLOSED: #1873

- moved test components to `test` endpoint
- added test helpers
- refactor so chart is disposed of properly before initialization