### PR TITLE
feat(Table): now dynamically sizing all columns

### DIFF
--- a/demo/app/components/selection-list/selection-list.component.html
+++ b/demo/app/components/selection-list/selection-list.component.html
@@ -27,6 +27,10 @@
     fxLayoutGap="1rem"
   >
 
+
+    <div fxLayout="row" fxLayoutAlign="center">
+
+      <div style="height: 42px; background: lightblue; " fxFlex="noshrink"></div>
     <ts-selection-list
       label="Select states"
       hint="Begin typing to search.."
@@ -53,6 +57,7 @@
         {{ state.name }}
       </ts-option>
     </ts-selection-list>
+    </div>
 
     <div>
       FormControl value: {{ complexMultipleControl.value | json }}

--- a/demo/app/components/selection-list/selection-list.module.ts
+++ b/demo/app/components/selection-list/selection-list.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
 import {
   FormsModule,
   ReactiveFormsModule,
@@ -17,6 +18,7 @@ import { SelectionListComponent } from './selection-list.component';
   imports: [
     CommonModule,
     FormsModule,
+    FlexLayoutModule,
     ReactiveFormsModule,
     SelectionListRoutingModule,
     TsCardModule,

--- a/demo/app/components/table/table.component.html
+++ b/demo/app/components/table/table.component.html
@@ -80,7 +80,7 @@
     #myTable="tsTable"
   >
 
-    <ng-container tsColumnDef="title" sticky>
+    <ng-container tsColumnDef="title">
       <th ts-header-cell *tsHeaderCellDef>
         Title
       </th>
@@ -172,7 +172,7 @@
       </td>
     </ng-container>
 
-    <ng-container tsColumnDef="html_url" stickyEnd>
+    <ng-container tsColumnDef="html_url">
       <th ts-header-cell *tsHeaderCellDef>
         View
       </th>

--- a/demo/app/components/table/table.component.scss
+++ b/demo/app/components/table/table.component.scss
@@ -1,5 +1,7 @@
 .example-container {
-  height: 400px;
+  //height: 400px;
+  overflow-y: scroll;
+  width: 100%;
 }
 
 .truncate {

--- a/terminus-ui/table/src/table-data-source.spec.ts
+++ b/terminus-ui/table/src/table-data-source.spec.ts
@@ -11,15 +11,19 @@ interface Foo {
 describe(`TsTableDataSource`, function() {
   let source: TsTableDataSource<Foo>;
   let seededSource: TsTableDataSource<any>;
+  const dataObject = { foo: 'bar' };
 
   beforeEach(() => {
     source = new TsTableDataSource();
-    seededSource = new TsTableDataSource([{ foo: 'bar' }]);
+    seededSource = new TsTableDataSource([dataObject]);
   });
 
   test(`should initialize an empty array if no data passed in`, () => {
     expect(source.data).toEqual([]);
-    expect(seededSource.data).toEqual([{ foo: 'bar' }]);
+  });
+
+  test(`should default to initial data if any is passed in`, () => {
+    expect(seededSource.data).toEqual([dataObject]);
   });
 
   describe(`in _renderChangesSubscription exists`, () => {

--- a/terminus-ui/table/src/table.component.md
+++ b/terminus-ui/table/src/table.component.md
@@ -19,6 +19,8 @@
   - [Sticky column at end](#sticky-column-at-end)
 - [Re-orderable columns](#re-orderable-columns)
 - [Density](#density)
+- [Outer border](#outer-border)
+- [Scrolling](#scrolling)
 - [Events](#events)
   - [Table](#table)
   - [Cell](#cell)
@@ -55,26 +57,24 @@ name property of each row's data.
 
 ### 2. Define the displayed columns
 
-The table expects an array of `TsColumn` definitions to manage the displayed columns and (optionally) their associated widths.
+The table expects an array of `TsColumn` definitions to manage the displayed columns and the initial column width.
 
 ```typescript
+import { TsColumn } from '@terminus/ui/table'; 
+
 const columns: TsColumn = [
-  {name: 'title', width: '200px'},
-  {name: 'body', width: '400px'},
-  // The width will default to `7rem` if not defined here
-  {name: 'link'},
+  {name: 'title', width: 200},
+  {name: 'body', width: 400},
 ];
 ```
-
-> NOTE: Any valid CSS string can be passed in for the width: `1rem|12px|13vw|etc`. But when the user resizes the column, the width will be
-> converted into pixels.
 
 ### 3. Define the table's rows
 
 After defining your columns, provide the header and data row templates that will be rendered out by the table. Each row needs to be given a
 list of the columns that it should contain. The order of the names will define the order of the cells rendered.
 
-NOTE: It is not required to provide a list of all the defined column names, but only the ones that you want to have rendered.
+NOTE: It is not required to provide a list of all the _defined_ column names, but only the ones that you want to have
+rendered.
 
 ```html
 <tr ts-header-row *tsHeaderRowDef="['userName', 'age']"></tr>
@@ -83,11 +83,11 @@ NOTE: It is not required to provide a list of all the defined column names, but 
 <tr ts-row *tsRowDef="let row; columns: ['userName', 'age']"></tr>
 ```
 
-> NOTE: `ts-header-row` & `ts-row` can both be used as a component selector or an attribute selector. We _highly_ encourage the attribute
-> usage as it is more accessible and has better support for items such as multiple sticky headers etc.
+> NOTE: `ts-header-row` & `ts-row` can both be used as a component selector or an attribute selector. Attribute usage is _highly_ encouraged  
+> as it is more accessible and has better support for items such as multiple sticky headers etc.
 
-The table component provides an array of column names built from the array of `TsColumn` definitions passed to the table. You can use this
-reference for the rows rather than defining two different arrays:
+The table component provides an array of column names built from the array of `TsColumn` definitions passed to the table. You can use this  
+ reference for the rows rather than defining two seperate arrays:
 
 ```html
 <table
@@ -107,16 +107,17 @@ reference for the rows rather than defining two different arrays:
 </table>
 ```
 
-> NOTE: `ts-table` can be used as a component selector or an attribute selector. We _highly_ encourage the attribute usage as it is more
+> NOTE: `ts-table` can be used as a component selector or an attribute selector. Attribute usage is _highly_ encouraged as it is more  
 > accessible and has better support for items such as multiple sticky headers etc.
 
 Mapping the array of names manually is also fairly simple:
 
 ```typescript
+import { TsColumn } from '@terminus/ui/table'; 
+
 const columns: TsColumn = [
-  {name: 'title', width: '200px'},
-  {name: 'body', width: '400px'},
-  {name: 'link'},
+  {name: 'title', width: 200},
+  {name: 'body', width: 400},
 ];
 const columnName = this.columns.map(c => c.name);
 ```
@@ -124,11 +125,13 @@ const columnName = this.columns.map(c => c.name);
 
 ### 4. Provide data
 
-The column and row definitions now capture how data will render - all that's left is to provide the data itself.
+The column and row definitions capture how data will render - all that's left is to provide the data itself.
 
 Create an instance of `TsTableDataSource` and set the items to be displayed to the `data` property.
 
 ```typescript
+import { TsTableDataSource } from '@terminus/ui/table'; 
+
 this.myDataSource = new TsTableDataSource();
 this.myDataSource.data = dataToRender;
 ```
@@ -142,12 +145,16 @@ this.myDataSource.data = dataToRender;
 The `DataSource` can be seeded with initial data:
 
 ```typescript
+import { TsTableDataSource } from '@terminus/ui/table'; 
+
 this.myDataSource = new TsTableDataSource(INITIAL_DATA);
 ```
 
 An interface for your table data can be passed to `TsTableDataSource` for stricter typing:
 
 ```typescript
+import { TsTableDataSource } from '@terminus/ui/table'; 
+
 export interface MyTableItem {
   name: string;
   id: number;
@@ -438,13 +445,14 @@ export class TableComponent {
     {
       display: 'Title',
       name: 'title',
-      width: '400px',
+      width: 300,
       control: new FormControl(true),
     },
     {
       display: 'Number',
       name: 'number',
       control: new FormControl(true),
+      width: 100,
     },
     // ...etc
   ];
@@ -484,6 +492,28 @@ The table supports two density settings: `comfy` (default) & `compact`.
 <table ts-table density="compact">
   ...
 </table>
+```
+
+## Outer border
+
+Since the scrolling container around the table is now a consumer responsibility, adding a border around the table also
+must be done by the consumer:
+
+```scss
+.my-table-container {
+  border: 1px solid color(utility, light);
+}
+```
+
+## Scrolling
+
+Scrolling is controlled by the containing element that is placed around the table. If persistent scrollbars are desired,
+the scrollbars mixin can be used:
+
+```scss
+.my-table-container {
+  @include visible-scrollbars;
+}
 ```
 
 
@@ -651,24 +681,27 @@ export class TableComponent implements AfterViewInit {
     {
       name: 'Created',
       value: 'created',
+      width: 100,
     },
     {
       name: 'Title',
       value: 'title',
-      width: '12.5rem',    
+      width: 100,
     },
     {
       name: 'Comments',
       value: 'comments',
-      width: '500px',
+      width: 200,
     },
     {
       name: 'State',
       value: 'state',
+      width: 100,
     },
     {
       name: 'Number',
       value: 'number',
+      width: 100,
     },
   ];
   // Default to all columns visible
@@ -720,7 +753,6 @@ export class TableComponent implements AfterViewInit {
       });
   }
 }
-
 
 export interface GithubApi {
   items: GithubIssue[];

--- a/terminus-ui/table/src/table.component.scss
+++ b/terminus-ui/table/src/table.component.scss
@@ -20,20 +20,19 @@
   --header-border-color: #{color(utility)};
   $primary: color(primary);
   --drop-bg: #{desaturate(lighten($primary, 66%), 70%)};
-  --z-index-base-context: 1;
+  --z-index-base-context: 2;
+  --z-index-resize-background: calc(var(--z-index-base-context) + 1);
+  --z-index-resize-grabber: calc(var(--z-index-resize-background) + 1);
   --cell-padding: #{spacing(default)};
   // Must be greater than 40 as that is the length of the generated z-indexes for header cells
   --sticky-end-z: 50;
   @include reset;
   @include typography;
-  @include visible-scrollbars;
-  border: 1px solid var(--border-color);
   border-collapse: separate;
   border-spacing: unset;
-  display: block;
   max-height: 100%;
-  max-width: 100%;
-  overflow: scroll;
+  table-layout: fixed;
+  width: 100%;
 
   &.ts-table--compact {
     --cell-padding: #{spacing(small, 2)};
@@ -56,15 +55,25 @@
 
   // Header row
   .ts-header-row {
-    @include typography(caption);
     $increased-weight: bold;
+    @include typography(caption);
+    // NOTE: Adding the background here ensures that no white area is seen during manual column resize.
+    background-color: var(--header-bg);
     color: var(--header-text-color);
     font-weight: $increased-weight;
     transition: background-color 200ms ease-out;
+
+    // NOTE: This is required for the tr background color to be visible.
+    &::after {
+      content: '';
+      display: block;
+    }
   }
 
   // Body row
   .ts-row {
+    border-bottom: 1px solid var(--border-color);
+
     &:hover {
       .ts-cell {
         background-color: var(--drop-bg);
@@ -84,8 +93,6 @@
   // Any cell
   .ts-cell,
   .ts-header-cell {
-    border-bottom: 1px solid var(--border-color);
-    border-right: 1px solid var(--border-color);
     min-height: inherit;
     position: relative;
     text-align: left;
@@ -135,6 +142,31 @@
     border-color: var(--header-border-color);
     padding: var(--cell-padding);
 
+    &:not(:last-of-type) {
+      position: relative;
+
+      &::after {
+        background-color: var(--header-border-color);
+        bottom: 0;
+        content: '';
+        display: block;
+        left: calc(100% - 1px);
+        opacity: 0;
+        position: absolute;
+        top: 0;
+        transition: opacity 200ms ease-out;
+        width: 1px;
+        z-index: var(--z-index-base-context);
+      }
+
+      &:focus,
+      &:hover {
+        &::after {
+          opacity: 1;
+        }
+      }
+    }
+
     // Class added when the column is sorted
     &.ts-sort-header-sorted {
       color: color(accent);
@@ -162,7 +194,6 @@
     // Class added when the user hovers the resize column hit area
     &.ts-cell--resizing {
       .ts-header-cell__resizer {
-        $resizer-width: #{spacing(small, 2)};
         opacity: 1;
 
         &::before {
@@ -183,6 +214,7 @@
       transform: translateX(50%);
       transition: opacity 200ms ease-out;
       width: spacing(large);
+      z-index: calc(var(--z-index-resize-background));
 
       // Visible container for grabber
       &::before {
@@ -196,12 +228,10 @@
         transform: translateX(-50%);
         transition: width 100ms ease-out;
         width: 1px;
-        z-index: var(--z-index-base-context);
       }
 
       // Dots inside grabber
       &::after {
-        --z-index-above-bg: 2;
         --grabber-icon-font-size: 14px;
         color: color(utility, xlight);
         content: '\2026';
@@ -212,7 +242,7 @@
         position: absolute;
         top: 30%;
         transform: rotate(90deg) translate(50%, -3px);
-        z-index: var(--z-index-above-bg);
+        z-index: var(--z-index-resize-grabber);
       }
     }
   }

--- a/terminus-ui/table/src/table.component.ts
+++ b/terminus-ui/table/src/table.component.ts
@@ -1,11 +1,14 @@
 import { Directionality } from '@angular/cdk/bidi';
 import { Platform } from '@angular/cdk/platform';
+import { ViewportRuler } from '@angular/cdk/scrolling';
 import {
   CDK_TABLE_TEMPLATE,
   CdkTable,
 } from '@angular/cdk/table';
 import { DOCUMENT } from '@angular/common';
 import {
+  AfterContentChecked,
+  AfterContentInit,
   AfterViewChecked,
   Attribute,
   ChangeDetectionStrategy,
@@ -26,8 +29,11 @@ import {
   Renderer2,
   ViewEncapsulation,
 } from '@angular/core';
-import { isUndefined } from '@terminus/ngx-tools/type-guards';
-import { debounce } from '@terminus/ngx-tools/utilities';
+import { TsWindowService } from '@terminus/ngx-tools/browser';
+import {
+  debounce,
+  untilComponentDestroyed,
+} from '@terminus/ngx-tools/utilities';
 import {
   defer,
   merge,
@@ -35,6 +41,7 @@ import {
   Subscription,
 } from 'rxjs';
 import {
+  pluck,
   switchMap,
   take,
 } from 'rxjs/operators';
@@ -42,7 +49,6 @@ import {
 import {
   TsHeaderCellDirective,
   TsHeaderCellResizeEvent,
-  TsHeaderCellResizeHoverEvent,
 } from './cell';
 import { TsRowComponent } from './row';
 
@@ -53,8 +59,8 @@ import { TsRowComponent } from './row';
 export interface TsColumn {
   // The column name
   name: string;
-  // The desired width as a string (eg '200px', '14rem' etc)
-  width?: string;
+  // The desired width in pixels as a integer (eg '200')
+  width: number;
   // Allow any other data properties the consumer may need
   // tslint:disable-next-line no-any
   [key: string]: any;
@@ -69,17 +75,10 @@ export type TsTableDensity
 ;
 
 /**
- * Default column width.
- *
- * NOTE: Columns will only expand until all cell content is visible for the entire column. So we are defaulting to a very large number and
- * rely on the consumer to constrain width where needed.
- */
-const DEFAULT_COLUMN_WIDTH = '1000px';
-
-/**
  * The default debounce delay for column sizing update calls
  */
 const COLUMN_DEBOUNCE_DELAY = 100;
+const VIEWPORT_DEBOUNCE = 500;
 
 /**
  * The payload for a columns change event
@@ -93,16 +92,19 @@ export class TsTableColumnsChangeEvent {
   ) {}
 }
 
+// Unique ID for each instance
+let nextUniqueId = 0;
+
 
 /**
  * The primary data table implementation
  *
  * @example
  *  <ts-table
- *    [dataSource]="dataSource"
  *    [columns]="myColumns"
- *    [trackBy]="myTrackByFn"
+ *    [dataSource]="dataSource"
  *    [multiTemplateDataRows]="false"
+ *    [trackBy]="myTrackByFn"
  *    (columnsChange)="columnsWereUpdated($event)
  *    #myTable="tsTable"
  *  >
@@ -138,6 +140,7 @@ export class TsTableColumnsChangeEvent {
     'class': 'ts-table',
     '[class.ts-table--comfy]': 'density === "comfy"',
     '[class.ts-table--compact]': 'density === "compact"',
+    '[id]': 'id',
   },
   providers: [{
     provide: CdkTable,
@@ -148,7 +151,30 @@ export class TsTableColumnsChangeEvent {
   exportAs: 'tsTable',
 })
 // tslint:disable-next-line no-any
-export class TsTableComponent<T = any> extends CdkTable<T> implements OnInit, AfterViewChecked, OnDestroy {
+export class TsTableComponent<T = any> extends CdkTable<T> implements
+  OnInit,
+  AfterViewChecked,
+  AfterContentInit,
+  AfterContentChecked,
+  OnDestroy {
+
+  /**
+   * Combined stream of all of the columns resized events
+   */
+  public readonly columnResizeChanges$: Observable<TsHeaderCellDirective> = defer(() => {
+    if (this.headerCells && this.headerCells.length) {
+      return merge<TsHeaderCellResizeEvent>(...this.headerCells.map(cell => cell.resized)).pipe(
+        pluck('instance'),
+        untilComponentDestroyed(this),
+      );
+    }
+
+    // If there are any subscribers before `ngAfterViewInit`, the `autocomplete` will be undefined.
+    // In that case, return a stream that we'll replace with the real one once everything is in place.
+    return this.ngZone.onStable
+      .asObservable()
+      .pipe(take(1), switchMap(() => this.columnResizeChanges$));
+  });
 
   /**
    * Create a debounced function to update CDK sticky styles
@@ -156,45 +182,34 @@ export class TsTableComponent<T = any> extends CdkTable<T> implements OnInit, Af
   public debouncedStickyColumnUpdate = debounce(this.updateStickyColumnStyles, COLUMN_DEBOUNCE_DELAY);
 
   /**
-   * Store subscription references for header cell functionality
+   * Store the header cell subscription
    */
-  private headerCellResize$: Subscription;
-  private headerCellHover$: Subscription;
+  private headerCellSubscription: Subscription;
 
   /**
-   * An observable of all header cell resize events
+   * Store a mutable array of internal column definitions
    */
-  public readonly headerCellResizes: Observable<TsHeaderCellResizeEvent> | Observable<{}> = defer(() => {
-    if (this.headerCells && this.headerCells.length) {
-      return merge(...this.headerCells.map(cell => cell.resized));
-    }
-
-    // If there are any subscribers before `ngAfterViewInit`, `headerCells` may be undefined.
-    // In that case, return a stream that we'll replace with the real one once everything is in place.
-    return this.ngZone.onStable
-      .asObservable()
-      .pipe(take(1), switchMap(() => this.headerCellResizes));
-  });
-
-  /**
-   * An observable of all header cell hover events
-   */
-  public readonly headerCellHovers: Observable<boolean> | Observable<{}> = defer(() => {
-    if (this.headerCells && this.headerCells.length) {
-      return merge(...this.headerCells.map(cell => cell.hovered));
-    }
-
-    // If there are any subscribers before `ngAfterViewInit`, `headerCells` may be undefined.
-    // In that case, return a stream that we'll replace with the real one once everything is in place.
-    return this.ngZone.onStable
-      .asObservable()
-      .pipe(take(1), switchMap(() => this.headerCellHovers));
-  });
+  private columnsInternal: TsColumn[] = [];
 
   /**
    * Override the sticky CSS class set by the `CdkTable`
    */
   protected stickyCssClass = 'ts-table--sticky';
+
+  /**
+   * Store the stream of viewport changes
+   */
+  private viewportChange$: Observable<Event>;
+
+  /**
+   * Define the default component ID
+   */
+  public readonly uid = `ts-table-${nextUniqueId++}`;
+
+  /**
+   * Store a reference to the window object
+   */
+  private window: Window;
 
   /**
    * Return a simple array of column names
@@ -206,10 +221,68 @@ export class TsTableComponent<T = any> extends CdkTable<T> implements OnInit, Af
   }
 
   /**
-   * Access child rows
+   * Build array of columns to emit out to the consumer
    */
-  @ContentChildren(TsRowComponent)
-  public rows: QueryList<TsRowComponent>;
+  public get columnsToSendToConsumer(): TsColumn[] {
+    const internalColumns = this.getFreshColumnsCopy(this.columnsInternal);
+    const userColumns = this.getFreshColumnsCopy();
+    const lastIndex = internalColumns.length - 1;
+    // Reset the last column width to the consumer defined width
+    internalColumns[lastIndex].width = userColumns[lastIndex].width;
+    return internalColumns;
+  }
+
+  /**
+   * Return the width of the element wrapping the table
+   */
+  public get containerWidth(): number {
+    return this.parentElement.offsetWidth;
+  }
+
+  /**
+   * Determine if the container around the table has overflow (ie the table is scrollable)
+   */
+  public get hasOverflowX(): boolean {
+    return this.parentElement.scrollWidth > this.tableWidth;
+  }
+
+  /**
+   * Return the parent HTMLElement
+   */
+  private get parentElement(): HTMLElement {
+    return (this.elementRef.nativeElement as HTMLElement).parentNode as HTMLElement;
+  }
+
+  /**
+   * Determine the remaining space in the table after the columns take up their needed width
+   */
+  private get remainingTableSpace(): number {
+    // NOTE: The outer borders take up 2px so we subtract them here to avoid a 2px overflow.
+    const borderOffset = 2;
+    const remainingWidth = (this.containerWidth - this.totalWidthOfColumns) - borderOffset;
+    return (remainingWidth > 0) ? remainingWidth : 0;
+  }
+
+  /**
+   * Return the width of the table
+   */
+  private get tableWidth(): number {
+    return this.elementRef.nativeElement.offsetWidth;
+  }
+
+  /**
+   * Return the total width of all visible columns
+   */
+  private get totalWidthOfColumns(): number {
+    const currentWidths = this.headerCells.map(hc => hc.cellWidth);
+    const userWidths = this.columns.map(v => v.width);
+    const columnsToReduce = currentWidths.slice();
+    // NOTE: Since the last column is never resized by the user, we should use the original size for the last column and the current
+    // size for all other columns.
+    const lastIndex = userWidths.length - 1;
+    columnsToReduce[lastIndex] = this.columns[lastIndex].width;
+    return columnsToReduce.reduce((a, b) => a + b, 0);
+  }
 
   /**
    * Access header cells
@@ -218,18 +291,20 @@ export class TsTableComponent<T = any> extends CdkTable<T> implements OnInit, Af
   public headerCells: QueryList<TsHeaderCellDirective>;
 
   /**
+   * Access child rows
+   */
+  @ContentChildren(TsRowComponent)
+  public rows: QueryList<TsRowComponent>;
+
+  /**
    * Define the array of columns
    */
   @Input()
   public set columns(value: ReadonlyArray<TsColumn>) {
     // istanbul ignore else
-    if (value && value.length) {
-      this._columns = value.map(column => {
-        if (isUndefined(column.width)) {
-          column.width = DEFAULT_COLUMN_WIDTH;
-        }
-        return column;
-      });
+    if (value && (value.length > 0)) {
+      this._columns = this.getFreshColumnsCopy(value);
+      this.columnsInternal = this.getFreshColumnsCopy(value);
     }
   }
   public get columns(): ReadonlyArray<TsColumn> {
@@ -244,6 +319,18 @@ export class TsTableComponent<T = any> extends CdkTable<T> implements OnInit, Af
   public density: TsTableDensity = 'comfy';
 
   /**
+   * Define a custom ID
+   */
+  @Input()
+  public set id(value: string) {
+    this._id = value || this.uid;
+  }
+  public get id(): string {
+    return this._id;
+  }
+  private _id: string = this.uid;
+
+  /**
    * Emit when a column is resized
    *
    * NOTE: This output is not debounce or throttled and may be called repeatedly
@@ -253,144 +340,196 @@ export class TsTableComponent<T = any> extends CdkTable<T> implements OnInit, Af
 
 
   constructor(
+    // tslint:disable-next-line no-attribute-decorator
+    @Attribute('role') role: string,
+    // tslint:disable-next-line no-any
+    @Inject(DOCUMENT) public document: any,
     private platform: Platform,
     protected readonly differs: IterableDiffers,
     protected readonly changeDetectorRef: ChangeDetectorRef,
     @Optional() protected readonly dir: Directionality,
     public readonly elementRef: ElementRef,
-    // tslint:disable-next-line no-attribute-decorator
-    @Attribute('role') role: string,
-    // tslint:disable-next-line no-any
-    @Inject(DOCUMENT) public document: any,
-    public renderer: Renderer2,
-    public ngZone: NgZone,
+    private renderer: Renderer2,
+    private ngZone: NgZone,
+    private windowService: TsWindowService,
+    private viewportRuler: ViewportRuler,
   ) {
     super(differs, changeDetectorRef, elementRef, role, dir, document, platform);
+    this.window = windowService.nativeWindow;
   }
 
 
   /**
-   * Subscribe to header cell resize & hover events
+   * Subscribe to viewport changes
    */
   public ngOnInit(): void {
     super.ngOnInit();
-    this.initHeaderSubscriptions();
+
+    this.viewportChange$ = this.viewportRuler.change(VIEWPORT_DEBOUNCE).pipe(untilComponentDestroyed(this));
+    this.viewportChange$.pipe(untilComponentDestroyed(this)).subscribe(() => {
+      this.window.requestAnimationFrame(() => {
+        this.updateInternalColumns(this.getFreshColumnsCopy());
+        this.columnsChange.emit(new TsTableColumnsChangeEvent(this, this.columnsToSendToConsumer));
+      });
+    });
   }
 
-
   /**
-   * Update the column width definitions when the rows change
+   * Set up header cell changes subscription
    */
   public ngAfterViewChecked(): void {
-    this.viewChange.subscribe(v => {
-      this.initHeaderSubscriptions();
-      // NOTE: We need to manually call this since we have likely adjusted the cell widths.
-      this.updateStickyColumnStyles();
-    });
-
-    this.rows.changes.subscribe(() => {
-      for (const column of this.columns) {
-        this.setColumnWidthStyle(column.name, column.width);
-      }
-      this.initHeaderSubscriptions();
-    });
+    this.subscribeToHeaderCellChanges();
   }
 
-
   /**
-   * Must be present for `untilComponentDestroyed`
+   * Subscribe to column resize events
    */
-  public ngOnDestroy(): void {}
-
+  public ngAfterContentInit(): void {
+    this.columnResizeChanges$
+      .subscribe(v => {
+        this.updateLastColumnWidth();
+        // Update the recorded width for the changed column
+        this.columnsInternal.find(column => column.name === v.columnDef.name).width = v.cellWidth;
+        this.columnsChange.emit(new TsTableColumnsChangeEvent(this, this.columnsToSendToConsumer));
+      });
+  }
 
   /**
-   * Update the stored column width
+   * NOTE: Must be present for `untilComponentDestroyed`
+   */
+  public ngOnDestroy(): void {
+    this.headerCellSubscription.unsubscribe();
+  }
+
+  /**
+   * Adjusts the last column of the array to fill any remaining space inside the table
    *
-   * @param columnName - The name of the column
-   * @param width - The width to set
+   * NOTE: Due to issues during testing, we have not made this function static.
+   *
+   * @param columns - The array of columns to adjust
+   * @param remainingWidth - The remaining table width to be added to the last column
+   * @return The adjusted array of columns
    */
-  public updateColumnWidth(columnName: string, width: string): void {
-    this.setColumnWidthStyle(columnName, width);
-    const columns = this.columns.slice();
-    const foundIndex = columns.findIndex(c => c.name === columnName);
+  private addRemainingSpaceToLastColumn(columns: TsColumn[], remainingWidth: number): TsColumn[] {
+    const lastColumn = columns[columns.length - 1];
+    lastColumn.width = lastColumn.width + remainingWidth;
+    return columns;
+  }
 
+  /**
+   * Return a fresh clone of the passed in array of columns
+   *
+   * @param columns - The array of columns to clone
+   * @return The array of fresh columns
+   */
+  private getFreshColumnsCopy(columns: ReadonlyArray<TsColumn> = this.columns): TsColumn[] {
+    return columns.slice().map(c => ({ ...c }));
+  }
+
+  /**
+   * Set the column widths for all columns passed in
+   *
+   * @param columns - The array of columns
+   */
+  private setAllColumnsToDefinedWidths(columns: TsColumn[]): void {
+    for (const column of columns) {
+      this.setColumnWidthStyle(column.name, column.width, false);
+    }
+    this.updateStickyCellsIfNeeded();
+  }
+
+  /**
+   * Set the width for a specific column
+   *
+   * @param columnName - The name of the column that needs it's width updated
+   * @param width - The width to set
+   * @param updateStickCells - Whether the sticky cells should be updated
+   */
+  private setColumnWidthStyle(columnName: string, width: number, updateStickCells = true): void {
+    // eslint-disable-next-line no-underscore-dangle
+    const columnDirective = this.headerCells.find(cell => cell.columnDef._name === columnName);
     // istanbul ignore else
-    if (foundIndex >= 0) {
-      columns[foundIndex].width = width;
-      this.columns = columns;
-      this.columnsChange.emit(new TsTableColumnsChangeEvent(this, this.columns.slice()));
+    if (columnDirective) {
+      columnDirective.setColumnWidth(width);
+
+      // istanbul ignore else
+      if (updateStickCells) {
+        this.updateStickyCellsIfNeeded();
+      }
     }
   }
 
-
   /**
-   * Set the max-width style for a column of cells
+   * Set up subscription to header cell changes
    */
-  public setColumnWidthStyle(columnName: string, width: string): void {
-    const columnCells = this.getColumnElements(columnName);
-    for (const cell of columnCells) {
-      this.renderer.setStyle(cell, 'max-width', width);
+  private subscribeToHeaderCellChanges(): void {
+    if (this.headerCellSubscription) {
+      this.headerCellSubscription.unsubscribe();
     }
 
+    this.headerCellSubscription = this.headerCells.changes
+      .pipe(untilComponentDestroyed(this))
+      .subscribe(() => {
+        // 1. Set user widths
+        this.setAllColumnsToDefinedWidths(this.getFreshColumnsCopy());
+        // 2. Add space to last column as needed
+        this.updateLastColumnWidth();
+        // 3. Set all widths to internal columns
+        this.setAllColumnsToDefinedWidths(this.getFreshColumnsCopy(this.columnsInternal));
+        // 4. Alert the consumer
+        this.columnsChange.emit(new TsTableColumnsChangeEvent(this, this.columnsToSendToConsumer));
+
+        // Inject the header cell resize element in every cell except the last (last column is not resizable)
+        this.headerCells.forEach((headerCellDirective, i) => {
+          if (i !== this.headerCells.length - 1) {
+            headerCellDirective.injectResizeElement();
+          }
+        });
+      });
+  }
+
+  /**
+   * Update the internal columns array and set widths
+   *
+   * @param columns - The array of columns to update
+   */
+  private updateInternalColumns(columns: TsColumn[]): void {
+    // If there is space left over, add all remaining space to the last column
+    if (!this.hasOverflowX) {
+      columns = this.addRemainingSpaceToLastColumn(columns, this.remainingTableSpace);
+    }
+    this.columnsInternal = columns;
+    this.setAllColumnsToDefinedWidths(this.columnsInternal);
+  }
+
+  /**
+   * Update the last column's width and update the internal columns
+   */
+  private updateLastColumnWidth(): void {
+    // 1. Determine last column width
+    const columns = this.getFreshColumnsCopy();
+    const lastIndex = columns.length - 1;
+    const lastColumn = columns[lastIndex];
+    let newWidth = lastColumn.width;
+    if (!this.hasOverflowX) {
+      newWidth = lastColumn.width + this.remainingTableSpace;
+    }
+    // 2. Set the width
+    this.setColumnWidthStyle(lastColumn.name, newWidth);
+    // 3. Update internal columns
+    this.columnsInternal[lastIndex].width = newWidth;
+  }
+
+  /**
+   * Trigger an update on sticky cells if they exist
+   */
+  private updateStickyCellsIfNeeded(): void {
     // NOTE: To lessen the thrashing, only call the sticky column updater if there are defined sticky columns
     const stickyCells = this.headerCells.toArray().filter(c => c.columnDef.sticky || c.columnDef.stickyEnd);
     // istanbul ignore else
     if (stickyCells.length) {
       this.debouncedStickyColumnUpdate();
     }
-  }
-
-
-  /**
-   * Collect all column elements from a column name
-   *
-   * @param columnName - The name of the column to collect
-   * @return An array of HTMLElements
-   */
-  public getColumnElements(columnName: string): HTMLElement[] {
-    const className = `.ts-column-${columnName}`;
-    return Array.from(this.elementRef.nativeElement.querySelectorAll(className));
-  }
-
-
-  /**
-   * Set the appropriate column class on mouseenter/mouseleave
-   *
-   * @param columnName - The name of the column to update
-   * @param isHovered - Whether the column is currently hovered
-   */
-  public updateColumnHoverClass(columnName: string, isHovered: boolean): void {
-    const columnCells = this.getColumnElements(columnName);
-    for (const cell of columnCells) {
-      if (isHovered) {
-        this.renderer.addClass(cell, 'ts-cell--resizing');
-      } else {
-        this.renderer.removeClass(cell, 'ts-cell--resizing');
-      }
-    }
-  }
-
-
-  /**
-   * Initialize subscriptions for header events
-   */
-  private initHeaderSubscriptions(): void {
-    if (this.headerCellResize$) {
-      this.headerCellResize$.unsubscribe();
-    }
-    if (this.headerCellHover$) {
-      this.headerCellHover$.unsubscribe();
-    }
-
-    this.headerCellResize$ = this.headerCellResizes.subscribe(v => {
-      const { instance, width } = v as TsHeaderCellResizeEvent;
-      this.updateColumnWidth(instance.columnDef.name, width);
-    });
-
-    this.headerCellHover$ = this.headerCellHovers.subscribe(v => {
-      const { instance, isHovered } = v as TsHeaderCellResizeHoverEvent;
-      this.updateColumnHoverClass(instance.columnDef.name, isHovered);
-    });
   }
 
 }

--- a/terminus-ui/table/testing/src/test-components.ts
+++ b/terminus-ui/table/testing/src/test-components.ts
@@ -27,6 +27,7 @@ import {
       [dataSource]="dataSource"
       [density]="density"
       [columns]="columns"
+      [id]="myId"
       (columnsChange)="columnsChanged($event)"
       #myTable="tsTable"
     >
@@ -63,8 +64,9 @@ export class TableApp {
   public columnsToRender = ['column_a', 'column_b', 'column_c'];
   public columns = this.columnsToRender.map(c => ({
     name: c,
-    width: '100px',
+    width: 100,
   }));
+  public myId = 'foobar';
   public isFourthRow = (i: number, _rowData: TestData) => i === 3;
   public columnsChanged(e: TsTableColumnsChangeEvent) {}
 }
@@ -94,7 +96,10 @@ export class TableWithWhenRowApp {
   public dataSource: FakeDataSource | null = new FakeDataSource();
   public isFourthRow = (i: number, _rowData: TestData) => i === 3;
   public columnsToRender = ['column_a'];
-  public columns = this.columnsToRender.map(c => ({ name: c }));
+  public columns = this.columnsToRender.map(c => ({
+    name: c,
+    width: 100,
+  }));
 }
 
 
@@ -125,7 +130,10 @@ export class ArrayDataSourceTableApp {
   public underlyingDataSource = new FakeDataSource();
   public dataSource = new TsTableDataSource<TestData>();
   public columnsToRender = ['column_a', 'column_b', 'column_c'];
-  public columns = this.columnsToRender.map(c => ({ name: c }));
+  public columns = this.columnsToRender.map(c => ({
+    name: c,
+    width: 100,
+  }));
 
   @ViewChild(TsTableComponent, { static: true })
   public table!: TsTableComponent<TestData>;
@@ -175,7 +183,10 @@ export class TableColumnAlignmentTableApp {
   public underlyingDataSource = new FakeDataSource();
   public dataSource = new TsTableDataSource<TestData>();
   public columnsToRender = ['column_a', 'column_b', 'column_c'];
-  public columns = this.columnsToRender.map(c => ({ name: c }));
+  public columns = this.columnsToRender.map(c => ({
+    name: c,
+    width: 100,
+  }));
 
   @ViewChild(TsTableComponent, { static: true })
   public table!: TsTableComponent<TestData>;
@@ -208,7 +219,10 @@ export class TableColumnInvalidAlignmentTableApp {
   public underlyingDataSource = new FakeDataSource();
   public dataSource = new TsTableDataSource<TestData>();
   public columnsToRender = ['column_a'];
-  public columns = this.columnsToRender.map(c => ({ name: c }));
+  public columns = this.columnsToRender.map(c => ({
+    name: c,
+    width: 100,
+  }));
 
   @ViewChild(TsTableComponent, { static: true })
   public table!: TsTableComponent<TestData>;
@@ -228,7 +242,7 @@ export class TableColumnInvalidAlignmentTableApp {
 
 @Component({
   template: `
-    <table ts-table [dataSource]="dataSource">
+    <table ts-table [dataSource]="dataSource" [columns]="columns">
       <ng-container tsColumnDef="column_a" sticky>
         <th ts-header-cell *tsHeaderCellDef> Column A</th>
         <td ts-cell *tsCellDef="let row">{{ row.a }}</td>
@@ -260,7 +274,52 @@ export class PinnedTableHeaderColumn {
 
   public dataSource: FakeDataSource | null = new FakeDataSource();
   public columnsToRender = ['column_a', 'column_b', 'column_c'];
+  public columns = this.columnsToRender.map(c => ({
+    name: c,
+    width: 100,
+  }));
   public isFourthRow = (i: number, _rowData: TestData) => i === 3;
+}
+
+@Component({
+  template: `
+    <div style="width: 250px;">
+      <table
+        ts-table
+        [dataSource]="dataSource"
+        [columns]="columns"
+        (columnsChange)="columnsChanged($event)"
+        #myTable="tsTable"
+      >
+        <ng-container tsColumnDef="column_a">
+          <th ts-header-cell *tsHeaderCellDef> Column A</th>
+          <td ts-cell *tsCellDef="let row">{{ row.a }}</td>
+        </ng-container>
+
+        <ng-container tsColumnDef="column_b">
+          <th ts-header-cell *tsHeaderCellDef> Column B</th>
+          <td ts-cell *tsCellDef="let row">{{ row.b }}</td>
+        </ng-container>
+
+        <ng-container tsColumnDef="column_c">
+          <th ts-header-cell *tsHeaderCellDef> Column C</th>
+          <td ts-cell *tsCellDef="let row">{{ row.c }}</td>
+        </ng-container>
+
+        <tr ts-header-row *tsHeaderRowDef="myTable.columnNames"></tr>
+        <tr ts-row *tsRowDef="let row; columns: myTable.columnNames"></tr>
+      </table>
+    </div>
+  `,
+})
+export class ScrollingTable {
+  public dataSource: FakeDataSource | null = new FakeDataSource();
+  public columnsToRender = ['column_a', 'column_b', 'column_c'];
+  public columns = this.columnsToRender.map(c => ({
+    name: c,
+    width: 100,
+  }));
+  public columnsChanged(e: TsTableColumnsChangeEvent) {}
 }
 
 
@@ -274,6 +333,7 @@ export class PinnedTableHeaderColumn {
   declarations: [
     ArrayDataSourceTableApp,
     PinnedTableHeaderColumn,
+    ScrollingTable,
     TableApp,
     TableColumnAlignmentTableApp,
     TableColumnInvalidAlignmentTableApp,


### PR DESCRIPTION
Table now dynamically sizes columns.

BREAKING CHANGE:
- TsColumn definition change
- Outer border change
- Style changes

ISSUES CLOSED: #1805
ISSUES CLOSED: #1813 

---

NOTE: Test coverage drops slightly in this release. This is just to get it out asap to unblock feature teams. I will continue working on this post-release until coverage is back up.

---

## Migration Notes

### `TsColumn`

`TsColumn` definitions now require a width to be set:

```diff
const columns: TsColumn[] = [
  {
    name: 'Column One',
+   width: 100,
  },
];
```

### Outer border

The table no longer defines it's own outer border. See usage docs.

### Persistent scrollbars

The table no longer controls the scrollbars. See usage docs.