### PR TITLE
fix(Table): resize handle now has correct vertical alignment in all table layout modes

### DIFF
--- a/terminus-ui/table/src/table.component.scss
+++ b/terminus-ui/table/src/table.component.scss
@@ -26,6 +26,7 @@
   --cell-padding: #{spacing(default)};
   // Must be greater than 40 as that is the length of the generated z-indexes for header cells
   --sticky-end-z: 50;
+  --grip-vertical-adjustment: 50%;
   @include reset;
   @include typography;
   border-collapse: separate;
@@ -36,6 +37,7 @@
 
   &.ts-table--compact {
     --cell-padding: #{spacing(small, 2)};
+    --grip-vertical-adjustment: calc(50% - 4px);
   }
 
   // Class added to all sticky-end cells
@@ -219,7 +221,7 @@
       // Visible container for grabber
       &::before {
         background-color: color(primary);
-        bottom: 0;
+        bottom: 1px;
         content: '';
         display: block;
         left: 50%;
@@ -241,7 +243,7 @@
         left: 50%;
         position: absolute;
         top: 30%;
-        transform: rotate(90deg) translate(50%, -3px);
+        transform: rotate(90deg) translate(var(--grip-vertical-adjustment), -3px);
         z-index: var(--z-index-resize-grabber);
       }
     }


### PR DESCRIPTION

ISSUES CLOSED: #1991

![resizer](https://user-images.githubusercontent.com/270193/73279966-dbc48280-41bb-11ea-8026-39ff1c1227c5.gif)

- Also fixed slight overlap of grabber bg.