### PR TITLE
stop auto-rebasing conflicts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,7 @@
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
   "rebaseLabel": "Action: rebase",
+  "rebaseConflictedPrs": false,
   "rebaseStalePrs": false,
   "reviewers": [
     "benjamincharity"


### PR DESCRIPTION
This was eating too many build cycles during work hours.