### PR TITLE
style: general cleanup focused on documentation and jsdocs

### DIFF
--- a/terminus-ui/chart/src/chart.component.md
+++ b/terminus-ui/chart/src/chart.component.md
@@ -68,7 +68,6 @@ Add the component and set up access to the generated chart:
 ```
 
 ```typescript
-
 setUpChart(chart: am4charts.Chart) {
   // Add axis' and series' etc...
 }

--- a/terminus-ui/checkbox/src/checkbox.component.md
+++ b/terminus-ui/checkbox/src/checkbox.component.md
@@ -12,7 +12,7 @@
 
 ## Basic usage
 
-Wrap your label text inside the component:
+Place your label text inside the component:
 
 ```html
 <ts-checkbox>

--- a/terminus-ui/chip/src/chip-collection.component.md
+++ b/terminus-ui/chip/src/chip-collection.component.md
@@ -25,12 +25,16 @@ NOTE: This component does not support a `FormControl`; it is a simple collection
 
 ## Basic Usage
 
-Loop through a collection to generate chips:
+Create a collection of chips:
+
+```typescript
+myChips = ['one', 'two', 'three'];
+```
 
 ```html
 <ts-chip-collection>
   <ts-chip
-    *ngFor="let chip of chips;"
+    *ngFor="let chip of myChips;"
     [value]="chip"
   >{{ chip }}</ts-chip>
 </ts-chip-collection>
@@ -50,7 +54,7 @@ For string based collections, the value input can be disregarded as the value wi
 
 ### Theme
 
-A theme can be set a the chip level:
+A theme can be defined at the chip level:
 
 ```html
 <ts-chip-collection>
@@ -63,7 +67,8 @@ A theme can be set a the chip level:
 
 ### Orientation
 
-A collection can be displayed in a row (`horizontal`) or a column (`vertical`) via the `orientation` input. By default it displays as a row.
+A collection of chips can be displayed in a row (`horizontal`) or a column (`vertical`) via the `orientation` input. By
+default it displays as a row.
 
 ```html
 <ts-chip-collection>
@@ -76,8 +81,9 @@ A collection can be displayed in a row (`horizontal`) or a column (`vertical`) v
 
 ### Removable
 
-By default, chips are 'removable'. Since this component does not directly manage the data, when a user tries to remove a chip, an event is
-emitted. The consumer is responsible to using that event to remove the item from the collection. (See [Events](#events))
+By default, chips are 'removable'. Since this component does not directly manage the data, when a user attempts to
+remove a chip, an event is emitted. The consumer is responsible to use that event to remove the item from the
+collection. (See [Events](#events))
 
 ```html
 <ts-chip-collection>
@@ -91,11 +97,8 @@ emitted. The consumer is responsible to using that event to remove the item from
 ```typescript
 myChips = ['apple', 'banana'];
 
-removeChip(event: TsChipEvent): void {
-  if (!event.chip.value) {
-    return;
-  }
-  const index = this.myChips.indexOf(event.chip.value);
+removeChip(removeEvent: TsChipEvent): void {
+  const index = this.myChips.indexOf(removeEvent.chip.value);
   if (index < 0) {
     return;
   }
@@ -106,11 +109,11 @@ removeChip(event: TsChipEvent): void {
 The ability to remove a chip can be disabled per chip or as a collection:
 
 ```html
-<!-- Disable on the chip directly -->
+<!-- Disable the chip directly -->
 <ts-chip-collection>
   <ts-chip
     *ngFor="let chip of chips"
-    [isRemovable]="chip.removable"
+    [isRemovable]="false"
   >{{ chip }}</ts-chip>
 </ts-chip-collection>
 
@@ -124,16 +127,17 @@ The ability to remove a chip can be disabled per chip or as a collection:
 
 ### Selectable
 
-Chips can be selected and visually show that selection. The style of the selected state reflects the current [theme](#theme).
+Chips can be selected and will visually show that selection. The style of the selected state reflects the current
+[theme](#theme).
 
-The ability to select chips can be disabled at the collection or chip level.
+The ability to select chips can be disabled per chip or as a collection:
 
 ```html
 <!-- Disable on the chip directly -->
 <ts-chip-collection>
   <ts-chip
     *ngFor="let chip of chips"
-    [isSelectable]="chip.canSelect"
+    [isSelectable]="false"
   >{{ chip }}</ts-chip>
 </ts-chip-collection>
 
@@ -157,7 +161,8 @@ This will disable the ability to remove, select or focus the chip.
 
 ## Events
 
-Since this component does not directly manage the data, we rely on emitting events to alert the consumer as to what needs to happen.
+Since this component does not directly manage the data, we rely on emitting events to alert the consumer for any user
+interaction.
 
 ### Collection events
 
@@ -186,17 +191,17 @@ Some helpers are exposed to assist with testing. These are imported from `@termi
 
 | Function                                  |
 |-------------------------------------------|
-| `getAllChipDebugElements`                 |
 | `getAllChipCollectionDebugElements`       |
+| `getAllChipCollectionInstances`           |
+| `getChipCollectionInstance`               |
+| `getChipCollectionInstanceInAutocomplete` |
+| `getChipCollectionElement`                |
 | `getAllChipInstances`                     |
 | `getChipInstance`                         |
-| `getAllChipCollectionInstances`           |
-| `getChipCollectionInstanceInAutocomplete` |
+| `getAllChipDebugElements`                 |
 | `getChipDebugElement`                     |
 | `getChipCollectionDebugElement`           |
-| `getChipCollectionInstance`               |
 | `getChipElement`                          |
-| `getChipCollectionElement`                |
 
 
 [test-helpers-src]: https://github.com/GetTerminus/terminus-ui/blob/release/terminus-ui/chip/testing/src/test-helpers.ts

--- a/terminus-ui/cohort-date-range/src/cohort-date-range.component.md
+++ b/terminus-ui/cohort-date-range/src/cohort-date-range.component.md
@@ -103,12 +103,12 @@ When `allowCustomDates` is set to `false`, the date range is readonly (this defa
 
 ```html
 <ts-cohort-date-range
-  [allowCustomDates]="allowCustomDates"
+  [allowCustomDates]="false"
   [cohorts]="cohorts"
 ></ts-cohort-date-range>
 ```
 
-When set to `true`, a `Custom Dates` option will be added to the dropdown.
+NOTE: When set to `true`, a `Custom Dates` option will be added to the dropdown.
 
 ### Disable
 

--- a/terminus-ui/confirmation/src/confirmation-overlay.component.html
+++ b/terminus-ui/confirmation/src/confirmation-overlay.component.html
@@ -1,7 +1,10 @@
-<div 
+<div
   fxLayout="column"
 >
-  <p *ngIf="explanationTxt" class="ts-confirmation-overlay__explanation">{{ explanationTxt }}</p>
+  <p *ngIf="explanationText" class="ts-confirmation-overlay__explanation">
+    {{ explanationText }}
+  </p>
+
   <div
     fxLayout="row"
     fxLayoutAlign="center space-between"
@@ -13,14 +16,14 @@
       format="hollow"
       (clicked)="confirm.next(false)"
     >
-      {{ cancelButtonTxt }}
+      {{ cancelButtonText }}
     </ts-button>
 
     <ts-button
       class="qa-confirmation-confirm"
       (clicked)="confirm.next(true)"
     >
-      {{ confirmationButtonTxt }}
+      {{ confirmationButtonText }}
     </ts-button>
   </div>
 </div>

--- a/terminus-ui/confirmation/src/confirmation-overlay.component.ts
+++ b/terminus-ui/confirmation/src/confirmation-overlay.component.ts
@@ -23,7 +23,7 @@ export class TsConfirmationOverlayComponent {
   /**
    * Stream confirmation choices
    */
-  public confirm: Subject<boolean> = new Subject<boolean>();
+  public confirm = new Subject<boolean>();
 
   /**
    * Define the space between the buttons
@@ -33,16 +33,16 @@ export class TsConfirmationOverlayComponent {
   /**
    * Text for confirmation button
    */
-  public confirmationButtonTxt: string | undefined;
+  public confirmationButtonText: string | undefined;
 
   /**
    * Text for cancel button
    */
-  public cancelButtonTxt: string | undefined;
+  public cancelButtonText: string | undefined;
 
   /**
    * Text for explanation
    */
-  public explanationTxt: string | undefined;
+  public explanationText: string | undefined;
 
 }

--- a/terminus-ui/confirmation/src/confirmation.directive.md
+++ b/terminus-ui/confirmation/src/confirmation.directive.md
@@ -17,9 +17,10 @@ Basic flow:
 
 - [Basic usage](#basic-usage)
 - [Cancelled event](#cancelled-event)
-- [Confirmation Button Text](#confirmation-button-text)
-- [Cancel Button Text](#cancel-button-text)
-- [Explanation Text](#explanation-text)
+- [Text customization](#text-customization)
+  - [Confirm button](#confirm-button)
+  - [Cancel button](#cancel-button)
+  - [Explanation text](#explanation-text)
 - [Position](#position)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -31,11 +32,9 @@ Add the directive to any `ts-button`:
 
 ```html
 <ts-button
-  ts-confirmation
+  tsConfirmation
   (clicked)="myContinueFn($event)"
->
-  Click me!
-</ts-button>
+>Click me!</ts-button>
 ```
 
 
@@ -46,73 +45,57 @@ from the confirmation pop-up.
 
 ```html
 <ts-button
-  ts-confirmation
-  (clicked)="myContinueFn($event)"
+  tsConfirmation
   (cancelled)="myCancelEvent($event)"
->
-  Click me!
-</ts-button>
+>Click me!</ts-button>
 ```
 
+## Text customization
 
-## Confirmation Button Text
+### Confirm button
 
-Customizes the text in the overlay of the confirmation button; default is "Confirm".
+Customizes the confirmation button text in the overlay. This defaults to `Confirm`.
 
 ```html
 <ts-button
-    tsConfirmation
-    (clicked)="submit()"
-    (cancelled)="cancel($event)"
-    confirmationButtonText="Custom Confirmation Button Text"
-  >
-    Click Me!
-  </ts-button>
+  tsConfirmation
+  confirmationButtonText="Custom Confirmation Button Text"
+>Click Me!</ts-button>
 ```
 
 
-## Cancel Button Text
+### Cancel button
 
 Customizes the text in the overlay of the cancel button; default is "Cancel".
 
 ```html
 <ts-button
-    tsConfirmation
-    (clicked)="submit()"
-    (cancelled)="cancel($event)"
-    cancelButtonText="Custom Cancel Button Text"
-  >
-    Click Me!
-  </ts-button>
+  tsConfirmation
+  cancelButtonText="Custom Cancel Button Text"
+>Click Me!</ts-button>
 ```
 
 
-## Explanation Text
+### Explanation text
 
-Optional text to appear inside of the overlay, generally to use as a warning, for example, "Are you sure you want to delete this tactic, a delete can not be undone". Default is null.
+Optional text to appear inside of the overlay, generally to use as a warning, for example, "Are you sure you want to do
+this action?". No explanation text exists by default.
 
 ```html
 <ts-button
-    tsConfirmation
-    (clicked)="submit()"
-    (cancelled)="cancel($event)"
-    explanationText="Optional text within overlay."
-  >
-    Click Me!
-  </ts-button>
+  tsConfirmation
+  explanationText="This will permanently delete this record."
+>Click Me!</ts-button>
 ```
 
 ## Position
 
-Optional overlayPosition for defining where the overlay will appear relative to the button. Options are defined in `TsConfirmationOverlayPositionTypes`. Default is 'below'.
+The position of the panel is centered below the trigger by default. This position can be changed to any of the  
+`TsConfirmationOverlayPositionTypes` (`above`|`below`|`before`|`after`).
 
 ```html
 <ts-button
-    tsConfirmation
-    (clicked)="submit()"
-    (cancelled)="cancel($event)"
-    overlayPosition="before"
-  >
-    Click Me!
-  </ts-button>
+  tsConfirmation
+  overlayPosition="before"
+>Click Me!</ts-button>
 ```

--- a/terminus-ui/confirmation/src/confirmation.directive.ts
+++ b/terminus-ui/confirmation/src/confirmation.directive.ts
@@ -1,5 +1,4 @@
 import {
-  ConnectedPositionStrategy,
   FlexibleConnectedPositionStrategy,
   HorizontalConnectionPos,
   Overlay,
@@ -52,12 +51,13 @@ export const allowedOverlayPositionTypes: TsConfirmationOverlayPositionTypes[] =
  * A directive to inject a confirmation step into any button
  *
  * @example
- *         <tsButton
+ *         <ts-button
  *           tsConfirmation
- *           explanationText="Are you sure you want to delete this?"
- *           confirmationButtonText="Confirm!"
  *           cancelButtonText="Abort!"
+ *           confirmationButtonText="Confirm!"
+ *           explanationText="Are you sure you want to do this?"
  *           overlayPosition="before"
+ *           (cancelled)="myFunction($event)"
  *         >
  *           Click me!
  *         </ts-button>
@@ -80,20 +80,12 @@ export class TsConfirmationDirective implements OnDestroy, OnInit {
    */
   private overlayRef!: OverlayRef | null;
 
-
   /**
-   * INPUTS
-   */
-
-  /**
-   * Define the Confirmation Button Text
+   * Define the confirmation button text
    */
   @Input()
   public set confirmationButtonText(value: string) {
-    if (!value) {
-      return;
-    }
-    this._confirmationButtonText = value;
+    this._confirmationButtonText = value || 'Confirm';
   }
   public get confirmationButtonText(): string {
     return this._confirmationButtonText;
@@ -101,14 +93,11 @@ export class TsConfirmationDirective implements OnDestroy, OnInit {
   private _confirmationButtonText = 'Confirm';
 
   /**
-   * Define the Cancel Button Text
+   * Define the cancel button text
    */
   @Input()
   public set cancelButtonText(value: string) {
-    if (!value) {
-      return;
-    }
-    this._cancelButtonText = value;
+    this._cancelButtonText = value || 'Cancel';
   }
   public get cancelButtonText(): string {
     return this._cancelButtonText;
@@ -116,16 +105,10 @@ export class TsConfirmationDirective implements OnDestroy, OnInit {
   private _cancelButtonText = 'Cancel';
 
   /**
-   * Define the Explanation Text
+   * Define the explanation text
    */
   @Input()
-  public set explanationText(value: string | undefined) {
-    this._explanationText = value;
-  }
-  public get explanationText(): string | undefined {
-    return this._explanationText;
-  }
-  private _explanationText: string | undefined;
+  public explanationText: string | undefined;
 
   /**
    * Define position of the overlay
@@ -148,7 +131,7 @@ export class TsConfirmationDirective implements OnDestroy, OnInit {
    * An event emitted when the confirmation is cancelled
    */
   @Output()
-  public readonly cancelled: EventEmitter<boolean> = new EventEmitter();
+  public readonly cancelled = new EventEmitter<boolean>();
 
 
   constructor(
@@ -162,7 +145,7 @@ export class TsConfirmationDirective implements OnDestroy, OnInit {
   /**
    * Spawn the confirmation overlay on click
    *
-   * @param event - The MouseEvent
+   * NOTE: Even though the 'event' param is not used, the param must exist for AoT to pass.
    */
   @HostListener('click', ['$event'])
   public onClick(event: Event): void {
@@ -172,8 +155,6 @@ export class TsConfirmationDirective implements OnDestroy, OnInit {
 
   /**
    * Dismiss the confirmation overlay on pressing escape
-   *
-   * @param event - The Keyboard Event
    */
   @HostListener('document:keydown.escape')
   public onKeydownHandler(): void {
@@ -223,9 +204,9 @@ export class TsConfirmationDirective implements OnDestroy, OnInit {
     // Create and attach the overlay
     const userProfilePortal = new ComponentPortal(TsConfirmationOverlayComponent);
     this.overlayInstance = this.overlayRef.attach(userProfilePortal).instance;
-    this.overlayInstance.confirmationButtonTxt = this.confirmationButtonText;
-    this.overlayInstance.cancelButtonTxt = this.cancelButtonText;
-    this.overlayInstance.explanationTxt = this.explanationText;
+    this.overlayInstance.confirmationButtonText = this.confirmationButtonText;
+    this.overlayInstance.cancelButtonText = this.cancelButtonText;
+    this.overlayInstance.explanationText = this.explanationText;
 
     // Start the progress indicator of the TsButton
     this.host.showProgress = true;
@@ -290,7 +271,6 @@ export class TsConfirmationDirective implements OnDestroy, OnInit {
       // skip default - unreachable
     }
 
-
     const positionStrategy: FlexibleConnectedPositionStrategy =
       this.overlay.position()
         .flexibleConnectedTo(this.elementRef)
@@ -305,15 +285,13 @@ export class TsConfirmationDirective implements OnDestroy, OnInit {
           },
         ]);
 
-    const overlayConfig: OverlayConfig = new OverlayConfig({
+    return new OverlayConfig({
       positionStrategy,
       scrollStrategy: this.overlay.scrollStrategies.reposition(),
       hasBackdrop: true,
       backdropClass: 'ts-confirmation-overlay',
       panelClass: ['qa-confirmation', 'ts-confirmation-overlay__panel', `${positionClass}`],
     });
-
-    return overlayConfig;
   }
 
 

--- a/terminus-ui/copy/src/copy.component.md
+++ b/terminus-ui/copy/src/copy.component.md
@@ -8,8 +8,8 @@ This component is used to contain very long strings that users may need to copy.
 **Table of Contents**
 
 - [Basic usage](#basic-usage)
-  - [Display format](#display-format)
-  - [Initial selection](#initial-selection)
+- [Display format](#display-format)
+- [Initial selection](#initial-selection)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -22,20 +22,20 @@ Pass in text content:
 <ts-copy>My text to copy!</ts-copy>
 ```
 
-### Display format
+## Display format
 
 Three display formats are offered:
 
-| mode       | description                                             |
+| Mode       | Description                                             |
 |------------|---------------------------------------------------------|
 | `standard` | The full, bordered version (default)                    |
 | `minimal`  | Slightly more compact with no border (useful in tables) |
 | `icon`     | Icon only, all text hidden (quick copy must be enabled) |
 
-### Initial selection
+## Initial selection
 
-By default, when a user focus on this component, the text is automatically selected. This provides an easy fallback in the instance where
-the user's browser does not support clipboard functionality.
+By default, when a user focuses on this component, the text is automatically selected. This provides an easy fallback in
+the instance where the user's browser does not support clipboard functionality.
 
 It should be extremely rare, but if needed, this functionality can be disabled.
 

--- a/terminus-ui/copy/src/copy.component.ts
+++ b/terminus-ui/copy/src/copy.component.ts
@@ -19,7 +19,9 @@ import {
 
 
 
-
+/**
+ * The possible display formats for {@link TsCopyComponent}
+ */
 export type TsCopyDisplayFormat
   = 'standard'
   | 'minimal'
@@ -28,17 +30,13 @@ export type TsCopyDisplayFormat
 
 
 /**
- * This is the TsCopyComponent UI Component
- *
- * #### QA CSS CLASSES
- * `qa-copy`: Placed on the div element which contains this component
- * `qa-copy-content`: Placed on a div element which contains the content which will be copied
- * `qa-copy-icon`: Placed on the icon which copies the content to the clipboard when clicked
+ * A component to facilitate the easy copying of text
  *
  * @example
  * <ts-copy
  *              [disableInitialSelection]="true"
  *              [enableQuickCopy]="true"
+ *              [format]="icon"
  *              theme="accent"
  * >My text to copy!</ts-copy>
  *
@@ -133,7 +131,6 @@ export class TsCopyComponent {
     return this._format;
   }
   private _format: TsCopyDisplayFormat = 'standard';
-
 
   /**
    * Define the component theme

--- a/terminus-ui/csv-entry/src/csv-entry.component.md
+++ b/terminus-ui/csv-entry/src/csv-entry.component.md
@@ -1,4 +1,4 @@
-<h1>csv-entry</h1>
+<h1>CSV Entry</h1>
 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -6,12 +6,12 @@
 **Table of Contents**
 
 - [Basic usage](#basic-usage)
-  - [Column Count](#column-count)
-  - [Row count](#row-count)
-  - [Max rows](#max-rows)
+- [Column count](#column-count)
+- [Row count](#row-count)
+- [Max rows](#max-rows)
 - [Column validation](#column-validation)
-- [Static Column Headers](#static-column-headers)
-- [Full Width Table](#full-width-table)
+- [Static column headers](#static-column-headers)
+- [Full width table](#full-width-table)
 - [Custom footer content](#custom-footer-content)
 - [Footer direction](#footer-direction)
 
@@ -20,8 +20,8 @@
 
 ## Basic usage
 
-The most basic implementation only needs the HTML and a single method. Each time the CSV table is updated, a new File Blob is generated and
-emitted.
+The most basic implementation only needs the HTML and a single method. Each time the CSV table is updated, a new File
+Blob is generated and emitted:
 
 ```html
 <ts-csv-entry (blobGenerated)="myFunc($event)">
@@ -29,41 +29,39 @@ emitted.
 ```
 
 ```typescript
-myFunc(blob: Blob) {
-  ...
-}
+myFunc(blob: Blob) { ... }
 ```
 
 
-### Column Count
+## Column count
 
-Control the default column count via an Input:
+Define the number of columns (default is 2):
 
 ```html
 <ts-csv-entry [columnCount]="7">
-  <!-- Will generate a table with 7 columns -->
+  <!-- Will generate a csv entry with 7 columns -->
 </ts-csv-entry>
 ```
 
-> NOTE: Column count does not restrict what is pasted into the table.
+> NOTE: Column count does not restrict how many columns can be pasted into the table.
 
 
-### Row count
+## Row count
 
-Control the default number of rows via an Input:
+Define the number of rows (default is 4):
 
 ```html
 <ts-csv-entry [rowCount]="5">
-  <!-- Will generate a table with 5 rows -->
+  <!-- Will generate a csv entry with 5 rows -->
 </ts-csv-entry>
 ```
 
-> NOTE: Row count does not restrict what is pasted into the table.
+> NOTE: Row count does not restrict how may rows can be pasted into the table.
 
 
-### Max rows
+## Max rows
 
-Control the maximum number of rows a table will allow
+Define the maximum number of rows a table will allow (default is 2000):
 
 ```html
 <ts-csv-entry [maxRows]="100">
@@ -91,7 +89,7 @@ myValidators = [null, this.validatorsService.url(), null, null];
 This example would add the URL validation to the second column only.
 
 
-## Static Column Headers
+## Static column headers
 
 If there are certain headers that must be available, these can be set via an input:
 
@@ -103,18 +101,19 @@ If there are certain headers that must be available, these can be set via an inp
 Setting static column headers will set the header cells to `readonly`. This will still allow keyboard navigation but will not allow the user
 to change the contents of the set header cells.
 
-## Full Width Table
-If the table should be one full-width column, set both in the input:
+## Full width table
+
+If the table should be a single, full-width column, set both `columnCount` and `fullWidth`:
 
 ```html
 <ts-csv-entry [columnCount]="1" [fullWidth]="true">
 </ts-csv-entry>
 ```
-> NOTE: full width should only be with one column
+> NOTE: full width should only be used with a single column
 
 ## Custom footer content
 
-Consumer's can add custom footer content by enclosing it within the CSVEntry component:
+Consumer's can add custom footer content by enclosing it within the CSV entry component:
 
 ```html
 <ts-csv-entry>
@@ -128,7 +127,7 @@ This content will be added opposite the default footer buttons set.
 ## Footer direction
 
 The footer layout defaults to `ltr` mode which lays out the default buttons on the left and any custom content on the
-right. This can be reversed by the `footerDirection` input.
+right. This can be reversed:
 
 ```html
 <ts-csv-entry footerDirection="rtl">

--- a/terminus-ui/csv-entry/src/csv-entry.component.ts
+++ b/terminus-ui/csv-entry/src/csv-entry.component.ts
@@ -74,6 +74,9 @@ export interface TsCSVFormError {
   url?: TsCSVUrlError;
 }
 
+/**
+ * The structure for a row
+ */
 export interface TsCSVRow {
   recordId: FormControl;
   columns: FormArray;
@@ -95,14 +98,14 @@ const DEFAULT_VALIDATION_MESSAGES_MAX = 6;
  *
  * @example
  * <ts-csv-entry
- *              id="my-id"
- *              maxRows="1000"
  *              columnCount="6"
- *              rowCount="12"
- *              [fullWidth]="false"
  *              [columnHeaders]="arrayOfHeaders"
  *              [columnValidators]="arrayOfValidators"
  *              [footerDirection]="ltr"
+ *              [fullWidth]="false"
+ *              id="my-id"
+ *              maxRows="1000"
+ *              rowCount="12"
  *              outputFormat="csv"
  *              (blobGenerated)="handleTheFileBlob($event)"
  * ></ts-csv-entry>
@@ -171,30 +174,6 @@ export class TsCSVEntryComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Define an ID for the component
-   */
-  @Input()
-  public set id(value: string) {
-    this._id = value || this.uid;
-  }
-  public get id(): string {
-    return this._id;
-  }
-  protected _id: string = this.uid;
-
-  /**
-   * Set the maximum number of allowed rows
-   */
-  @Input()
-  public set maxRows(value: number) {
-    this._maxRows = coerceNumberProperty(value, DEFAULT_MAX_ROWS);
-  }
-  public get maxRows(): number {
-    return this._maxRows;
-  }
-  private _maxRows: number = DEFAULT_MAX_ROWS;
-
-  /**
    * Set the number of columns
    */
   @Input()
@@ -205,24 +184,6 @@ export class TsCSVEntryComponent implements OnInit, OnDestroy {
     return this._columnCount;
   }
   private _columnCount: number = DEFAULT_COLUMN_COUNT;
-
-  /**
-   * Define the number of rows
-   */
-  @Input()
-  public set rowCount(value: number) {
-    this._rowCount = coerceNumberProperty(value, DEFAULT_ROW_COUNT);
-  }
-  public get rowCount(): number {
-    return this._rowCount;
-  }
-  private _rowCount: number = DEFAULT_ROW_COUNT;
-
-  /**
-   * Allow full-width mode
-   */
-  @Input()
-  public fullWidth = false;
 
   /**
    * Allow static headers to be set
@@ -261,10 +222,52 @@ export class TsCSVEntryComponent implements OnInit, OnDestroy {
   public footerDirection: 'ltr' | 'rtl' = 'ltr';
 
   /**
+   * Allow full-width mode
+   */
+  @Input()
+  public fullWidth = false;
+
+  /**
+   * Define an ID for the component
+   */
+  @Input()
+  public set id(value: string) {
+    this._id = value || this.uid;
+  }
+  public get id(): string {
+    return this._id;
+  }
+  protected _id: string = this.uid;
+
+  /**
+   * Set the maximum number of allowed rows
+   */
+  @Input()
+  public set maxRows(value: number) {
+    this._maxRows = coerceNumberProperty(value, DEFAULT_MAX_ROWS);
+  }
+  public get maxRows(): number {
+    return this._maxRows;
+  }
+  private _maxRows: number = DEFAULT_MAX_ROWS;
+
+  /**
    * Define output to be CSV rather than TSV
    */
   @Input()
   public outputFormat: 'csv' | 'tsv' = 'tsv';
+
+  /**
+   * Define the number of rows
+   */
+  @Input()
+  public set rowCount(value: number) {
+    this._rowCount = coerceNumberProperty(value, DEFAULT_ROW_COUNT);
+  }
+  public get rowCount(): number {
+    return this._rowCount;
+  }
+  private _rowCount: number = DEFAULT_ROW_COUNT;
 
   /**
    * Emit the built file blob

--- a/terminus-ui/date-range/src/date-range.component.ts
+++ b/terminus-ui/date-range/src/date-range.component.ts
@@ -38,11 +38,6 @@ export interface TsDateRange {
 /**
  * This is the date-range UI Component
  *
- * #### QA CSS CLASSES
- * - `qa-date-range`: The primary component container
- * - `qa-date-range-start-datepicker`: The start date {@link TsInputComponent}
- * - `qa-date-range-end-datepicker`: The end date {@link TsInputComponent}
- *
  * @example
  * <ts-date-range
  *              [dateFormGroup]="myForm.get('dateRange')"

--- a/terminus-ui/drawer/src/drawer-container.component.ts
+++ b/terminus-ui/drawer/src/drawer-container.component.ts
@@ -138,16 +138,11 @@ export class TsDrawerContainerComponent implements AfterContentInit, DoCheck, On
 
   /**
    * Whether the drawer container should have a backdrop while one of the drawers is open.
-   * If explicitly set to `true`, the backdrop will be enabled for drawers.
+   *
+   * If set to `true`, the backdrop will be enabled for all contained drawers.
    */
   @Input()
-  public set hasBackdrop(value: boolean) {
-    this._hasBackdrop = value;
-  }
-  public get hasBackdrop(): boolean {
-    return this._hasBackdrop;
-  }
-  public _hasBackdrop = false;
+  public hasBackdrop = false;
 
   /**
    * Event emitted when the drawer backdrop is clicked.

--- a/terminus-ui/drawer/src/drawer-footer.component.ts
+++ b/terminus-ui/drawer/src/drawer-footer.component.ts
@@ -1,16 +1,15 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  ElementRef,
   ViewEncapsulation,
 } from '@angular/core';
 
 /**
- * The drawer footer UI Component
+ * The footer component for the {@link TsDrawerComponent}
  *
  * @example
  * <ts-drawer-footer>
- *              THIS IS MY FOOTER
+ *              My content.
  * </ts-drawer-footer>
  *
  * <example-url>https://getterminus.github.io/ui-demos-release/components/drawer</example-url>

--- a/terminus-ui/drawer/src/drawer-header.component.ts
+++ b/terminus-ui/drawer/src/drawer-header.component.ts
@@ -1,16 +1,15 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  ElementRef,
   ViewEncapsulation,
 } from '@angular/core';
 
 /**
- * The drawer header UI Component
+ * The header component for the {@link TsDrawerComponent}
  *
  * @example
  * <ts-drawer-header>
- *              THIS IS MY HEADER
+ *              My content.
  * </ts-drawer-header>
  *
  * <example-url>https://getterminus.github.io/ui-demos-release/components/drawer</example-url>

--- a/terminus-ui/drawer/src/drawer.component.md
+++ b/terminus-ui/drawer/src/drawer.component.md
@@ -1,16 +1,16 @@
 <h1>Drawer</h1>
 
-Drawer component is designed to add side content to a small section of a page.
+The drawer component is designed to add side content to a section of content.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
-- [Basic Usage](#basic-usage)
-  - [Backdrop](#backdrop)
-  - [Mode](#mode)
-  - [Position](#position)
-  - [Collapsed size and expanded size](#collapsed-size-and-expanded-size)
+- [Basic usage](#basic-usage)
+- [Backdrop](#backdrop)
+- [Mode](#mode)
+- [Position](#position)
+  - [Collapsed and expanded sizes](#collapsed-and-expanded-sizes)
   - [Expand on load](#expand-on-load)
   - [Fixed header and footer](#fixed-header-and-footer)
 - [Events](#events)
@@ -20,9 +20,9 @@ Drawer component is designed to add side content to a small section of a page.
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
-## Basic Usage
+## Basic usage
 
-Define a drawer:
+Define a container, a drawer, and the page content:
 
 ```html
 <ts-drawer-container>
@@ -42,89 +42,72 @@ Define a drawer:
 </ts-drawer-container>
 ```
 
-### Backdrop
+## Backdrop
 
-If `hasBackdrop` set to `true`, users can close the drawer if they click the backdrops.
+If `hasBackdrop` is set to `true`, users can close the drawer by clicking outside (default is `false`):
 
 ```html
-<ts-drawer-container
-  hasBackdrop="true"
->
-  <ts-drawer>
-  
-  </ts-drawer>
+<ts-drawer-container hasBackdrop="true">
+  <ts-drawer>...</ts-drawer>
 </ts-drawer-container>
 ```
 
-`hasBackdrop` defaults to `false`.
+## Mode
 
-### Mode
-
-Mode property defines how a drawer expanded on the page. It defaults to `overlay`.
+The mode defines how the page content reacts to the drawer. A drawer can open over the page content (`overlay`) or push
+(`push`) the content to make room for the drawer (default is `overlay`):
 
 ```html
-<ts-drawer
-  [mode]="push"
->
+<ts-drawer [mode]="push">
+</ts-drawer>
+```
+ 
+## Position
+
+Consumers can specify which side of the container the drawer opens from. The default is `start` which opens from the
+left side of the page. If set to `end`, it would expand the drawer from right of the page.
+
+```html
+<ts-drawer [position]="end">
 </ts-drawer>
 ```
 
-We currently support two types of modes, `overlay` and `push`. 
-`overlay` means that the drawer floats over the main content, which is covered by a backdrop.
-`push` is that drawer pushes the primary content out of its way and also covering it with a backdrop.
- 
- ### Position
- 
- ```html
- <ts-drawer
-   [position]="end"
- >
- </ts-drawer>
- ```
- 
- Consumers can specify which side the drawer opens at. It defaults to `start`, which opens from the left of the page. If set to `end`, it would expand the drawer from right of the page.
- 
- NOTE: An error is thrown if users have more than one drawer in a given container with the same position AND `push` mode.
- 
- ### Collapsed size and expanded size
- 
- Users can specify the size of a drawer when it's collapsed and expanded.
- 
- ```html
- <ts-drawer
-   [collpasedSize]="2rem"
-   [expandedSize]="12rem"
- >
- </ts-drawer>
- ```
+NOTE: An error will be thrown if more than one drawer in a given container has the same position AND `push` mode set.
 
-`collapsedSize` defaults to `3.75rem` and `expandedSize` to `12.5rem` if not specified.
+### Collapsed and expanded sizes
+
+The size of a drawer when it's collapsed and expanded can be customized:
+
+```html
+<ts-drawer
+  [collapsedSize]="2rem"
+  [expandedSize]="12rem"
+></ts-drawer>
+```
+
+NOTE: `collapsedSize` defaults to `3.75rem` and `expandedSize` to `12.5rem`.
 
 ### Expand on load
 
-Users can set the drawer to expand on load
+The drawer can be forced to expand on load:
 
 ```html
-<ts-drawer
-  [isExpanded]="true"
->
+<ts-drawer [isExpanded]="true">
 </ts-drawer>
 ```
 
-`isExpanded` set to `true` would have drawer expanded on load. It defaults to `false`.
-
 ### Fixed header and footer
 
-Users can set drawer header and footer within a drawer, both are sticky to the view.
+The drawer supports both a header and footer:
 
 ```html
 <ts-drawer-header>
-  THIS IS MY HEADER
+  My header content...
 </ts-drawer-header>
 ```
 ```html
 <ts-drawer-footer>
-  THIS IS MY FOOTER
+  My footer content...
 </ts-drawer-footer>
 ```
 
@@ -132,15 +115,15 @@ Users can set drawer header and footer within a drawer, both are sticky to the v
 
 ### Container events
 
-| Event              | Description                                    | Payload                  |
-|:-------------------|:-----------------------------------------------|:-------------------------|
-| `backdropClick`    | Fired when backdrop is clicked                 |  void                    |
+| Event           | Description                    | Payload |
+|:----------------|:-------------------------------|:--------|
+| `backdropClick` | Fired when backdrop is clicked | void    |
 
 ### Drawer events
 
-| Event             | Description                                 | Payload                 |
-|:------------------|:--------------------------------------------|:------------------------|
-| `expandedStart`   | Fired when the drawer expansion starts      |    void                 |
-| `collapsedStart`  | Fired when the drawer collapse starts       |    void                 |
-| `expandedChange`  | Fired when state change ends (animation ends)| boolean                  |
+| Event            | Description                                   | Payload |
+|:-----------------|:----------------------------------------------|:--------|
+| `expandedStart`  | Fired when the drawer expansion starts        | void    |
+| `collapsedStart` | Fired when the drawer collapse starts         | void    |
+| `expandedChange` | Fired when state change ends (animation ends) | boolean |
 

--- a/terminus-ui/drawer/src/drawer.component.ts
+++ b/terminus-ui/drawer/src/drawer.component.ts
@@ -58,12 +58,12 @@ export const TS_DRAWER_DEFAULT_EXPAND_SIZE = '12.5rem';
  *
  * @example
  * <ts-drawer
- *              [mode]="mode"
- *              [position]="position"
  *              [collapsedSize]="collapsedSize"
  *              [expandedSize]="expandedSize"
- *              [role]="role"
  *              [isExpanded]="isExpanded"
+ *              [mode]="mode"
+ *              [position]="position"
+ *              [role]="role"
  *              (expandedChange)="expandedChanged($event)"
  *              (expandedStart)="expandedStarted($event)"
  *              (collapsedStart)="collapsedStarted($event)"
@@ -99,7 +99,6 @@ export const TS_DRAWER_DEFAULT_EXPAND_SIZE = '12.5rem';
   exportAs: 'tsDrawer',
 })
 export class TsDrawerComponent implements AfterContentChecked, OnDestroy {
-
   /**
    * Define animation state, defaults to void state
    */
@@ -132,12 +131,6 @@ export class TsDrawerComponent implements AfterContentChecked, OnDestroy {
   public readonly modeChanged = new Subject();
 
   /**
-   * aria role label, default to nothing
-   */
-  @Input()
-  public role = '';
-
-  /**
    * Collapsed drawer width
    */
   @Input()
@@ -162,6 +155,31 @@ export class TsDrawerComponent implements AfterContentChecked, OnDestroy {
   public _expandedSize = '12.75rem';
 
   /**
+   * Define whether the drawer is open
+   */
+  @Input()
+  public set isExpanded(value: boolean) {
+    this.toggle(value);
+  }
+  public get isExpanded(): boolean {
+    return this._isExpanded;
+  }
+  private _isExpanded = false;
+
+  /**
+   * Mode of the drawer, overlay or push
+   */
+  @Input()
+  public set mode(value: TsDrawerModes) {
+    this._mode = value;
+    this.modeChanged.next();
+  }
+  public get mode(): TsDrawerModes {
+    return this._mode;
+  }
+  private _mode: TsDrawerModes = 'overlay';
+
+  /**
    * The side that the drawer is attached to.
    */
   @Input()
@@ -179,34 +197,15 @@ export class TsDrawerComponent implements AfterContentChecked, OnDestroy {
   private _position: TsDrawerPosition = 'start';
 
   /**
-   * Mode of the drawer, overlay or push
+   * Define the aria role label, default to nothing
    */
   @Input()
-  public set mode(value: TsDrawerModes) {
-    this._mode = value;
-    this.modeChanged.next();
-  }
-  public get mode(): TsDrawerModes {
-    return this._mode;
-  }
-  private _mode: TsDrawerModes = 'overlay';
-
-  /**
-   * Whether the drawer is opened. We overload this because we trigger an event when it
-   * starts or end.
-   */
-  @Input()
-  public set isExpanded(value: boolean) {
-    this.toggle(value);
-  }
-  public get isExpanded(): boolean {
-    return this._isExpanded;
-  }
-  private _isExpanded = false;
+  public role = '';
 
   /**
    * Event emitted when the drawer open state is changed.
-   * Note this has to be async in order to avoid some issues with two-bindings - setting isAsync to true.
+   *
+   * NOTE: This has to be async in order to avoid some issues with two-way bindings - setting isAsync to true.
    */
   @Output()
   public readonly expandedChange = new EventEmitter<boolean>(true);

--- a/terminus-ui/expansion-panel/src/expansion-panel.component.md
+++ b/terminus-ui/expansion-panel/src/expansion-panel.component.md
@@ -5,15 +5,15 @@
 **Table of Contents**
 
 - [Basic usage](#basic-usage)
-  - [Title and description](#title-and-description)
-  - [Disable a panel](#disable-a-panel)
-  - [Default a panel open](#default-a-panel-open)
-  - [Lazy loaded content](#lazy-loaded-content)
-  - [Panel events](#panel-events)
-  - [Custom trigger heights](#custom-trigger-heights)
-  - [Manual panel control](#manual-panel-control)
+- [Title and description](#title-and-description)
+- [Disable a panel](#disable-a-panel)
+- [Default a panel open](#default-a-panel-open)
+- [Lazy loaded content](#lazy-loaded-content)
+- [Panel events](#panel-events)
+- [Custom trigger heights](#custom-trigger-heights)
+- [Manual panel control](#manual-panel-control)
 - [Accordion](#accordion)
-  - [Allow mutiple panels to be open](#allow-mutiple-panels-to-be-open)
+  - [Allow multiple panels to be open](#allow-multiple-panels-to-be-open)
   - [Accordion events](#accordion-events)
   - [Accordion as a stepper](#accordion-as-a-stepper)
   - [Hide toggle](#hide-toggle)
@@ -22,8 +22,6 @@
 - [Test Helpers](#test-helpers)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-
 
 
 ## Basic usage
@@ -43,7 +41,7 @@ The most basic usage is a single panel with a trigger:
 > NOTE: Without a trigger, the panel will not be visible.
 
 
-### Title and description
+## Title and description
 
 Trigger text can be split into `title` and `description` using the `TsExpansionPanelTitleComponent` and
 `TsExpansionPanelDescriptionComponent` respectively.
@@ -68,9 +66,9 @@ Trigger text can be split into `title` and `description` using the `TsExpansionP
 ```
 
 
-### Disable a panel
+## Disable a panel
 
-The `isDisabled` flag will disable a panel and it's trigger.
+The `isDisabled` flag will disable a panel and it's trigger:
 
 ```html
 <ts-expansion-panel [isDisabled]="true">
@@ -83,7 +81,7 @@ The `isDisabled` flag will disable a panel and it's trigger.
 ```
 
 
-### Default a panel open
+## Default a panel open
 
 The `isExpanded` flag will change the state of a panel. This can be used to default to a specific state or to dynamically change the state.
 
@@ -98,7 +96,7 @@ The `isExpanded` flag will change the state of a panel. This can be used to defa
 ```
 
 
-### Lazy loaded content
+## Lazy loaded content
 
 Panel content can be lazily loaded by using a template with the `tsExpansionPanelContent` directive. The template will not be loaded until
 the panel is opened for the first time. The content will remain in the DOM until the panel is destroyed.
@@ -116,7 +114,7 @@ the panel is opened for the first time. The content will remain in the DOM until
 ```
 
 
-### Panel events
+## Panel events
 
 | Event            | Description                                        | Payload   |
 |:-----------------|:---------------------------------------------------|:----------|
@@ -134,7 +132,7 @@ the panel is opened for the first time. The content will remain in the DOM until
 ```
 
 
-### Custom trigger heights
+## Custom trigger heights
 
 Custom heights can be set for a trigger's collapsed and/or expanded state.
 
@@ -153,9 +151,9 @@ Custom heights can be set for a trigger's collapsed and/or expanded state.
 </ts-expansion-panel>
 ```
 
-### Manual panel control
+## Manual panel control
 
-Panels can be programatically opened, closed or toggled through a reference to the instance.
+Panels can be programmatically opened, closed or toggled through a reference to the instance:
 
 ```typescript
 @ViewChild(TsExpansionPanelComponent, {static: false})
@@ -188,7 +186,7 @@ An accordion is created by wrapping two or more `TsExpansionPanelComponent`s ins
 ```
 
 
-### Allow mutiple panels to be open
+### Allow multiple panels to be open
 
 By default an accordion can only have a single panel open at a time. This functionality can be change with the `multi` input.
 
@@ -223,7 +221,7 @@ An accordion can function as a stepper which can be useful for guided flows. To 
 the `ts-expansion-panel-action-row`.
 
 ```html
-<!-- Hide the toggle icon since this is a programatically controlled flow -->
+<!-- Hide the toggle icon since this is a programmatically controlled flow -->
 <ts-accordion [hideToggle]="true">
   <!-- STEP 1 -->
   <ts-expansion-panel [isExpanded]="activeStep === 0">
@@ -280,7 +278,7 @@ the `ts-expansion-panel-action-row`.
 
 ### Hide toggle
 
-When an accordion is controlled programatically, the toggle icon can be hidden to avoid confusion for the user. Setting `hideToggle` on the
+When an accordion is controlled programmatically, the toggle icon can be hidden to avoid confusion for the user. Setting `hideToggle` on the
 accordion will hide the toggle icon for *all panels within*.
 
 > NOTE: This should _only_ be used in cases when the accordion is functioning as a stepper.
@@ -322,7 +320,7 @@ controls.
 
 ### Open or close all panels
 
-An accordion can programatically open or close all panels at once.
+An accordion can programmatically open or close all panels at once.
 
 ```typescript
 @ViewChild(TsAccordionComponent, {static: false})
@@ -335,10 +333,6 @@ accordion.closeAll();
 ```
 
 > NOTE: These methods will *not* change the state of disabled panels.
-
-
-
-
 
 
 ## Test Helpers

--- a/terminus-ui/expansion-panel/src/expansion-panel.component.ts
+++ b/terminus-ui/expansion-panel/src/expansion-panel.component.ts
@@ -148,7 +148,7 @@ export class TsExpansionPanelComponent extends CdkAccordionItem implements After
   /**
    * A stored reference to the document
    */
-  private document: Document;
+  private readonly document: Document;
 
   /**
    * The ID for the associated trigger element. Used for a11y labelling.

--- a/terminus-ui/file-upload/src/file-upload.component.md
+++ b/terminus-ui/file-upload/src/file-upload.component.md
@@ -42,7 +42,7 @@ Collect the selected file via the `selected` event:
 
 The `TsSelectedFile` instance will have several items available:
 
-```typescript
+```
 file.fileContents // string
 file.height       // number (will be 0 for CSVs)
 file.isCSV        // boolean
@@ -190,6 +190,11 @@ If a file is loaded that do not meet any ratio constraints, a validation message
 
 The user can clear the selected file by clicking the `X` button next to the filename. An event will be emitted when this occurs:
 
+```html
+<ts-file-upload (cleared)="fileWasCleared()">
+</ts-file-upload>
+```
+
 ```typescript
 ...
 
@@ -198,15 +203,15 @@ The user can clear the selected file by clicking the `X` button next to the file
   }
 ```
 
-```html
-<ts-file-upload (cleared)="fileWasCleared()">
-</ts-file-upload>
-```
-
 
 ## Showing upload progress
 
 The progress of an upload can be reflected in the UI by passing a number between 0 and 100 to the `progress` input:
+
+```html
+<ts-file-upload [progress]="myProgress">
+</ts-file-upload>
+```
 
 ```typescript
 ...
@@ -226,11 +231,6 @@ The progress of an upload can be reflected in the UI by passing a number between
   }
 ```
 
-```html
-<ts-file-upload [progress]="myProgress">
-</ts-file-upload>
-```
-
 
 ## Enable multiple file selection
 
@@ -248,6 +248,26 @@ Currently this component does not natively handle multiple file uploads (this su
 that functionality in a way.
 
 An example:
+
+```html
+<!--
+  Here is the original file upload. Initially this is all the user sees.
+  When multiple files are selected, they will be emitted through this event:
+-->
+<ts-file-upload
+  (selectedMultiple)="selectedMultiple($event)"
+></ts-file-upload>
+
+<!-- Loop over the files that were collected from the selectedMultiple event -->
+<ng-container *ngFor="let v of files">
+  <ts-file-upload
+    <!-- Only show this upload if the file still exists in our files collection: -->
+    *ngIf="fileExists(v.id)"
+    <!-- Seed the file input with the file from our collection: -->
+    [seedFile]="v.file"
+  ></ts-file-upload>
+</ng-container>
+```
 
 ```typescript
 ...
@@ -290,24 +310,4 @@ An example:
 
     return found ? true : false;
   }
-```
-
-```html
-<!--
-  Here is the original file upload. Initially this is all the user sees.
-  When multiple files are selected, they will be emitted through this event:
--->
-<ts-file-upload
-  (selectedMultiple)="selectedMultiple($event)"
-></ts-file-upload>
-
-<!-- Loop over the files that were collected from the selectedMultiple event -->
-<ng-container *ngFor="let v of files">
-  <ts-file-upload
-    <!-- Only show this upload if the file still exists in our files collection: -->
-    *ngIf="fileExists(v.id)"
-    <!-- Seed the file input with the file from our collection: -->
-    [seedFile]="v.file"
-  ></ts-file-upload>
-</ng-container>
 ```

--- a/terminus-ui/file-upload/src/file-upload.component.ts
+++ b/terminus-ui/file-upload/src/file-upload.component.ts
@@ -75,34 +75,25 @@ let nextUniqueId = 0;
 /**
  * This is the file-upload UI Component
  *
- * #### QA CSS CLASSES
- * - `qa-file-upload`: Placed on the primary container
- * - `qa-file-upload-empty`: Placed on the container shown when no file exists
- * - `qa-file-upload-preview`: The file preview container
- * - `qa-file-upload-name`: The filename container
- * - `qa-file-upload-remove`: The button to remove a loaded file
- * - `qa-file-upload-prompt`: The button to open the native file picker
- * - `qa-file-upload-validation-messages`: The container for validation messages
- * - `qa-file-upload-hints`: The container for input hints
- * - `qa-file-upload-progress`: The upload progress bar
- *
  * @example
  * <ts-file-upload
  *              accept="['image/png', 'image/jpg']"
- *              id="my-id"
- *              maximumKilobytesPerFile="{{ 10 * 1024 }}"
- *              ratioConstraints="['2:1', '3:4']"
- *              [multiple]="false"
- *              [formControl]="myForm.get('myControl')"
- *              [progress]="myUploadProgress"
- *              [seedFile]="myFile"
  *              dimensionConstraints="myConstraints" (see TsFileImageDimensionConstraints)
+ *              [formControl]="myForm.get('myControl')"
+ *              [hideButton]="false"
+ *              id="my-id"
+ *              [isDisabled]="true"
+ *              maximumKilobytesPerFile="{{ 10 * 1024 }}"
+ *              [multiple]="false"
+ *              [progress]="myUploadProgress"
+ *              ratioConstraints="['2:1', '3:4']"
+ *              [seedFile]="myFile"
  *              theme="primary"
+ *              (cleared)="fileWasCleared($event)"
  *              (enter)="userDragBegin($event)"
  *              (exit)="userDragEnd($event)"
  *              (selected)="handleFile($event)"
  *              (selectedMultiple)="handleMultipleFiles($event)"
- *              (cleared)="fileWasCleared($event)"
  * ></ts-file-upload>
  *
  * <example-url>https://getterminus.github.io/ui-demos-release/components/file-upload</example-url>
@@ -241,6 +232,18 @@ export class TsFileUploadComponent extends TsReactiveFormBaseComponent implement
   private _acceptedTypes: TsFileAcceptedMimeTypes[] = TS_ACCEPTED_MIME_TYPES.slice();
 
   /**
+   * Define maximum and minimum pixel dimensions for images
+   */
+  @Input()
+  public set dimensionConstraints(value: TsFileImageDimensionConstraints | undefined) {
+    this._sizeConstraints = value;
+  }
+  public get dimensionConstraints(): TsFileImageDimensionConstraints | undefined {
+    return this._sizeConstraints;
+  }
+  private _sizeConstraints: TsFileImageDimensionConstraints | undefined;
+
+  /**
    * Create a form control to manage validation messages
    */
   @Input()
@@ -289,6 +292,24 @@ export class TsFileUploadComponent extends TsReactiveFormBaseComponent implement
   private _maximumKilobytesPerFile: number = MAXIMUM_KILOBYTES_PER_FILE;
 
   /**
+   * Define if multiple files may be uploaded
+   */
+  @Input()
+  public multiple = false;
+
+  /**
+   * Define the upload progress
+   */
+  @Input()
+  public set progress(value: number) {
+    this._progress = coerceNumberProperty(value);
+  }
+  public get progress(): number {
+    return this._progress;
+  }
+  private _progress = 0;
+
+  /**
    * Define supported ratio for images
    */
   @Input()
@@ -308,24 +329,6 @@ export class TsFileUploadComponent extends TsReactiveFormBaseComponent implement
     return this.parseRatioToString(this._ratioConstraints);
   }
   private _ratioConstraints: Array<ImageRatio> | undefined;
-
-  /**
-   * Define if multiple files may be uploaded
-   */
-  @Input()
-  public multiple = false;
-
-  /**
-   * Define the upload progress
-   */
-  @Input()
-  public set progress(value: number) {
-    this._progress = coerceNumberProperty(value);
-  }
-  public get progress(): number {
-    return this._progress;
-  }
-  private _progress = 0;
 
   /**
    * Seed an existing file (used for multiple upload hack)
@@ -360,22 +363,16 @@ export class TsFileUploadComponent extends TsReactiveFormBaseComponent implement
   private _seedFile: File | undefined;
 
   /**
-   * Define maximum and minimum pixel dimensions for images
-   */
-  @Input()
-  public set dimensionConstraints(value: TsFileImageDimensionConstraints | undefined) {
-    this._sizeConstraints = value;
-  }
-  public get dimensionConstraints(): TsFileImageDimensionConstraints | undefined {
-    return this._sizeConstraints;
-  }
-  private _sizeConstraints: TsFileImageDimensionConstraints | undefined;
-
-  /**
    * Define the theme. See {@link TsStyleThemeTypes}.
    */
   @Input()
   public theme: TsStyleThemeTypes = 'primary';
+
+  /**
+   * Event emitted when the user clears a loaded file
+   */
+  @Output()
+  public readonly cleared = new EventEmitter<boolean>();
 
   /**
    * Event emitted when the user's cursor enters the field while dragging a file
@@ -400,12 +397,6 @@ export class TsFileUploadComponent extends TsReactiveFormBaseComponent implement
    */
   @Output()
   public readonly selectedMultiple = new EventEmitter<File[]>();
-
-  /**
-   * Event emitted when the user clears a loaded file
-   */
-  @Output()
-  public readonly cleared = new EventEmitter<boolean>();
 
   /**
    * HostListeners

--- a/terminus-ui/icon-button/src/icon-button.component.md
+++ b/terminus-ui/icon-button/src/icon-button.component.md
@@ -1,3 +1,5 @@
+<h1>Icon Button</h1>
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
@@ -7,6 +9,7 @@
 - [Accessibility](#accessibility)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 
 ## Basic usage
 

--- a/terminus-ui/icon-button/src/icon-button.component.ts
+++ b/terminus-ui/icon-button/src/icon-button.component.ts
@@ -16,9 +16,6 @@ import {
 /**
  * This is the icon-button UI Component
  *
- * #### QA CSS CLASSES
- * - `qa-icon-button`: Placed on the primary container
- *
  * @example
  * <ts-icon-button
  *              actionName="Menu"

--- a/terminus-ui/icon/src/icon.component.md
+++ b/terminus-ui/icon/src/icon.component.md
@@ -89,7 +89,9 @@ Custom icons are accessed via a `ts-icon` `@Input`:
 ```
 
 ## Special Cases
-Any icon with a -color suffix will not accept themes. Currently they accept a background, but the display might be problematic and background should be used with extreme caution. A non "-color" version should be used instead.
+
+Any icon with a -color suffix will not accept themes. Currently they accept a background, but the display might be
+problematic and background should be used with extreme caution. A non "-color" version should be used instead.
 
 
 ### Available

--- a/terminus-ui/input/src/input.component.md
+++ b/terminus-ui/input/src/input.component.md
@@ -112,7 +112,7 @@ When using `ngModel`, validations are placed on the input as data-attributes (ju
 ></ts-input>
 ```
 
-If only the required asterisk is needed rather than valiation errors, the `isRequired` flag can be used:
+If only the required asterisk is needed rather than validation errors, the `isRequired` flag can be used:
 
 ```html
 <ts-input

--- a/terminus-ui/link/src/link.component.md
+++ b/terminus-ui/link/src/link.component.md
@@ -54,7 +54,7 @@ A custom tabindex can also be set:
 
 ## Local URL fragments
 
-Local fragements are supported for deep linking within a page:
+Local fragments are supported for deep linking within a page:
 
 ```html
 <ts-link

--- a/terminus-ui/login-form/src/login-form.component.md
+++ b/terminus-ui/login-form/src/login-form.component.md
@@ -1,5 +1,6 @@
 <h1>Login Form</h1>
 
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
@@ -8,12 +9,13 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+
 ## Basic Usage
 
 Create a basic login form with submit function:
 
 ```html
 <ts-login-form
-  (submission)="mySumbitFunction($event)"
+  (submission)="mySubmitFunction($event)"
 ></ts-login-form>
 ```

--- a/terminus-ui/logo/src/logo.component.md
+++ b/terminus-ui/logo/src/logo.component.md
@@ -10,28 +10,29 @@
 - [Colors](#colors)
 - [Sizing](#sizing)
 - [Special Cases](#special-cases)
-- [Available](#available)
+- [Available logos](#available-logos)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
 ## Basic usage
 
-The most basic implementation is only html. Defaults to full gradient type. 
+The most basic implementation is only HTML:
 
 ```html
 <ts-logo></ts-logo>
 ```
 
 ## Type
-Types are full logo or mark, gradient (full color) or solid.
+
+Multiple logo types are available:
 
 ```html
 <ts-logo type="full-solid"></ts-logo>
 <ts-logo type="mark-gradient"></ts-logo>
 ```
 
-Search `TS_LOGO_TYPES` to see all allowed types.
+See `TS_LOGO_TYPES` to see all allowed types.
 
 ## Colors
 
@@ -42,26 +43,22 @@ Solid logos are white by default, but can also be black (Terminus Dark) or gray 
 <ts-logo type="mark-solid" logoColor="black"></ts-logo>
 ```
 
-Search for `TS_LOGO_COLORS` to see all allowed logo colors.
-
+See for `TS_LOGO_COLORS` to see all allowed logo colors.
 
 ## Sizing
-The four main logos are full-size so they will adapt to the *width* of their container. Changing the height of the parent container will result in weird spacing issues, and is not recommended.
 
-
+The four main logos are full-size so they will adapt to the width of their container.
 
 ## Special Cases
-Any logo with a gradient will not honor a logoColor.
-Sometimes marketing will request a logo for marketing purposes and those logos have special rules. 
 
+- Any logo with a gradient will not honor a logoColor.
 
+## Available logos
 
-## Available
-
-| Name                | Description                                                                                                 |
-|--------------------:|:------------------------------------------------------------------------------------------------------------|
-| `full-account-hub`  | Special logo for Account Hub, includes spacing and color, should be used according to marketing standards   |
-| `full-gradient`     | Default. Gradient mark with logo gray "terminus" text                                                       |
-| `full-solid`        | Mark with "terminus" text, white by default, accepts logoColor                                              |
-| `mark-gradient`     | T formed by arrow on top and blocks below to form a T in negative space, postive space has gradient         |
-| `mark-solid`        | T formed by arrow on top and blocks below to form a T in negative space, postive space is white by default  |
+|               Name | Description                                                                                                 |
+|-------------------:|:------------------------------------------------------------------------------------------------------------|
+| `full-account-hub` | Special logo for Account Hub, includes spacing and color, should be used according to marketing standards   |
+|    `full-gradient` | Default. Gradient mark with logo gray "terminus" text                                                       |
+|       `full-solid` | Mark with "terminus" text, white by default, accepts logoColor                                              |
+|    `mark-gradient` | T formed by arrow on top and blocks below to form a T in negative space, positive space has gradient        |
+|       `mark-solid` | T formed by arrow on top and blocks below to form a T in negative space, positive space is white by default |

--- a/terminus-ui/menu/src/menu.component.md
+++ b/terminus-ui/menu/src/menu.component.md
@@ -1,11 +1,15 @@
+<h1>Menu</h1>
+
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
 - [Basic Usage](#basic-usage)
-- [Checkbox Menu](#checkbox-menu)
+- [Checkbox menu](#checkbox-menu)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 
 ## Basic Usage
 
@@ -33,7 +37,7 @@ proxied through event emitters.
 > NOTE: `<ts-link>` and `<ts-button>` will be styled the same within a menu.
 
 
-## Checkbox Menu
+## Checkbox menu
 
 > This is very similar to the basic usage example, with a few small, key differences.
 

--- a/terminus-ui/menu/src/menu.component.ts
+++ b/terminus-ui/menu/src/menu.component.ts
@@ -17,8 +17,8 @@ import { TsStyleThemeTypes } from '@terminus/ui/utilities';
 /**
  * Define the allowed X positions for a menu
  */
-export type TsMenuPositionTypesX =
-  'before'
+export type TsMenuPositionTypesX
+  = 'before'
   | 'after'
 ;
 
@@ -26,8 +26,8 @@ export type TsMenuPositionTypesX =
 /**
  * Define the allowed Y positions for a menu
  */
-export type TsMenuPositionTypesY =
-  'above'
+export type TsMenuPositionTypesY
+  = 'above'
   | 'below'
 ;
 
@@ -44,20 +44,16 @@ export type TsMenuTriggerTypes
 /**
  * A presentational component to render a dropdown menu.
  *
- * #### QA CSS CLASSES
- * -`qa-menu`: Placed on the wrapper around the menu items
- * -`qa-menu-trigger`: Placed on the menu trigger
- *
  * @example
  * <ts-menu
  *              [defaultOpened]="false"
+ *              format="filled"
  *              [isDisabled]="false"
  *              [menuItemsTemplate]="myTemplate"
  *              menuPositionX="20px"
  *              menuPositionY="20px"
  *              theme="accent"
  *              triggerType="utility"
- *              (selected)="myMethod($event)"
  * >Select Item</ts-menu>
  *
  * <example-url>https://getterminus.github.io/ui-demos-release/components/menu</example-url>
@@ -112,6 +108,12 @@ export class TsMenuComponent implements AfterViewInit, OnInit {
   public defaultOpened = false;
 
   /**
+   * Define the button format
+   */
+  @Input()
+  public format: TsButtonFormatTypes = 'filled';
+
+  /**
    * Define if the menu should be disabled
    */
   @Input()
@@ -140,12 +142,6 @@ export class TsMenuComponent implements AfterViewInit, OnInit {
    */
   @Input()
   public theme: TsStyleThemeTypes = 'primary';
-
-  /**
-   * Define the button format
-   */
-  @Input()
-  public format: TsButtonFormatTypes = 'filled';
 
   /**
    * Define the type of trigger {@link TsMenuTriggerTypes}

--- a/terminus-ui/navigation/src/navigation.component.md
+++ b/terminus-ui/navigation/src/navigation.component.md
@@ -5,34 +5,34 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
-- [Basic Usage](#basic-usage)
-- [Navigation Item](#navigation-item)
+- [Basic usage](#basic-usage)
+- [Navigation item](#navigation-item)
   - [Actions](#actions)
   - [Links](#links)
-- [Nav Items Array](#nav-items-array)
-- [Welcome Message](#welcome-message)
+- [Nav items array](#nav-items-array)
+- [Welcome message](#welcome-message)
 - [User](#user)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
+## Basic usage
 
-## Basic Usage
-
-Create a navigation menu. A navigation menu is a collection of [Nav Items](#nav-items) grouped together, with a space for [User](#user) and [Welcome Message](#welcome-message).
+Create a navigation menu. A navigation menu is a collection of [Nav Items](#nav-items) grouped together, with a space for [User](#user)  
+ and [Welcome Message](#welcome-message).
 
 ```html
 <ts-navigation
   [items]="navigationItems$"
   (itemSelected)="myMethod($event)"
-  >
-</ts-navigation>
+></ts-navigation>
 ```
 
 
-## Navigation Item
+## Navigation item
 
-An object describing a "link" within the navigation. It gets a name, an action or destination, and a boolean alwaysHidden. Optionally, it can receive boolean values for `isForAdmin` and `isDisabled`.
+An object describing a "link" within the navigation. It gets a name, an action or destination, and a boolean `alwaysHidden`. Optionally,  
+ it can receive boolean values for `isForAdmin` and `isDisabled`.
 
 ```typescript
 const NEW_NAV_ITEM: TsNavigationItem = {
@@ -44,7 +44,6 @@ const NEW_NAV_ITEM: TsNavigationItem = {
 };
 ```
 \- or -
-
 ```typescript
 const NEW_NAV_ITEM: TsNavigationItem = {
   name: '1 Bar',
@@ -61,7 +60,7 @@ An action is an object with a `type`. It gets emitted upon click.
 
 A link is a string or string[], with a `destination` and optional boolean `isExternal`. Without isExternal, a link is considered a router link, and with isExternal, it's treated as an href.
 
-## Nav Items Array
+## Nav items array
 
 An array of navigation items that is passed to `ts-navigation` as `items`.
 
@@ -86,30 +85,30 @@ const NAV_ITEMS_MOCK: TsNavigationItem[] = [
 ```
 
 
-## Welcome Message
-A message presented with the user name in the navigation. Default message is `Welcome`. Custom messages will truncate after exceeding `welcomeMsgLength` which is also customizable, and defaults to 25 characters. Any truncated message will appears with ellipses and have a tooltip with the full message.
+## Welcome message
+
+A message presented with the user name in the navigation. Default message is `Welcome`. Custom messages will truncate
+after exceeding `welcomeMsgLength` which is also customizable, and defaults to 25 characters. Any truncated message will appears with
+ellipses and have a tooltip with the full message.
 
 ```html
 <ts-navigation
-  [items]="navigationItems$"
-  (itemSelected)="myMethod($event)"
   welcomeMessage="Welcome back,"
   welcomeMsgLength="15"
-  >
-</ts-navigation>
+></ts-navigation>
 ```
 
 
 ## User
-The user's name which, if defined, displays with the welcome message, in a location separate from the items. User names will truncate after exceeding `userNameLength` which is also customizable, and defaults to 20 characters. A truncated user name will appear with ellipses and have a tooltip with the full name.
+
+The user's name which, if defined, displays with the welcome message, in a location separate from the items. User names will truncate after  
+ exceeding `userNameLength` which is also customizable, and defaults to 20 characters. A truncated user name will appear with ellipses and  
+ have a tooltip with the full name.
 
 ```html
 <ts-navigation
-  [items]="navigationItems$ | async"
-  (itemSelected)="myMethod($event)"
   [user]="currentUser$ | async"
   userNameLength="10"
-  >
-</ts-navigation>
+></ts-navigation>
 ```
 

--- a/terminus-ui/navigation/src/navigation.component.ts
+++ b/terminus-ui/navigation/src/navigation.component.ts
@@ -129,24 +129,12 @@ const DEFAULT_WELCOME_MESSAGE_MAX_LENGTH = 20;
 /**
  * This is the navigation UI Component
  *
- * #### QA CSS CLASSES
- * - `qa-navigation`: Placed on the nav element which contains this component
- * - `qa-navigation-items`: Placed on the div element which contains the navigation items
- * - `qa-navigation-item`: Placed on the button elements which represent each visible navigation
- * item
- * - `qa-navigation-secondary-trigger`: Placed on the button element which displays the drop down
- * containing secondary links when clicked
- * - `qa-navigation-secondary-items`: Placed on the menu element which contains the secondary
- * navigation items
- * - `qa-navigation-secondary-item`: Placed on the button elements which represent each secondary
- * navigation item
- *
  * @example
  * <ts-navigation
  *              [items]="navigationItems$ | async"
  *              [user]="currentUser$ | async"
- *              welcomeMessage="Hi!"
  *              userNameLength="20"
+ *              welcomeMessage="Hi!"
  *              welcomeMsgLength="25"
  *              (itemSelected)="myMethod($event)"
  * ></ts-navigation>

--- a/terminus-ui/option/src/option.component.ts
+++ b/terminus-ui/option/src/option.component.ts
@@ -92,16 +92,12 @@ let nextUniqueId = 0;
 /**
  * Single option inside of a {@link TsSelectComponent}
  *
- * #### QA CSS CLASSES
- * - `qa-option-checkbox`: The option checkbox
- * - `qa-option-text`: The option text content
- *
  * @example
  * <ts-option
  *              id="my-id"
  *              [isDisabled]="true"
- *              value="My value!"
  *              [option]="myOptionObject"
+ *              value="My value!"
  *              (selectionChange)="selectedStateChanged($event)"
  * ></ts-option>
  *
@@ -242,13 +238,6 @@ export class TsOptionComponent implements Highlightable, AfterContentInit, After
   private _isDisabled = false;
 
   /**
-   * The form value of the option
-   */
-  @Input()
-  // tslint:disable-next-line no-any
-  public value: any;
-
-  /**
    * Define the option data object (needed for template support)
    */
   @Input()
@@ -259,6 +248,13 @@ export class TsOptionComponent implements Highlightable, AfterContentInit, After
     return this._option;
   }
   private _option: TsOption | undefined;
+
+  /**
+   * The form value of the option
+   */
+  @Input()
+  // tslint:disable-next-line no-any
+  public value: any;
 
   /**
    * Event emitted when the option is selected or deselected

--- a/terminus-ui/paginator/src/paginator.component.md
+++ b/terminus-ui/paginator/src/paginator.component.md
@@ -8,7 +8,7 @@
 - [Basic usage](#basic-usage)
 - [Events](#events)
 - [Current page](#current-page)
-- [Zero or One based pagination](#zero-or-one-based-pagination)
+- [Zero or one based pagination](#zero-or-one-based-pagination)
 - [Record count too high](#record-count-too-high)
   - [Max records](#max-records)
   - [Record count message](#record-count-message)
@@ -19,7 +19,7 @@
 
 ## Basic usage
 
-For the most minimal implementation, just pass in the total record count:
+For the most minimal implementation, just pass in the total number of records:
 
 ```html
 <ts-paginator
@@ -29,8 +29,7 @@ For the most minimal implementation, just pass in the total record count:
 
 ## Events
 
-The paginator will emit the current page each time the page is changed or the records-per-page count
-is changed:
+The paginator will emit the current page each time the page is changed or the records-per-page count is changed:
 
 ```html
 <ts-paginator
@@ -57,7 +56,7 @@ myChangeFunc(v: number) {
 
 ## Current page
 
-Set the current page:
+Define the current active page by index:
 
 ```html
 <ts-paginator
@@ -67,7 +66,7 @@ Set the current page:
 ```
 
 
-## Zero or One based pagination
+## Zero or one based pagination
 
 By default the paginator starts the pages array with a value of '0'. If your API starts it's
 pagination at 1 (such as Rails) you can set `isZeroBased` to `false`:
@@ -88,12 +87,12 @@ pagination at 1 (such as Rails) you can set `isZeroBased` to `false`:
 
 ## Record count too high
 
-The paginator will display a message if too many records are found. This is to encourage better
-filtering rather than more time paging through results.
+The paginator will display a message if too many records are found. This is to encourage better filtering rather than
+spending time paging through results.
 
 ### Max records
 
-By default, anything over `100` is considered too many. To change this value, pass in a number to
+By default, anything over `100` is considered too many records. To change this value, pass in a number to
 `maxPreferredRecords`:
 
 ```html
@@ -110,17 +109,17 @@ A custom message may be defined:
 ```html
 <ts-paginator
   [totalRecords]="100"
-  recordCountTooHighMessage="What they heck are you looking for?"
+  recordCountTooHighMessage="What the heck are you looking for?"
 ></ts-paginator>
 ```
 
-A custom message template can also be defined. This allows dynamic links to documentation, help or a
-better set of filters.
+A custom message template can also be defined. This allows dynamic links to documentation, help, or a better set of
+filters.
 
 ```html
 <ts-paginator
   [totalRecords]="100"
-  recordCountTooHighMessage="What they heck are you looking for?"
+  recordCountTooHighMessage="What the heck are you looking for?"
   [paginatorMessageTemplate]="myTemplate"
 ></ts-paginator>
 
@@ -129,13 +128,13 @@ better set of filters.
   example.
 -->
 <ng-template #myTemplate let-message>
-  <a routerLink="/components/link">{{ message }}</a>
+  <a routerLink="/my/route">{{ message }}</a>
 </ng-template>
 ```
 
 ## Records per page
 
-Define the choices for how many records can be displayed on a single 'page':
+Define the choices for how many records will be displayed on a single 'page':
 
 ```html
 <ts-paginator
@@ -144,7 +143,7 @@ Define the choices for how many records can be displayed on a single 'page':
 ></ts-paginator>
 ```
 
-This menu can be disabled completely if desired:
+This menu can be removed if desired:
 
 ```html
 <ts-paginator

--- a/terminus-ui/popover/src/popover-trigger.directive.ts
+++ b/terminus-ui/popover/src/popover-trigger.directive.ts
@@ -41,12 +41,18 @@ let nextUniqueId = 0;
  * @example
  * <button
  *              tsPopoverTrigger="popper1"
- *              [position]="position"
- *              [popover]="popper1"
  *              [defaultOpened]="defaultOpened"
- *              (popoverOnShown)="popoverOnShown()"
- *              (popoverOnHidden)="popoverOnHidden()"
+ *              [hideOnBlur]="false"
+ *              id="my-id"
+ *              [popover]="popper1"
+ *              [position]="position"
+ *              (popoverOnCreate)="myFunction($event)"
+ *              (popoverOnShown)="myFunction($event)"
+ *              (popoverOnHidden)="myFunction($event)"
+ *              (popoverOnUpdate)="myFunction($event)"
  * />
+ *
+ * <example-url>https://getterminus.github.io/ui-demos-release/components/popover</example-url>
  */
 @Directive({
   selector: '[tsPopoverTrigger]',
@@ -54,19 +60,18 @@ let nextUniqueId = 0;
   exportAs: 'tsPopoverTrigger',
 })
 export class TsPopoverTriggerDirective implements OnInit, OnDestroy, OnChanges, AfterContentInit, AfterContentChecked {
-
   /**
    * Store a reference to the document object
    */
   private document: Document;
 
   /**
-   * When no id provided, it falls back to uid
+   * Define the UID
    */
   public readonly uid = `ts-popover-trigger-${nextUniqueId++}`;
 
   /**
-   * Some default options for popper.
+   * Default options for popper
    *
    * For now we only support click, so it specifies click here. But could support more if needed.
    */
@@ -85,25 +90,13 @@ export class TsPopoverTriggerDirective implements OnInit, OnDestroy, OnChanges, 
    * Whether popover is opened on load.
    */
   @Input()
-  public set defaultOpened(value: boolean) {
-    this._defaultOpened = value;
-  }
-  public get defaultOpened(): boolean {
-    return this._defaultOpened;
-  }
-  public _defaultOpened = false;
+  public defaultOpened = false;
 
   /**
    * Whether popover closes when click outside.
    */
   @Input()
-  public set hideOnBlur(value: boolean) {
-    this._hideOnBlur = value;
-  }
-  public get hideOnBlur(): boolean {
-    return this._hideOnBlur;
-  }
-  public _hideOnBlur = true;
+  public hideOnBlur = true;
 
   /**
    * Define an ID for the directive
@@ -116,6 +109,12 @@ export class TsPopoverTriggerDirective implements OnInit, OnDestroy, OnChanges, 
     return this._id;
   }
   protected _id: string = this.uid;
+
+  /**
+   * TsPopoverComponent provided as an input
+   */
+  @Input()
+  public popover!: TsPopoverComponent;
 
   /**
    * Set position of where popover opens
@@ -131,12 +130,6 @@ export class TsPopoverTriggerDirective implements OnInit, OnDestroy, OnChanges, 
     return this._position;
   }
   public _position = TsPopoverPositions.Bottom;
-
-  /**
-   * TsPopoverComponent provided as an input
-   */
-  @Input()
-  public popover!: TsPopoverComponent;
 
   /**
    * Emit when create popover.

--- a/terminus-ui/popover/src/popover.component.md
+++ b/terminus-ui/popover/src/popover.component.md
@@ -7,9 +7,9 @@ Popover component is designed to pop up content based on user trigger.
 **Table of Contents**
 
 - [Basic info](#basic-info)
-- [Basic Usage](#basic-usage)
+- [Basic usage](#basic-usage)
   - [Position](#position)
-  - [Hide on Blur](#hide-on-blur)
+  - [Hide on blur](#hide-on-blur)
   - [Open on load](#open-on-load)
 - [Events](#events)
 - [popper.js documentations](#popperjs-documentations)
@@ -19,12 +19,13 @@ Popover component is designed to pop up content based on user trigger.
 ## Basic info
 
 We wrap our popover trigger/component with a third party library, named [popper.js](#popperjs-documentations).
-`popper.js` is not a required import for ui library but if it's not imported and consumers try to use popover component, an error will show up.
+`popper.js` must be installed and imported before using this component.
 
 `popper.js` can be installed via `yarn add popper.js`
-Please refer to [popper.js docs](#popperjs-documentations) for detailed documentation on `popper.js`. 
 
-## Basic Usage
+Refer to [popper.js docs](#popperjs-documentations) for detailed documentation on `popper.js`. 
+
+## Basic usage
 
 Define a popover trigger and popover content:
 
@@ -33,13 +34,13 @@ Define a popover trigger and popover content:
 
 <ts-popover #popper1>
   <h1>My Title</h1>
-  <p>Other random content.</p>
+  <p>Any HTML can be placed here!</p>
 </ts-popover>
 ```
 
 ### Position
 
-Defines where the popover shows relative to current element.
+Defines where the popover is positioned, relative to current element:
 
 ```html
 <button 
@@ -48,16 +49,16 @@ Defines where the popover shows relative to current element.
 >Click me!</button>
 
 <ts-popover #popper1>
-  <h1>My Title</h1>
-  <p>Other random content.</p>
+  My popover
 </ts-popover>
 ```
 
-It defaults to `bottom`. For all available positions, please reference [popper.js docs](#popperjs-documentations).
+The default is `bottom`. For all available positions, please see the [popper.js docs](#popperjs-documentations).
 
-### Hide on Blur
+### Hide on blur
 
-If `hideOnBlur` set to `true`, it allows close by clicking outside the popover. If it's `false`, popover can only be closed by clicking on trigger element.
+By default, the popover will be closed by clicking outside the popover. If this functionality is not desired, it can be
+disabled:
 
 ```html
 <button 
@@ -66,8 +67,7 @@ If `hideOnBlur` set to `true`, it allows close by clicking outside the popover. 
 >Click me!</button>
 
 <ts-popover #popper1>
-  <h1>My Title</h1>
-  <p>Other random content.</p>
+  My popover
 </ts-popover>
 ```
 
@@ -75,7 +75,7 @@ It defaults to `true`.
 
 ### Open on load
 
-If `defaultOpened` set to `true`, popover content opens up on initial load.
+The popover can be defined to open on load:
 
 ```html
 <button 
@@ -84,8 +84,7 @@ If `defaultOpened` set to `true`, popover content opens up on initial load.
 >Click me!</button>
 
 <ts-popover #popper1>
-  <h1>My Title</h1>
-  <p>Other random content.</p>
+  My popover
 </ts-popover>
 ```
 
@@ -93,10 +92,10 @@ It defaults to `false`.
 
 ## Events
 
-| Event             | Description                                 | Payload                 |
-|:------------------|:--------------------------------------------|:------------------------|
-| `popoverOnShown`  | Fired when popover shows up                 |    popoverInstance                 |
-| `popoverOnHidden` | Fired when popover hides                    |    popoverInstance                 |
+| Event             | Description                 | Payload         |
+|:------------------|:----------------------------|:----------------|
+| `popoverOnShown`  | Fired when popover shows up | popoverInstance |
+| `popoverOnHidden` | Fired when popover hides    | popoverInstance |
 
 ## popper.js documentations
 

--- a/terminus-ui/popover/src/popover.component.ts
+++ b/terminus-ui/popover/src/popover.component.ts
@@ -22,6 +22,22 @@ import {
 } from './popover-options';
 
 
+/**
+ * A popover component that supports rich HTML
+ *
+ * @example
+ * <ts-popover
+ *              #myPopper
+ *              (onHidden)="myFunction($event)"
+ *              (onUpdate)="myFunction($event)"
+ *              (popoverHidden)="myFunction($event)"
+ *              (popoverShown)="myFunction($event)"
+ * >
+ *              My popover content
+ * </ts-popover>
+ *
+ * <example-url>https://getterminus.github.io/ui-demos-release/components/popover</example-url>
+ */
 @Component({
   selector: 'ts-popover',
   styleUrls: ['./popover.component.scss'],
@@ -32,7 +48,6 @@ import {
   exportAs: 'tsPopoverComponent',
 })
 export class TsPopoverComponent implements OnDestroy, OnInit {
-
   /**
    * The element that passed to popper.js
    */
@@ -64,12 +79,12 @@ export class TsPopoverComponent implements OnDestroy, OnInit {
   public visibility = false;
 
   /**
-   * id set by trigger and pass to popover element
+   * ID set by trigger and pass to popover element
    */
   public id = '';
 
   /**
-   * options needed for popper.js
+   * Options needed for popper.js
    */
   public popoverOptions: TsPopoverOptions = {
     placement: TsPopoverPositions.Bottom,
@@ -77,48 +92,48 @@ export class TsPopoverComponent implements OnDestroy, OnInit {
   };
 
   /**
-   * A reference to popover view
+   * A reference to the popover view
    */
   @ViewChild('popoverViewRef', { static: true })
   public popoverViewRef!: ElementRef;
 
   /**
-   * Emit when it's updated.
-   */
-  // tslint:disable-next-line:no-output-on-prefix
-  @Output()
-  public readonly onUpdate = new EventEmitter<Popper>();
-
-  /**
-   * Emit when it's hidden.
+   * Event emitted when the popover is hidden
    */
   // tslint:disable-next-line:no-output-on-prefix
   @Output()
   public readonly onHidden = new EventEmitter<Popper>();
 
   /**
-   * Emit when popover shown.
+   * Event emitted when the popover is updated
    */
+  // tslint:disable-next-line:no-output-on-prefix
   @Output()
-  public readonly popoverShown = new EventEmitter<Popper>();
+  public readonly onUpdate = new EventEmitter<Popper>();
 
   /**
-   * Emit when popover hidden
+   * Event emitted when the popover is hidden
    */
   @Output()
   public readonly popoverHidden = new EventEmitter<Popper>();
+
+  /**
+   * Event emitted when the popover is shown
+   */
+  @Output()
+  public readonly popoverShown = new EventEmitter<Popper>();
 
   constructor(
     private viewRef: ViewContainerRef,
     private CDR: ChangeDetectorRef,
   ) { }
 
+  /**
+   * Check whether popper.js has been properly imported.
+   */
   public ngOnInit(): void {
-    /**
-     * Check whether popper.js has been properly imported.
-     */
     if (!Popper) {
-      throw new TsUILibraryError('TsPopoverComponent:: popper.js is not available to reference.');
+      throw new TsUILibraryError('TsPopoverComponent: popper.js is not available to reference.');
     }
   }
 
@@ -182,7 +197,6 @@ export class TsPopoverComponent implements OnDestroy, OnInit {
       this.displayType = 'block';
       this.ariaHidden = 'false';
       this.visibility = true;
-
     } else {
       this.opacity = 0;
       this.displayType = 'none';

--- a/terminus-ui/radio-group/src/radio-group.component.md
+++ b/terminus-ui/radio-group/src/radio-group.component.md
@@ -13,7 +13,7 @@
   - [Disabled option](#disabled-option)
 - [Visual mode](#visual-mode)
   - [Small](#small)
-  - [Centered Content](#centered-content)
+  - [Centered content](#centered-content)
   - [Custom content](#custom-content)
 - [Test Helpers](#test-helpers)
 
@@ -24,13 +24,13 @@
 
 Pass in:
 
-1. an array of items
-1. a form control
-1. a formatter function to determine the UI display value
-1. a formatter function to determine the model value
+1. An array of items
+1. A form control
+1. A formatter function to determine the UI display value
+1. A formatter function to determine the model value
 
 ```html
-<form [formGroup]="myForm" novalidate>
+<form [formGroup]="myForm">
   <ts-radio-group
     [options]="items$ | async"
     [formControl]="myForm.get('myRadioGroup')"
@@ -70,12 +70,9 @@ myForm = this.formBuilder.group({
 
 // Use the 'bar' value as the UI display
 uiFormatter = (v) => v.bar;
-// use the 'foo' value to save to the model
+// Use the 'foo' value to save to the model
 modelFormatter = (v) => v.foo;
 ```
-
-> NOTE: Since we can set the default value in the form control, we no longer need to add the
-> `checked` property to any or our items.
 
 
 ## Sub-labels
@@ -185,9 +182,9 @@ Enable by setting the `isVisual` flag:
 
 ### Small
 
-For a smaller clickable area, use the `small` flag. This sets the visual radio buttons to 13.75rem x 7rem.
+For a smaller clickable area, use the `small` flag.
 
-_Note_ The maximum content should be a title with two lines and body with 3 lines
+NOTE: The maximum content should be a title with two lines and body with 3 lines
 
 ```html
 <ts-radio-group
@@ -197,14 +194,14 @@ _Note_ The maximum content should be a title with two lines and body with 3 line
 ></ts-radio-group>
 ```
 
-### Centered Content
+### Centered content
 
 By default the content is centered when in visual mode. Setting `centeredContent` to `false` will use standard top/left alignment.
 
 ```html
 <ts-radio-group
   [isVisual]="true"
-  [centeredContent]="true"
+  [centeredContent]="false"
   ...
 ></ts-radio-group>
 ```

--- a/terminus-ui/radio-group/src/radio-group.component.ts
+++ b/terminus-ui/radio-group/src/radio-group.component.ts
@@ -73,11 +73,6 @@ let nextUniqueId = 0;
 /**
  * This is the radio UI Component
  *
- * #### QA CSS CLASSES
- * - `qa-radio-group`: The primary container
- * - `qa-radio-control`: An individual radio control
- * - `qa-radio-validation-messages`: The validation messages container
- *
  * @example
  * <ts-radio-group
  *              [ariaDescribedby]="Aria Describedby"

--- a/terminus-ui/scrollbars/src/scrollbars.component.ts
+++ b/terminus-ui/scrollbars/src/scrollbars.component.ts
@@ -27,7 +27,7 @@ export type TsScrollbarsScrollDirections
 
 
 /**
- * A class that represents the current gemotric state of scrolling for {@link TsScrollbarsComponent}.
+ * A class that represents the current geometric state of scrolling for {@link TsScrollbarsComponent}.
  */
 export class TsScrollbarsGeometry extends Geometry {}
 
@@ -48,9 +48,6 @@ const DEFAULT_SCROLL_SPEED = 400;
 /**
  * The scrollbars UI Component
  *
- * #### QA CSS CLASSES
- * - `qa-scrollbars`: Placed on the primary container
- *
  * @example
  * <ts-scrollbars
  *              id="my-id"
@@ -65,7 +62,7 @@ const DEFAULT_SCROLL_SPEED = 400;
  *              (xReachStart)="myFunc($event)
  *              (yReachEnd)="myFunc($event)
  *              (yReachStart)="myFunc($event)
- * ></ts-scrollbars>
+ * >My content...</ts-scrollbars>
  *
  * <example-url>https://getterminus.github.io/ui-demos-release/components/scrollbars</example-url>
  */
@@ -95,6 +92,32 @@ export class TsScrollbarsComponent {
   protected scrollSpeed = DEFAULT_SCROLL_SPEED;
 
   /**
+   * Return an object containing scrollbar geometry.
+   *
+   * @return An object with all geometry information
+   */
+  public get geometry(): TsScrollbarsGeometry | null {
+    if (this.scrollbar) {
+      return this.scrollbar.geometry('scroll') as TsScrollbarsGeometry;
+    }
+    return null;
+
+  }
+
+  /**
+   * Return the current scrollbar position.
+   *
+   * @return The current scrollbar position
+   */
+  public get position(): TsScrollbarPosition | null {
+    if (this.scrollbar) {
+      return this.scrollbar.position() as TsScrollbarPosition;
+    }
+    return null;
+
+  }
+
+  /**
    * Define an ID for the component
    */
   @Input()
@@ -119,71 +142,43 @@ export class TsScrollbarsComponent {
   public scrollbar!: PerfectScrollbarDirective;
 
   /**
-   * Event Emitters:
+   * Event Emitters
    */
   @Output()
-  public readonly scrollDown: EventEmitter<Event> = new EventEmitter();
+  public readonly scrollDown = new EventEmitter<Event>();
 
   @Output()
-  public readonly scrollLeft: EventEmitter<Event> = new EventEmitter();
+  public readonly scrollLeft = new EventEmitter<Event>();
 
   @Output()
-  public readonly scrollRight: EventEmitter<Event> = new EventEmitter();
+  public readonly scrollRight = new EventEmitter<Event>();
 
   @Output()
-  public readonly scrollUp: EventEmitter<Event> = new EventEmitter();
+  public readonly scrollUp = new EventEmitter<Event>();
 
   @Output()
-  public readonly scrollX: EventEmitter<Event> = new EventEmitter();
+  public readonly scrollX = new EventEmitter<Event>();
 
   @Output()
-  public readonly scrollY: EventEmitter<Event> = new EventEmitter();
+  public readonly scrollY = new EventEmitter<Event>();
 
   @Output()
-  public readonly xReachEnd: EventEmitter<Event> = new EventEmitter();
+  public readonly xReachEnd = new EventEmitter<Event>();
 
   @Output()
-  public readonly xReachStart: EventEmitter<Event> = new EventEmitter();
+  public readonly xReachStart = new EventEmitter<Event>();
 
   @Output()
-  public readonly yReachEnd: EventEmitter<Event> = new EventEmitter();
+  public readonly yReachEnd = new EventEmitter<Event>();
 
   @Output()
-  public readonly yReachStart: EventEmitter<Event> = new EventEmitter();
-
-
+  public readonly yReachStart = new EventEmitter<Event>();
 
 
   /**
-   * Return an object containing scrollbar geometry.
+   * Determine if a direction is scrollable.
    *
-   * @return An object with all geometry information
-   */
-  public get geometry(): TsScrollbarsGeometry | null {
-    if (this.scrollbar) {
-      return this.scrollbar.geometry('scroll') as TsScrollbarsGeometry;
-    }
-    return null;
-
-  }
-
-
-  /**
-   * Return the current scrollbar position.
-   *
-   * @return The current scrollbar position
-   */
-  public get position(): TsScrollbarPosition | null {
-    if (this.scrollbar) {
-      return this.scrollbar.position() as TsScrollbarPosition;
-    }
-    return null;
-
-  }
-
-
-  /**
-   * Determine if a direction is scrollable. See {@link TsScrollbarsScrollDirections} for all possible options.
+   * See {@link TsScrollbarsScrollDirections} for all possible options.
    *
    * @param direction - The scroll direction to check
    * @return Whether the direction is currently scrollable
@@ -193,10 +188,15 @@ export class TsScrollbarsComponent {
       return this.scrollbar.scrollable(direction);
     }
     return null;
-
   }
 
-
+  /**
+   * Scroll to a location
+   *
+   * @param x - The value to scroll the x axis
+   * @param y - The value to scroll the y axis
+   * @param x - The speed to scroll at
+   */
   public scrollTo(x: number, y?: number, speed?: number): void {
     // istanbul ignore else
     if (this.scrollbar) {
@@ -204,13 +204,12 @@ export class TsScrollbarsComponent {
     }
   }
 
-
   /**
    * Scroll to element
    *
    * @param queryString - The string to query the DOM for
    * @param speed - The speed to move at
-   * @param offset - A px offest
+   * @param offset - A px offset
    */
   public scrollToElement(queryString: string, speed: number = this.scrollSpeed, offset?: number): void {
     // istanbul ignore else

--- a/terminus-ui/search/src/search.component.ts
+++ b/terminus-ui/search/src/search.component.ts
@@ -39,24 +39,20 @@ const INPUT_MINIMUM_LENGTH = 2;
 /**
  * A presentational component to render a search form
  *
- * #### QA CSS CLASSES
- * - `qa-search`: Placed on the form element which contains this component
- * - `qa-search-input`: Placed on the {@link TsInputComponent} used for the search text input
- * - `qa-search-button`: Placed on the {@link TsButtonComponent} used for the submit button
- *
  * @example
  * <ts-search
  *              [autoSubmit]="true"
  *              initialValue="My starting value"
- *              inputLabel="Search for a tactic"
  *              inputHint="Enter at least 17 characters"
+ *              inputLabel="Search for a tactic"
+ *              [isDisabled]="false"
  *              [isFocused]="false"
  *              [isSubmitting]="false"
  *              theme="primary"
  *              [userCanClear]="true"
  *              (changed)="doSomething($event)"
- *              (submitted)="doSomething($event)"
  *              (cleared)="doSomething()"
+ *              (submitted)="doSomething($event)"
  * ></ts-search>
  *
  * <example-url>https://getterminus.github.io/ui-demos-release/components/search</example-url>
@@ -188,27 +184,24 @@ export class TsSearchComponent implements OnInit {
   public userCanClear = true;
 
   /**
-   * The event to emit when the form is submitted
-   */
-  @Output()
-  public readonly submitted: EventEmitter<TsSearchResponse> = new EventEmitter();
-
-  /**
    * The event to emit when the internal input value is changed
    */
   @Output()
-  public readonly changed: EventEmitter<string> = new EventEmitter();
+  public readonly changed = new EventEmitter<string>();
 
   /**
    * The event to emit when the internal input value is cleared
    */
   @Output()
-  public readonly cleared: EventEmitter<boolean> = new EventEmitter();
-
+  public readonly cleared = new EventEmitter<boolean>();
 
   /**
-   * Inject services
+   * The event to emit when the form is submitted
    */
+  @Output()
+  public readonly submitted = new EventEmitter<TsSearchResponse>();
+
+
   constructor(
     private formBuilder: FormBuilder,
   ) {}

--- a/terminus-ui/selection-list/src/selection-list.component.md
+++ b/terminus-ui/selection-list/src/selection-list.component.md
@@ -1,17 +1,17 @@
-<h1>SelectionList</h1>
+<h1>Selection List</h1>
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
 - [Basic usage](#basic-usage)
-  - [Duplicate selections](#duplicate-selections)
-  - [Keeping the panel open](#keeping-the-panel-open)
-  - [Debouncing queries](#debouncing-queries)
-  - [Minimum Characters](#minimum-characters)
-  - [Formatting](#formatting)
-  - [Complex comparator](#complex-comparator)
-  - [Standard dropdown mode (no typing)](#standard-dropdown-mode-no-typing)
+- [Duplicate selections](#duplicate-selections)
+- [Keeping the panel open](#keeping-the-panel-open)
+- [Debouncing queries](#debouncing-queries)
+- [Minimum characters](#minimum-characters)
+- [Formatting](#formatting)
+- [Complex comparator](#complex-comparator)
+- [Standard dropdown mode (no typing)](#standard-dropdown-mode-no-typing)
 - [Events](#events)
 - [Test Helpers](#test-helpers)
 
@@ -35,7 +35,7 @@ Pass a collection of `ts-option` components inside the `selection-list`:
 ```
 
 
-### Duplicate selections
+## Duplicate selections
 
 By default, duplicate selections are ignored. They can be allowed via a flag:
 
@@ -50,7 +50,7 @@ By default, duplicate selections are ignored. They can be allowed via a flag:
 ```
 
 
-### Keeping the panel open
+## Keeping the panel open
 
 By default, the panel will close after each selection. It can be forced to stay open via a flag.
 
@@ -68,7 +68,7 @@ By default, the panel will close after each selection. It can be forced to stay 
 ```
 
 
-### Debouncing queries
+## Debouncing queries
 
 By default, the input query will be debounced 200ms. This time may be adjusted as needed:
 
@@ -82,7 +82,7 @@ By default, the input query will be debounced 200ms. This time may be adjusted a
 ```
 
 
-### Minimum Characters
+## Minimum characters
 
 By default, at least two characters must be typed before the query is fired. This limit may be adjusted:
 
@@ -95,7 +95,7 @@ By default, at least two characters must be typed before the query is fired. Thi
 </ts-selection-list>
 ```
 
-### Formatting
+## Formatting
 
 For complex object support, a formatter function may be passed in to define the view value:
 
@@ -114,14 +114,14 @@ import { TsSelectionListFormatter } from '@terminus/ui/selection-list';
 public formatDisplay: TsSelectionListFormatter = v => v.name;
 ```
 
-### Complex comparator
+## Complex comparator
 
 To compare custom objects, a compare function may be passed in:
 
 ```html
 <ts-selection-list
   [formControl]="myCtrl"
-  [compareWith]="compareFunc"
+  [valueComparator]="myCompareFunction"
 >
   ...
 </ts-selection-list>
@@ -130,10 +130,10 @@ To compare custom objects, a compare function may be passed in:
 ```typescript
 import { TsSelectionListComparator } from '@terminus/ui/selection-list';
 
-public compareFunc: TsSelectionListComparator = (a, b) => a.id === b.id;
+public myCompareFunction: TsSelectionListComparator = (a, b) => a.id === b.id;
 ```
 
-### Standard dropdown mode (no typing)
+## Standard dropdown mode (no typing)
 
 If the component should act as a standard dropdown with no ability to type a query, set the flag `allowUserInput` to
 `false`. By default it is `true`.

--- a/terminus-ui/sort/src/sort.directive.md
+++ b/terminus-ui/sort/src/sort.directive.md
@@ -1,3 +1,5 @@
+<h1>Sort</h1>
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
@@ -11,7 +13,7 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
-### Adding sort to table headers
+## Adding sort to table headers
 
 To add sorting behavior and styling to a set of table headers, add `ts-sort-header` to each header
 and provide an id that will identify it. These headers should be contained within a parent element
@@ -23,7 +25,7 @@ Users can trigger the sort header through a mouse click or keyboard action. When
 direction to sort (`asc` or `desc`).
 
 
-### Changing the sort order
+## Changing the sort order
 
 By default, a sort header starts its sorting at `asc` and then `desc`. Triggering the sort header
 after `desc` will remove sorting.
@@ -37,18 +39,18 @@ To prevent the user from clearing the sort sort state from an already sorted col
 a specific header.
 
 
-### Disabling sorting
+## Disabling sorting
 
 If you want to prevent the user from changing the sorting order of any column, you can use the
 `tsSortDisabled` binding on the `ts-sort`, or the `disabled` on an single `ts-sort-header`.
 
 
-### Using sort with the `ts-table`
+## Using sort with the `ts-table`
 
 When used on an `ts-table` header, it is not required to set an `ts-sort-header` id on because by
 default it will use the id of the column.
 
 
-### Accessibility
+## Accessibility
 
 The `aria-label` for the sort button can be set in `TsSortHeaderIntl`.

--- a/terminus-ui/spacing/src/vertical-spacing.directive.ts
+++ b/terminus-ui/spacing/src/vertical-spacing.directive.ts
@@ -82,10 +82,6 @@ export class TsVerticalSpacingDirective {
     this.elementRef.nativeElement.style.marginBottom = margin;
   }
 
-
-  /**
-   * Inject services
-   */
   constructor(
     private elementRef: ElementRef,
   ) {}

--- a/terminus-ui/table/src/table.component.md
+++ b/terminus-ui/table/src/table.component.md
@@ -87,7 +87,7 @@ rendered.
 > as it is more accessible and has better support for items such as multiple sticky headers etc.
 
 The table component provides an array of column names built from the array of `TsColumn` definitions passed to the table. You can use this  
- reference for the rows rather than defining two seperate arrays:
+ reference for the rows rather than defining two separate arrays:
 
 ```html
 <table

--- a/terminus-ui/table/src/table.component.ts
+++ b/terminus-ui/table/src/table.component.ts
@@ -59,7 +59,7 @@ import { TsRowComponent } from './row';
 export interface TsColumn {
   // The column name
   name: string;
-  // The desired width in pixels as a integer (eg '200')
+  // The desired pixel width as an integer (eg '200')
   width: number;
   // Allow any other data properties the consumer may need
   // tslint:disable-next-line no-any

--- a/terminus-ui/tabs/src/body/tab-body.component.ts
+++ b/terminus-ui/tabs/src/body/tab-body.component.ts
@@ -1,8 +1,5 @@
 import { AnimationEvent } from '@angular/animations';
-import {
-  PortalHostDirective,
-  TemplatePortal,
-} from '@angular/cdk/portal';
+import { TemplatePortal } from '@angular/cdk/portal';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -11,17 +8,12 @@ import {
   Input,
   OnDestroy,
   OnInit,
-  Optional,
   Output,
-  ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
 import { isNumber } from '@terminus/ngx-tools/type-guards';
 import { untilComponentDestroyed } from '@terminus/ngx-tools/utilities';
-import {
-  Subject,
-  Subscription,
-} from 'rxjs';
+import { Subject } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
 
 import { tsTabsAnimations } from './tab-animations';
@@ -33,7 +25,7 @@ import { tsTabsAnimations } from './tab-animations';
  * tab body), then there will be no transition animation to its state.
  *
  * In the case of a new tab body that should immediately be centered with an animating transition, then left-origin-center or
- * right-origin-center can be used, which will use left or right as its psuedo-prior state.
+ * right-origin-center can be used, which will use left or right as its pseudo-prior state.
  */
 export type TsTabBodyPositionState
   = 'left'
@@ -219,7 +211,7 @@ export class TsTabBodyComponent implements OnInit, OnDestroy {
 
 
   /**
-   * Deterimine whether the provided position state is considered center (regardless of origin)
+   * Determine whether the provided position state is considered center (regardless of origin)
    *
    * @param position - The toState of the animation
    * @return True if in a center position

--- a/terminus-ui/tabs/src/collection/tab-collection.component.md
+++ b/terminus-ui/tabs/src/collection/tab-collection.component.md
@@ -6,9 +6,9 @@
 **Table of Contents**
 
 - [Basic usage](#basic-usage)
-  - [Events](#events)
-  - [Label alignment](#label-alignment)
-  - [Header position](#header-position)
+- [Events](#events)
+- [Label alignment](#label-alignment)
+- [Header position](#header-position)
 - [Dynamically insert a tab](#dynamically-insert-a-tab)
 - [Custom label template](#custom-label-template)
 - [Lazy load tab content](#lazy-load-tab-content)
@@ -22,7 +22,6 @@ In its most simple form this must consist of a collection with at least one tab:
 
 ```html
 <ts-tab-collection>
-
   <ts-tab label="First">
     Content 1
   </ts-tab>
@@ -30,12 +29,11 @@ In its most simple form this must consist of a collection with at least one tab:
   <ts-tab label="Second">
     Content 2
   </ts-tab>
-
 </ts-tab-collection>
 ```
 
 
-### Events
+## Events
 
 | Event                 | Description                                      | Payload            |
 |:----------------------|:-------------------------------------------------|:-------------------|
@@ -64,7 +62,7 @@ class TsTabChangeEvent {
 ```
 
 
-### Label alignment
+## Label alignment
 
 There are four horizontal layout options for tab labels.
 
@@ -82,9 +80,9 @@ There are four horizontal layout options for tab labels.
 ```
 
 
-### Header position
+## Header position
 
-The collection of tab labels are positioned above the tab content by default. This can be inverted so  the labels appear below the tab
+The collection of tab labels are positioned above the tab content by default. This can be inverted so the labels appear below the tab
 content:
 
 ```html
@@ -112,7 +110,6 @@ Or by showing and hiding via `ngIf`:
 
 ```html
 <ts-tab-collection>
-
   <ts-tab label="First">
     Content 1
   </ts-tab>
@@ -120,7 +117,6 @@ Or by showing and hiding via `ngIf`:
   <ts-tab label="Second" *ngIf="shouldIncludeTab">
     Content 2
   </ts-tab>
-
 </ts-tab-collection>
 ```
 
@@ -132,7 +128,6 @@ If label customization is needed a template can be defined to contain custom lab
 
 ```html
 <ts-tab-collection>
-
   <ts-tab>
     <ng-template tsTabLabel>
       <ts-icon>home</ts-icon>
@@ -141,7 +136,6 @@ If label customization is needed a template can be defined to contain custom lab
 
     Content 1
   </ts-tab>
-
 </ts-tab-collection>
 ```
 

--- a/terminus-ui/tabs/src/ink-bar/ink-bar.component.ts
+++ b/terminus-ui/tabs/src/ink-bar/ink-bar.component.ts
@@ -2,12 +2,9 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
-  Inject,
-  InjectionToken,
   NgZone,
   ViewEncapsulation,
 } from '@angular/core';
-import { isSet } from '@terminus/ngx-tools/type-guards';
 
 
 /**

--- a/terminus-ui/tabs/src/label/tab-label.directive.ts
+++ b/terminus-ui/tabs/src/label/tab-label.directive.ts
@@ -9,5 +9,4 @@ import { Directive } from '@angular/core';
   selector: '[tsTabLabel]',
   exportAs: 'tsTabLabel',
 })
-export class TsTabLabelDirective extends CdkPortal {
-}
+export class TsTabLabelDirective extends CdkPortal { }

--- a/terminus-ui/tabs/src/tab/tab.component.ts
+++ b/terminus-ui/tabs/src/tab/tab.component.ts
@@ -29,10 +29,10 @@ let nextUniqueId = 0;
  *
  * @example
  * <ts-tab
- *               [isDisabled]="true"
- *               label="First"
  *               ariaLabel="My label"
  *               ariaLabelledby="myId"
+ *               [isDisabled]="true"
+ *               label="First"
  * >
  *               My tab content!
  * </ts-tab>
@@ -79,7 +79,7 @@ export class TsTabComponent implements OnInit, OnChanges, OnDestroy {
   public isActive = false;
 
   /**
-   * Provides quick access to the content poratl
+   * Provides quick access to the content portal
    */
   public get content(): TemplatePortal | null {
     return this.contentPortal;
@@ -109,18 +109,6 @@ export class TsTabComponent implements OnInit, OnChanges, OnDestroy {
   public templateLabel!: TsTabLabelDirective;
 
   /**
-   * Define if the tab is disabled
-   */
-  @Input()
-  public isDisabled = false;
-
-  /**
-   * Simple text label for the tab (used when there is no template label)
-   */
-  @Input()
-  public label = '';
-
-  /**
    * Aria label for the tab
    */
   @Input()
@@ -133,6 +121,18 @@ export class TsTabComponent implements OnInit, OnChanges, OnDestroy {
    */
   @Input()
   public ariaLabelledby: string | undefined;
+
+  /**
+   * Define if the tab is disabled
+   */
+  @Input()
+  public isDisabled = false;
+
+  /**
+   * Simple text label for the tab (used when there is no template label)
+   */
+  @Input()
+  public label = '';
 
 
   constructor(

--- a/terminus-ui/toggle/src/toggle.component.md
+++ b/terminus-ui/toggle/src/toggle.component.md
@@ -1,5 +1,6 @@
 <h1>Toggle</h1>
 
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
@@ -8,12 +9,11 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+
  ## Basic Usage
 
  Create a basic toggle
 
  ```html
-<ts-toggle
-  (selectionChange)="myChange($event)"
->Toggle</ts-toggle>
+<ts-toggle (selectionChange)="myChange($event)">Toggle</ts-toggle>
 ```

--- a/terminus-ui/toggle/src/toggle.component.ts
+++ b/terminus-ui/toggle/src/toggle.component.ts
@@ -23,13 +23,10 @@ export class TsSlideToggleChange extends MatSlideToggleChange {}
 /**
  * The is a toggle component
  *
- * #### QA CSS CLASSES
- * - `qa-toggle`: The toggle element
- *
  * @example
  * <ts-toggle
- *              [formControl]="yourHelperToGetFormControl('thingIsDisabled')"
  *              arialLabel="Disable my thing"
+ *              [formControl]="yourHelperToGetFormControl('thingIsDisabled')"
  *              [isDisabled]="true"
  *              [isRequired]="true"
  *              labelPosition="before"
@@ -103,8 +100,6 @@ export class TsToggleComponent extends TsReactiveFormBaseComponent {
   /**
    * Emit an event each time the toggle value changes
    */
-  // tslint:disable-next-line: no-output-native
   @Output()
   public readonly selectionChange: EventEmitter<TsSlideToggleChange> = new EventEmitter();
-
 }

--- a/terminus-ui/tooltip/src/tooltip.component.ts
+++ b/terminus-ui/tooltip/src/tooltip.component.ts
@@ -33,15 +33,11 @@ export const allowedTooltipTypes: TsTooltipPositionTypes[] = [
 /**
  * This is the tooltip UI Component
  *
- * #### QA CSS CLASSES
- *
- * - qa-tooltip : Placed on the span element used for this component
- *
  * @example
  * <ts-tooltip
- *              [tooltipValue]="myTooltip"
- *              [tooltipPosition]="myPosition"
  *              [hasUnderline]="myUnderlineOption"
+ *              [tooltipPosition]="myPosition"
+ *              [tooltipValue]="myTooltip"
  * >My Tooltip!</ts-tooltip>
  *
  * <example-url>https://getterminus.github.io/ui-demos-release/components/tooltip</example-url>
@@ -55,6 +51,12 @@ export const allowedTooltipTypes: TsTooltipPositionTypes[] = [
   encapsulation: ViewEncapsulation.None,
 })
 export class TsTooltipComponent {
+  /**
+   * Define whether there is a dotted underline shown on the text
+   */
+  @Input()
+  public hasUnderline = false;
+
   /**
    * Define the position of the tooltip
    */
@@ -75,12 +77,6 @@ export class TsTooltipComponent {
    */
   @Input()
   public tooltipValue!: string;
-
-  /**
-   * Define whether there is a dotted underline shown on the text
-   */
-  @Input()
-  public hasUnderline = false;
 
   /**
    * Access Material Tooltip Directive

--- a/terminus-ui/validation-messages/src/validation-messages.component.ts
+++ b/terminus-ui/validation-messages/src/validation-messages.component.ts
@@ -19,13 +19,12 @@ let nextUniqueId = 0;
 /**
  * A presentational component to render validation messages
  *
- * #### QA CSS CLASSES
- * - `qa-validation-message`: Placed on the error element used for this component
- *
  * @example
  * <ts-validation-messages
  *              [control]="myForm.get('controlName')"
+ *              id="my-id"
  *              [validateOnChange]="true"
+ *              [validateImmediately]="false"
  * ></ts-validation-messages>
  *
  * <example-url>https://getterminus.github.io/ui-demos-release/components/validation</example-url>
@@ -67,7 +66,6 @@ export class TsValidationMessagesComponent implements OnDestroy {
 
       }
     }
-
     return null;
   }
 


### PR DESCRIPTION
ISSUES CLOSED: #1929

This looks scary because of the file count, but it's pretty much all no-brainer stuff.

- Fixed misspelled words
- Removed unused setters
- Reworded/trimmed various docs for clarity
- Fixed header levels for consistency
- Removed doc references to QA classes since we don't support them anymore
- Alphabetized a few inputs
- Down-cased markdown titles
- Formatted markdown tables