### PR TITLE
fix(Services): define external services as singletons

### DIFF
--- a/terminus-ui/chart/src/amcharts.service.ts
+++ b/terminus-ui/chart/src/amcharts.service.ts
@@ -23,7 +23,7 @@ export const TS_AMCHARTS_TOKEN = new InjectionToken<TsAmChartsToken>('amCharts')
 /**
  * Expose amCharts via a service
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class TsAmChartsService {
 
   constructor(

--- a/terminus-ui/chart/src/chart.component.md
+++ b/terminus-ui/chart/src/chart.component.md
@@ -22,7 +22,7 @@
 
 > Note:  Since the end-user of this library is the one with the actual license to use amCharts, we let the consumer pass in the library.
 
-Create a factory function to inject the needed libraries:
+Create a factory function to inject the needed libraries and plugins:
 
 ```typescript
 import { TS_AMCHARTS_TOKEN, TsAmChartsToken } from '@terminus/ui/chart';

--- a/terminus-ui/validators/src/validators.service.md
+++ b/terminus-ui/validators/src/validators.service.md
@@ -12,6 +12,7 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
+NOTE: This service is provided as a singleton by defining the `providedIn` property as `root`.
 
 ## Basic usage
 

--- a/terminus-ui/validators/src/validators.service.ts
+++ b/terminus-ui/validators/src/validators.service.ts
@@ -20,7 +20,7 @@ import { urlValidator } from './validators/url/url';
 /**
  * Define a service that exposes custom form validators for use with reactive forms.
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class TsValidatorsService {
   public creditCard = creditCardValidator;
   public domain = domainValidator;


### PR DESCRIPTION
ISSUES CLOSED: #2014

Note: Only two services from this library are used externally. I set both to root. I only added a note to the readme for the validators service as it's the only one the consumers really deal with.