### PR TITLE
fix(Input): sanitize input value inside of value setter before value emits

### DIFF
--- a/terminus-ui/input/src/input.component.ts
+++ b/terminus-ui/input/src/input.component.ts
@@ -411,8 +411,9 @@ export class TsInputComponent implements
 
     // istanbul ignore else
     if (v !== this.value) {
+      const sanitizedValue = this.maskSanitizeValue && this.currentMask ? this.cleanValue(v, this.currentMask.unmaskRegex) : v;
       this.inputValueAccessor.value = v;
-      this.onChangeCallback(v);
+      this.onChangeCallback(sanitizedValue);
       this.stateChanges.next();
     }
 


### PR DESCRIPTION
Engage had a bug where our validation was failing because the validator was being called before the currency value was sanitized. This led us to comparing two values that weren't a number.  Example; when the validator was called, the two values would look like "$40" and "10".  The first one was not being sanitized fast enough.