### PR TITLE
feat(CohortDateRange): Now supports start & end date minimum & maximum values

### DIFF
--- a/projects/demo/src/app/components/cohort-date-range/cohort-date-range.component.html
+++ b/projects/demo/src/app/components/cohort-date-range/cohort-date-range.component.html
@@ -1,3 +1,21 @@
+<ts-card tsVerticalSpacing>
+  <h3 tsCardTitle tsVerticalSpacing>Demo Controls</h3>
+
+  <div>
+    <div tsVerticalSpacing>Start date minimum and maximum</div>
+    <form [formGroup]="constraintForm" novalidate>
+      <ts-date-range
+        [dateFormGroup]="constraintForm.get('startDateRange')"
+      ></ts-date-range>
+
+      <div tsVerticalSpacing>End date minimum and maximum</div>
+      <ts-date-range
+        [dateFormGroup]="constraintForm.get('endDateRange')"
+      ></ts-date-range>
+    </form>
+  </div>
+</ts-card>
+
 <ts-card>
   <form [formGroup]="myForm" novalidate>
     <ts-cohort-date-range
@@ -5,11 +23,15 @@
       [allowCustomDates]="true"
       (cohortDateRangeChanged)="printRange($event)"
       [isDisabled]="false"
+      [startMinDate]="constraintForm.get('startDateRange')?.get('startDate')?.value"
+      [startMaxDate]="constraintForm.get('startDateRange')?.get('endDate')?.value"
+      [endMinDate]="constraintForm.get('endDateRange')?.get('startDate')?.value"
+      [endMaxDate]="constraintForm.get('endDateRange')?.get('endDate')?.value"
     ></ts-cohort-date-range>
   </form>
 
-<pre *ngIf="lastRange">
-  Start: {{ lastRange.start }}
-  End: {{ lastRange.end }}
-</pre>
+  <pre *ngIf="lastRange">
+    Start: {{ lastRange.start }}
+    End: {{ lastRange.end }}
+  </pre>
 </ts-card>

--- a/projects/demo/src/app/components/cohort-date-range/cohort-date-range.component.ts
+++ b/projects/demo/src/app/components/cohort-date-range/cohort-date-range.component.ts
@@ -38,6 +38,28 @@ export class CohortDateRangeComponent {
       ],
     }),
   });
+  public constraintForm: FormGroup = this.formBuilder.group({
+    startDateRange: this.formBuilder.group({
+      startDate: [
+        startOfDay(subDays(new Date(), 120)),
+        [Validators.required],
+      ],
+      endDate: [
+        startOfDay(subDays(new Date(), 1)),
+        [Validators.required],
+      ],
+    }),
+    endDateRange: this.formBuilder.group({
+      startDate: [
+        startOfDay(subDays(new Date(), 119)),
+        [Validators.required],
+      ],
+      endDate: [
+        endOfDay(new Date()),
+        [Validators.required],
+      ],
+    }),
+  });
   public cohorts: TsDateCohort[] = [
     {
       display: 'Last 90 days',

--- a/projects/library/cohort-date-range/src/cohort-date-range.component.html
+++ b/projects/library/cohort-date-range/src/cohort-date-range.component.html
@@ -3,6 +3,10 @@
   [dateFormGroup]="dateRangeFormGroup"
   [isDisabled]="!allowCustomDates || isDisabled"
   (dateRangeChange)="cohortDateRangeChange($event)"
+  [startMinDate]="startMinDate"
+  [startMaxDate]="startMaxDate"
+  [endMinDate]="endMinDate"
+  [endMaxDate]="endMaxDate"
 ></ts-date-range>
 
 <ts-selection-list

--- a/projects/library/cohort-date-range/src/cohort-date-range.component.md
+++ b/projects/library/cohort-date-range/src/cohort-date-range.component.md
@@ -8,6 +8,7 @@
   - [Event driven](#event-driven)
   - [Inputs to the component](#inputs-to-the-component)
     - [allowCustomDates](#allowcustomdates)
+  - [Date range boundaries](#date-range-boundaries)
     - [Disable](#disable)
   - [Test Helpers](#test-helpers)
 
@@ -109,6 +110,33 @@ When `allowCustomDates` is set to `false`, the date range is readonly (this defa
 ```
 
 NOTE: When set to `true`, a `Custom Dates` option will be added to the dropdown.
+
+
+## Date range boundaries
+
+To define bounds for custom date selection, pass in a valid `Date` to each of these `@Inputs`:
+
+1. `endMaxDate`
+1. `endMinDate`
+1. `startMaxDate`
+1. `startMinDate`
+
+```html
+<ts-cohort-date-range
+  [startMinDate]="startDate1"
+  [startMaxDate]="startDate2"
+  [endMinDate]="endDate1"
+  [endMaxDate]="endDate2"
+></ts-cohort-date-range>
+```
+
+```typescript
+startDate1 = new Date(2017, 1, 1);
+startDate2 = new Date(2017, 8, 1);
+endDate1 = new Date(2017, 1, 2);
+endDate2 = new Date(2017, 8, 2;
+```
+
 
 ### Disable
 

--- a/projects/library/cohort-date-range/src/cohort-date-range.component.spec.ts
+++ b/projects/library/cohort-date-range/src/cohort-date-range.component.spec.ts
@@ -39,6 +39,7 @@ describe(`TsCohortDateRangeComponent`, () => {
   let fixture: ComponentFixture<TsCohortDateRangeTestComponent>;
   let hostInstance: TsCohortDateRangeTestComponent;
   let startInputInstance: TsInputComponent;
+  let endInputInstance: TsInputComponent;
   let formFieldElement: HTMLElement;
   let cohortDebugElement: DebugElement;
   let cohortInstance: TsCohortDateRangeComponent;
@@ -48,6 +49,7 @@ describe(`TsCohortDateRangeComponent`, () => {
     fixture.detectChanges();
     hostInstance = fixture.componentInstance;
     startInputInstance = getRangeInputInstances(fixture)[0];
+    endInputInstance = getRangeInputInstances(fixture)[1];
     formFieldElement = getFormFieldElement(fixture);
     cohortDebugElement = getCohortDebugElement(fixture);
     cohortInstance = cohortDebugElement.componentInstance;
@@ -213,7 +215,27 @@ describe(`TsCohortDateRangeComponent`, () => {
 
       expect(instance.setDateRangeValues).toHaveBeenCalled();
     });
-
   });
 
+  describe.only(`date constraints`, function() {
+    beforeEach(() => {
+      setupComponent(testComponents.DateConstraints);
+    });
+
+    test(`should set end min date to provided value`, function() {
+      expect(endInputInstance.minDate).toEqual(new Date(2020, 2, 1));
+    });
+
+    test(`should set end max date to provided value`, function() {
+      expect(endInputInstance.maxDate).toEqual(new Date(2020, 2, 25));
+    });
+
+    test(`should set start min date to provided value`, function() {
+      expect(startInputInstance.minDate).toEqual(new Date(2020, 0, 1));
+    });
+
+    test(`should set start max date to provided value`, function() {
+      expect(startInputInstance.maxDate).toEqual(new Date(2020, 0, 25));
+    });
+  });
 });

--- a/projects/library/cohort-date-range/src/cohort-date-range.component.ts
+++ b/projects/library/cohort-date-range/src/cohort-date-range.component.ts
@@ -70,7 +70,11 @@ let nextUniqueId = 0;
  * <ts-cohort-date-range
  *              [allowCustomDates]="true"
  *              [cohorts]="myCohorts"
+ *              endMaxDate="{{ new Date(2017, 4, 30) }}"
+ *              endMinDate="{{ new Date(2017, 4, 1) }}"
  *              id="myID"
+ *              startMaxDate="{{ new Date(2017, 4, 30) }}"
+ *              startMinDate="{{ new Date(2017, 4, 1) }}"
  *              (cohortDateRangeChange)="myFunc($event)"
  * ></ts-cohort-date-range>
  *
@@ -190,6 +194,18 @@ export class TsCohortDateRangeComponent implements OnInit, OnDestroy {
   private originalCohorts: ReadonlyArray<TsDateCohort>;
 
   /**
+   * Define the max date for the end date
+   */
+  @Input()
+  public endMaxDate: Date | undefined;
+
+  /**
+   * Define the min date for the end date
+   */
+  @Input()
+  public endMinDate: Date | undefined;
+
+  /**
    * Define an ID for the component
    */
   @Input()
@@ -208,11 +224,22 @@ export class TsCohortDateRangeComponent implements OnInit, OnDestroy {
   public isDisabled = false;
 
   /**
+   * Define the max date for the starting date
+   */
+  @Input()
+  public startMaxDate: Date | undefined;
+
+  /**
+   * Define the min date for the starting date
+   */
+  @Input()
+  public startMinDate: Date | undefined;
+
+  /**
    * Cohort change event emitter
    */
   @Output()
   public readonly cohortDateRangeChanged = new EventEmitter<TsCohortDateRangeChanged>();
-
 
   constructor(
     public formBuilder: FormBuilder,

--- a/projects/library/cohort-date-range/testing/src/test-components.ts
+++ b/projects/library/cohort-date-range/testing/src/test-components.ts
@@ -129,12 +129,45 @@ export class NoCustomDates {
 // tslint:disable-next-line:component-class-suffix
 export class NoCohorts {}
 
+@Component({
+  template: `
+      <ts-cohort-date-range
+        [allowCustomDates]="allowCustomDates"
+        [cohorts]="dateCohorts"
+        (cohortDateRangeChanged)="cohortDateRangeChanged()"
+        [startMinDate]="startMinDate"
+        [startMaxDate]="startMaxDate"
+        [endMinDate]="endMinDate"
+        [endMaxDate]="endMaxDate"
+      ></ts-cohort-date-range>
+  `,
+})
+export class DateConstraints {
+  public date1 = new Date(2018, 1, 1);
+  public date2 = new Date(2018, 2, 1);
+  public startMinDate = new Date(2020, 0, 1);
+  public startMaxDate = new Date(2020, 0, 25);
+  public endMinDate = new Date(2020, 2, 1);
+  public endMaxDate = new Date(2020, 2, 25);
+  public dateCohorts: TsDateCohort[] = [{
+    display: 'last year',
+    range: {
+      start: this.date1,
+      end: this.date2,
+    },
+  }];
+  public allowCustomDates = true;
+  public cohortDateRangeChanged() { }
+}
+
+
 export type TsCohortDateRangeTestComponent
   = Basic
   | DefaultCohort
   | NoCohorts
   | NoCustomDates
   | Standard
+  | DateConstraints
 ;
 
 /**
@@ -155,6 +188,7 @@ export type TsCohortDateRangeTestComponent
     NoCohorts,
     NoCustomDates,
     Standard,
+    DateConstraints,
   ],
 })
 export class TsCohortDateRangeTestComponentsModule {}


### PR DESCRIPTION
The Cohort Date Range component now supports setting minimum and maximum values for both the start and end dates of custom date ranges.