### PR TITLE
feat(Table): support footer rows

### DIFF
--- a/projects/demo/src/app/components/table/table.component.html
+++ b/projects/demo/src/app/components/table/table.component.html
@@ -80,13 +80,10 @@
     #myTable="tsTable"
   >
 
-    <ng-container tsColumnDef="title">
-      <th ts-header-cell *tsHeaderCellDef>
-        Title
-      </th>
-      <td ts-cell *tsCellDef="let item">
-        {{ item.title }}
-      </td>
+    <ng-container tsColumnDef="title" sticky>
+      <th ts-header-cell *tsHeaderCellDef>Title</th>
+      <td ts-cell *tsCellDef="let item">{{ item.title }}</td>
+      <td ts-footer-cell *tsFooterCellDef>TEST footer content</td>
     </ng-container>
 
     <ng-container tsColumnDef="updated" alignment="right">
@@ -96,6 +93,7 @@
       <td ts-cell *tsCellDef="let item">
         {{ item.updated_at | date:"shortDate" }}
       </td>
+      <td ts-footer-cell *tsFooterCellDef>-</td>
     </ng-container>
 
     <ng-container tsColumnDef="comments" alignment="right">
@@ -105,6 +103,7 @@
       <td ts-cell *tsCellDef="let item">
         {{ item.comments }}
       </td>
+      <td ts-footer-cell *matfootercelldef>427</td>
     </ng-container>
 
     <ng-container tsColumnDef="assignee">
@@ -114,6 +113,7 @@
       <td ts-cell *tsCellDef="let item">
         {{ item.login }}
       </td>
+      <td ts-footer-cell *tsFooterCellDef>-</td>
     </ng-container>
 
     <ng-container tsColumnDef="number" alignment="right">
@@ -123,6 +123,7 @@
       <td ts-cell *tsCellDef="let item">
         {{ item.number }}
       </td>
+      <td ts-footer-cell *tsFooterCellDef>-</td>
     </ng-container>
 
     <ng-container tsColumnDef="labels">
@@ -134,6 +135,7 @@
           {{ l.name }},
         </span>
       </td>
+      <td ts-footer-cell *tsFooterCellDef>-</td>
     </ng-container>
 
     <ng-container tsColumnDef="created">
@@ -143,6 +145,7 @@
       <td ts-cell *tsCellDef="let item">
         {{ item.created_at | date:"shortDate" }}
       </td>
+      <td ts-footer-cell *tsFooterCellDef>{{ latestCreationDate }}</td>
     </ng-container>
 
     <ng-container tsColumnDef="body">
@@ -152,6 +155,7 @@
       <td ts-cell *tsCellDef="let item">
         <span class="truncate" [innerHTML]="sanitize(item.body)"></span>
       </td>
+      <td ts-footer-cell *tsFooterCellDef>-</td>
     </ng-container>
 
     <ng-container tsColumnDef="state">
@@ -161,6 +165,7 @@
       <td ts-cell *tsCellDef="let item">
         {{ item.state }}
       </td>
+      <td ts-footer-cell *tsFooterCellDef>-</td>
     </ng-container>
 
     <ng-container tsColumnDef="id" alignment="right">
@@ -170,6 +175,7 @@
       <td ts-cell *tsCellDef="let item">
         {{ item.id }}
       </td>
+      <td ts-footer-cell *tsFooterCellDef>-</td>
     </ng-container>
 
     <ng-container tsColumnDef="html_url">
@@ -181,10 +187,12 @@
           <ts-icon theme="accent">open_in_new</ts-icon>
         </a>
       </td>
+      <td ts-footer-cell *tsFooterCellDef>-</td>
     </ng-container>
 
     <tr ts-header-row *tsHeaderRowDef="myTable.columnNames; sticky: true"></tr>
     <tr ts-row *tsRowDef="let row; columns: myTable.columnNames;"></tr>
+    <tr ts-footer-row *tsFooterRowDef="myTable.columnNames; sticky: true"></tr>
   </table>
 </div>
 

--- a/projects/demo/src/app/components/table/table.component.ts
+++ b/projects/demo/src/app/components/table/table.component.ts
@@ -97,7 +97,7 @@ export class TableComponent implements OnInit, AfterViewInit, OnDestroy {
     {
       display: 'Title',
       name: 'title',
-      width: 200,
+      width: 300,
       control: new FormControl(true),
     },
     {
@@ -115,7 +115,7 @@ export class TableComponent implements OnInit, AfterViewInit, OnDestroy {
     {
       display: 'Updated',
       name: 'updated',
-      width: 100,
+      width: 200,
       control: new FormControl(true),
     },
     {
@@ -171,6 +171,7 @@ export class TableComponent implements OnInit, AfterViewInit, OnDestroy {
   public density: TsTableDensity = 'comfy';
   public visibleColumns: TsColumn[] = [];
   public allFormControlChanges$ = merge(...this.allPossibleColumns.map(c => c.control && c.control.valueChanges));
+  public latestCreationDate = new Date(2020, 2, 23);
 
   @ViewChild(TsSortDirective, { static: true })
   public sort!: TsSortDirective;

--- a/projects/library/table/src/cell.ts
+++ b/projects/library/table/src/cell.ts
@@ -5,6 +5,8 @@ import {
   CdkCell,
   CdkCellDef,
   CdkColumnDef,
+  CdkFooterCell,
+  CdkFooterCellDef,
   CdkHeaderCell,
   CdkHeaderCellDef,
 } from '@angular/cdk/table';
@@ -379,5 +381,60 @@ export class TsCellDirective extends CdkCell {
       elementRef.nativeElement.classList.add(`ts-table__column--sticky`);
     }
   }
+}
 
+
+/**
+ * Footer cell definition for the mat-table.
+ *
+ * Captures the template of a column's footer cell and as well as cell-specific properties.
+ */
+@Directive({
+  selector: '[tsFooterCellDef]',
+  providers: [{
+    provide: CdkFooterCellDef,
+    useExisting: TsFooterCellDefDirective,
+  }],
+})
+export class TsFooterCellDefDirective extends CdkFooterCellDef {}
+
+/**
+ * Footer cell template container that adds the right classes and role.
+ */
+@Directive({
+  selector: 'ts-footer-cell, td[ts-footer-cell]',
+  host: {
+    class: 'ts-footer-cell',
+    role: 'gridcell',
+  },
+})
+export class TsFooterCellDirective extends CdkFooterCell {
+  /**
+   * Store a reference to the column
+   */
+  public column: TsColumnDefDirective;
+
+  constructor(
+    public columnDef: CdkColumnDef,
+    public elementRef: ElementRef,
+    private renderer: Renderer2,
+  ) {
+    super(columnDef, elementRef);
+    elementRef.nativeElement.classList.add(`ts-column-${columnDef.cssClassFriendlyName}`);
+
+    // NOTE: Changing the type in the constructor from `CdkColumnDef` to `TsColumnDefDirective` doesn't seem to play well with the CDK.
+    // Coercing the type here is a hack, but allows us to reference properties that do not exist on the underlying `CdkColumnDef`.
+    this.column = columnDef as TsColumnDefDirective;
+
+    setColumnAlignment(this.column, renderer, elementRef);
+
+    // eslint-disable-next-line no-underscore-dangle
+    if (columnDef._stickyEnd) {
+      elementRef.nativeElement.classList.add(`ts-table__column--sticky-end`);
+    }
+
+    if (columnDef.sticky) {
+      elementRef.nativeElement.classList.add(`ts-table__column--sticky`);
+    }
+  }
 }

--- a/projects/library/table/src/row.ts
+++ b/projects/library/table/src/row.ts
@@ -1,5 +1,7 @@
 import {
   CDK_ROW_TEMPLATE,
+  CdkFooterRow,
+  CdkFooterRowDef,
   CdkHeaderRow,
   CdkHeaderRowDef,
   CdkRow,
@@ -89,6 +91,47 @@ export class TsRowComponent extends CdkRow {
 })
 export class TsHeaderRowDefDirective extends CdkHeaderRowDef {}
 
+/**
+ * Footer row definition for the {@link TsTableComponent}.
+ *
+ * Captures the footer row's template and other footer properties such as the columns to display.
+ */
+@Directive({
+  selector: '[tsFooterRowDef]',
+  providers: [{
+    provide: CdkFooterRowDef,
+    useExisting: TsFooterRowDefDirective,
+  }],
+  // NOTE: @Inputs are defined here rather than using decorators since we are extending the @Inputs of the base class
+  // tslint:disable-next-line:no-inputs-metadata-property
+  inputs: [
+    'columns: tsFooterRowDef',
+    'sticky: tsFooterRowDefSticky',
+  ],
+})
+export class TsFooterRowDefDirective extends CdkFooterRowDef {}
+
+/**
+ * Footer template container that contains the cell outlet. Adds the right class and role.
+ */
+@Component({
+  selector: 'ts-footer-row, tr[ts-footer-row]',
+  template: CDK_ROW_TEMPLATE,
+  host: {
+    class: 'ts-footer-row',
+    role: 'row',
+  },
+  providers: [{
+    provide: CdkFooterRow,
+    useExisting: TsFooterRowComponent,
+  }],
+  // See note on CdkTable for explanation on why this uses the default change detection strategy.
+  // tslint:disable-next-line:prefer-on-push-component-change-detection
+  changeDetection: ChangeDetectionStrategy.Default,
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'tsFooterRow',
+})
+export class TsFooterRowComponent extends CdkFooterRow {}
 
 /**
  * Data row definition for the {@link TsTableComponent}.

--- a/projects/library/table/src/table.component.md
+++ b/projects/library/table/src/table.component.md
@@ -15,6 +15,7 @@
 - [Content wrapping](#content-wrapping)
 - [Cell alignment](#cell-alignment)
 - [Sticky header](#sticky-header)
+- [Footer](#footer)
 - [Sticky column](#sticky-column)
   - [Sticky column at end](#sticky-column-at-end)
 - [Re-orderable columns](#re-orderable-columns)
@@ -316,7 +317,15 @@ Defining the header as sticky will ensure it is always visible as the table scro
 <tr ts-header-row *tsHeaderRowDef="displayedColumns; sticky: true"></tr>
 ```
 
-> NOTE: Multiple sticky headers can be defined.
+
+## Footer
+
+A footer row can be defined to be output at the bottom of the table. It supports the same 'sticky' setting that the
+header row does.
+
+```html
+<tr ts-footer-row *tsFooterRowDef="displayedColumns; sticky: true"></tr>
+```
 
 
 ## Sticky column
@@ -612,52 +621,26 @@ import { TsPaginatorComponent } from '@terminus/ui/paginator';
       #myTable="tsTable"
     >
       <ng-container tsColumnDef="created">
-        <th ts-header-cell *tsHeaderCellDef ts-sort-header>
-          Created
-        </th>
-        <td ts-cell *tsCellDef="let item">
-          {{ item.created_at | date:shortDate }}
-        </td>
+        <th ts-header-cell *tsHeaderCellDef ts-sort-header>Created</th>
+        <td ts-cell *tsCellDef="let item">{{ item.created_at | date:shortDate }}</td>
+        <td ts-footer-cell *tsFooterCellDef>Footer A</td>
       </ng-container>
 
       <ng-container tsColumnDef="number" alignment="right">
-        <th ts-header-cell *tsHeaderCellDef>
-          Number
-        </th>
-        <td ts-cell *tsCellDef="let item">
-          {{ item.number }}
-        </td>
+        <th ts-header-cell *tsHeaderCellDef>Number</th>
+        <td ts-cell *tsCellDef="let item">{{ item.number }}</td>
+        <td ts-footer-cell *tsFooterCellDef>Footer B</td>
       </ng-container>
 
       <ng-container tsColumnDef="title">
-        <th ts-header-cell *tsHeaderCellDef>
-          Title
-        </th>
-        <td ts-cell *tsCellDef="let item">
-          {{ item.title }}
-        </td>
-      </ng-container>
-
-      <ng-container tsColumnDef="state">
-        <th ts-header-cell *tsHeaderCellDef>
-          State
-        </th>
-        <td ts-cell *tsCellDef="let item">
-          {{ item.state }}
-        </td>
-      </ng-container>
-
-      <ng-container tsColumnDef="comments">
-        <th ts-header-cell *tsHeaderCellDef ts-sort-header>
-          Comments
-        </th>
-        <td ts-cell *tsCellDef="let item">
-          {{ item.comments }}
-        </td>
+        <th ts-header-cell *tsHeaderCellDef>Title</th>
+        <td ts-cell *tsCellDef="let item">{{ item.title }}</td>
+        <td ts-footer-cell *tsFooterCellDef>Footer C</td>
       </ng-container>
 
       <tr ts-header-row *tsHeaderRowDef="myTable.columnNames"></tr>
-      <tr ts-row *tsRowDef="let row; columns: myTable.columnNames;"></tr>
+      <tr ts-row *tsRowDef="let row; columns: myTable.columnNames"></tr>
+      <tr ts-footer-row *tsFooterRowDef="myTable.columnNames"></tr>
     </table>
 
 

--- a/projects/library/table/src/table.component.scss
+++ b/projects/library/table/src/table.component.scss
@@ -94,7 +94,8 @@
 
   // Any cell
   .ts-cell,
-  .ts-header-cell {
+  .ts-header-cell,
+  .ts-footer-cell {
     min-height: inherit;
     position: relative;
     text-align: left;
@@ -133,7 +134,8 @@
   }
 
   // Body cell
-  .ts-cell {
+  .ts-cell,
+  .ts-footer-cell {
     background-color: var(--table-bg);
     overflow: hidden;
     padding: var(--cell-padding);

--- a/projects/library/table/src/table.component.spec.ts
+++ b/projects/library/table/src/table.component.spec.ts
@@ -18,6 +18,10 @@ import {
   getTableInstance,
   TestData,
 } from '@terminus/ui/table/testing';
+import {
+  getFooterCells,
+  getFooterRows,
+} from '../testing/src/test-helpers';
 
 import {
   TsCellDirective,
@@ -226,6 +230,8 @@ describe(`TsTableComponent`, function() {
       fixture.detectChanges();
       const tableElement = fixture.nativeElement.querySelector('.ts-table');
       const headerCells = getHeaderCells(tableElement);
+      const footerRow = getFooterRows(tableElement)[0];
+      const footerCells = getFooterCells(footerRow);
       const cells = getCells(tableElement);
 
       expect(headerCells[0].classList).toContain('ts-table__column--sticky');
@@ -233,6 +239,9 @@ describe(`TsTableComponent`, function() {
 
       expect(cells[0].classList).not.toContain('ts-table__column--sticky-end');
       expect(cells[2].classList).toContain('ts-table__column--sticky-end');
+
+      expect(footerCells[0].classList).toContain('ts-table__column--sticky');
+      expect(footerCells[1].classList).not.toContain('ts-table__column--sticky');
     });
 
     test(`should only call to update sticky columns if at least one column is marked as sticky`, () => {

--- a/projects/library/table/src/table.module.ts
+++ b/projects/library/table/src/table.module.ts
@@ -7,11 +7,15 @@ import { TsSortModule } from '@terminus/ui/sort';
 import {
   TsCellDefDirective,
   TsCellDirective,
+  TsFooterCellDefDirective,
+  TsFooterCellDirective,
   TsHeaderCellDefDirective,
   TsHeaderCellDirective,
 } from './cell';
 import { TsColumnDefDirective } from './column';
 import {
+  TsFooterRowComponent,
+  TsFooterRowDefDirective,
   TsHeaderRowComponent,
   TsHeaderRowDefDirective,
   TsRowComponent,
@@ -39,38 +43,46 @@ export * from './table.component';
     TsTableComponent,
 
     // Template definitions
-    TsCellDefDirective,
-    TsColumnDefDirective,
     TsHeaderCellDefDirective,
     TsHeaderRowDefDirective,
+    TsColumnDefDirective,
+    TsCellDefDirective,
     TsRowDefDirective,
+    TsFooterCellDefDirective,
+    TsFooterRowDefDirective,
 
     // Cell directives
-    TsCellDirective,
     TsHeaderCellDirective,
+    TsCellDirective,
+    TsFooterCellDirective,
 
     // Row directives
     TsHeaderRowComponent,
     TsRowComponent,
+    TsFooterRowComponent,
   ],
   exports: [
     // Table
     TsTableComponent,
 
     // Template definitions
-    TsCellDefDirective,
-    TsColumnDefDirective,
     TsHeaderCellDefDirective,
     TsHeaderRowDefDirective,
+    TsColumnDefDirective,
+    TsCellDefDirective,
     TsRowDefDirective,
+    TsFooterCellDefDirective,
+    TsFooterRowDefDirective,
 
     // Cell directives
-    TsCellDirective,
     TsHeaderCellDirective,
+    TsCellDirective,
+    TsFooterCellDirective,
 
     // Row directives
     TsHeaderRowComponent,
     TsRowComponent,
+    TsFooterRowComponent,
   ],
 })
 export class TsTableModule {}

--- a/projects/library/table/testing/src/test-components.ts
+++ b/projects/library/table/testing/src/test-components.ts
@@ -247,16 +247,19 @@ export class TableColumnInvalidAlignmentTableApp {
       <ng-container tsColumnDef="column_a" sticky>
         <th ts-header-cell *tsHeaderCellDef> Column A</th>
         <td ts-cell *tsCellDef="let row">{{ row.a }}</td>
+        <td ts-footer-cell *tsFooterCellDef> Footer A</td>
       </ng-container>
 
       <ng-container tsColumnDef="column_b">
         <th ts-header-cell *tsHeaderCellDef> Column B</th>
         <td ts-cell *tsCellDef="let row">{{ row.b }}</td>
+        <td ts-footer-cell *tsFooterCellDef> Footer B</td>
       </ng-container>
 
       <ng-container tsColumnDef="column_c" stickyEnd>
         <th ts-header-cell *tsHeaderCellDef> Column C</th>
         <td ts-cell *tsCellDef="let row">{{ row.c }}</td>
+        <td ts-footer-cell *tsFooterCellDef> Footer C</td>
       </ng-container>
 
       <ng-container tsColumnDef="special_column">
@@ -266,6 +269,7 @@ export class TableColumnInvalidAlignmentTableApp {
       <tr ts-header-row *tsHeaderRowDef="columnsToRender; sticky: true"></tr>
       <tr ts-row *tsRowDef="let row; columns: columnsToRender"></tr>
       <tr ts-row *tsRowDef="let row; columns: ['special_column']; when: isFourthRow"></tr>
+      <tr ts-footer-row *tsFooterRowDef="columnsToRender; sticky: true"></tr>
     </table>
   `,
 })

--- a/projects/library/table/testing/src/test-helpers.ts
+++ b/projects/library/table/testing/src/test-helpers.ts
@@ -88,6 +88,16 @@ export function getHeaderRow(tableElement: Element): Element {
 }
 
 /**
+ * Return all footer rows
+ *
+ * @param tableElement - The table element to search within
+ * @returns An array of footer rows
+ */
+export function getFooterRows(tableElement: Element): Element[] {
+  return Array.from(tableElement.querySelectorAll('.ts-footer-row'));
+}
+
+/**
  * Get all row elements
  *
  * @param tableElement - The table to search within
@@ -115,6 +125,20 @@ export function getCells(row: Element): Element[] {
  */
 export function getHeaderCells(tableElement: Element): Element[] {
   return getElements(getHeaderRow(tableElement), '.ts-header-cell');
+}
+
+/**
+ * Get all footer cells
+ *
+ * @param footerRow - The Row to search within
+ * @return An array of footer cells
+ */
+export function getFooterCells(footerRow: Element): Element[] {
+  let cells = getElements(footerRow, 'ts-footer-cell');
+  if (!cells.length) {
+    cells = getElements(footerRow, 'td');
+  }
+  return cells;
 }
 
 /**


### PR DESCRIPTION
Although we were originally asked specifically to not implement support for a footer row, Retargeting now needs it.

Here is that support.

NOTE: Once this lands in v17 I will pluck the commits over to `release`.

![Screen Shot 2020-04-27 at 3 54 21 PM](https://user-images.githubusercontent.com/270193/80416204-bb32c400-88a1-11ea-98c9-05b2eec8a164.png)